### PR TITLE
build: correct library dependencies for tests

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,9 +10,9 @@ LibTorrentTest_LDADD = \
 	../src/torrent/peer/libsub_torrentpeer.la \
 	../src/data/libsub_data.la \
 	../src/dht/libsub_dht.la \
-	../src/download/libsub_download.la \
 	../src/net/libsub_net.la \
 	../src/protocol/libsub_protocol.la \
+	../src/download/libsub_download.la \
 	../src/tracker/libsub_tracker.la \
 	../src/utils/libsub_utils.la \
 	../src/torrent/utils/libsub_torrentutils.la


### PR DESCRIPTION
The request list processing in the protocol implementation references the
download delegate method.  This creates a dependency on download from protocol.
Correct the order of the dependencies so that the linker is properly able to
resolve the symbols.

Closes #59.
