### PR TITLE
Fixed another potential issue causing high loads while waiting for main thread to exit polling.

### DIFF
--- a/src/torrent/utils/thread_base.cc
+++ b/src/torrent/utils/thread_base.cc
@@ -88,6 +88,8 @@ thread_base::stop_thread_wait() {
 
 void
 thread_base::interrupt() {
+  int sleep_length = 0;
+
   __sync_fetch_and_or(&m_flags, flag_no_timeout);
 
   while (is_polling() && has_no_timeout()) {
@@ -96,7 +98,8 @@ thread_base::interrupt() {
     if (!(is_polling() && has_no_timeout()))
       return;
 
-    usleep(0);
+    usleep(sleep_length);
+    sleep_length = std::min(sleep_length + 50, 1000);
   }
 }
 


### PR DESCRIPTION
In rtorrent ce16621 some magic was added to src/thread_base.cc to migitate high load problems.  A similar issue manifests on FreeBSD in the "new" libtorrent method thread_base::interrupt() in src/torrent/utils/thread_base.cc, added with commit aa9d73e4. The attached commit fixes this issue the same way as it was done in rtorrent.
