### PR TITLE
Fix warning on automake-1.12.4

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,4 +35,4 @@ libtorrent_la_SOURCES = \
 	thread_main.cc \
 	thread_main.h
 
-INCLUDES = -I$(srcdir) -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)

--- a/src/data/Makefile.am
+++ b/src/data/Makefile.am
@@ -25,4 +25,4 @@ libsub_data_la_SOURCES = \
 	socket_file.cc \
 	socket_file.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/dht/Makefile.am
+++ b/src/dht/Makefile.am
@@ -15,4 +15,4 @@ libsub_dht_la_SOURCES = \
 	dht_transaction.cc \
 	dht_transaction.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/download/Makefile.am
+++ b/src/download/Makefile.am
@@ -16,4 +16,4 @@ libsub_download_la_SOURCES = \
 	download_wrapper.cc \
 	download_wrapper.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/net/Makefile.am
+++ b/src/net/Makefile.am
@@ -23,4 +23,4 @@ libsub_net_la_SOURCES = \
 	throttle_list.h \
 	throttle_node.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -25,4 +25,4 @@ libsub_protocol_la_SOURCES = \
 	request_list.cc \
 	request_list.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/torrent/Makefile.am
+++ b/src/torrent/Makefile.am
@@ -57,7 +57,7 @@ libsub_torrent_la_SOURCES = \
 	tracker_list.cc \
 	tracker_list.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
 
 libtorrentincludedir = $(includedir)/torrent
 libtorrentinclude_HEADERS = \

--- a/src/torrent/data/Makefile.am
+++ b/src/torrent/data/Makefile.am
@@ -25,7 +25,7 @@ libsub_torrentdata_la_SOURCES = \
 	transfer_list.cc \
 	transfer_list.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
 
 libtorrentincludedir = $(includedir)/torrent/data
 libtorrentinclude_HEADERS = \

--- a/src/torrent/download/Makefile.am
+++ b/src/torrent/download/Makefile.am
@@ -11,7 +11,7 @@ libsub_torrentdownload_la_SOURCES = \
 	resource_manager.cc \
 	resource_manager.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
 
 libtorrentincludedir = $(includedir)/torrent/download
 libtorrentinclude_HEADERS = \

--- a/src/torrent/peer/Makefile.am
+++ b/src/torrent/peer/Makefile.am
@@ -15,7 +15,7 @@ libsub_torrentpeer_la_SOURCES = \
 	peer_list.cc \
 	peer_list.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
 
 libtorrentincludedir = $(includedir)/torrent/peer
 libtorrentinclude_HEADERS = \

--- a/src/torrent/utils/Makefile.am
+++ b/src/torrent/utils/Makefile.am
@@ -22,7 +22,7 @@ libsub_torrentutils_la_SOURCES = \
 	thread_interrupt.cc \
 	thread_interrupt.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(srcdir)/../.. -I$(top_srcdir)
 
 libtorrentincludedir = $(includedir)/torrent/utils
 libtorrentinclude_HEADERS = \

--- a/src/tracker/Makefile.am
+++ b/src/tracker/Makefile.am
@@ -8,4 +8,4 @@ libsub_tracker_la_SOURCES = \
 	tracker_udp.cc \
 	tracker_udp.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -8,4 +8,4 @@ libsub_utils_la_SOURCES = \
 	sha_fast.cc \
 	sha_fast.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -73,4 +73,4 @@ LibTorrentTest_SOURCES = \
 LibTorrentTest_CXXFLAGS = $(CPPUNIT_CFLAGS)
 LibTorrentTest_LDFLAGS = $(CPPUNIT_LIBS)  -ldl
 
-INCLUDES = -I$(srcdir) -I$(top_srcdir) -I$(top_srcdir)/src
+AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir) -I$(top_srcdir)/src


### PR DESCRIPTION
warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
