### PR TITLE
Sort files by path for a more compact and nicer directory tree

### DIFF
--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -331,6 +331,7 @@ DownloadConstructor::parse_multi_files(const Object& b, uint32_t chunkSize) {
 
   fileList->initialize(torrentSize, chunkSize);
   fileList->split(fileList->begin(), &*splitList.begin(), &*splitList.end());
+  fileList->sort();
   fileList->update_paths(fileList->begin(), fileList->end());  
 }
 

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -151,6 +151,8 @@ public:
   bool                make_root_path();
   bool                make_all_paths();
 
+  void                sort();
+
 protected:
   static const int open_no_create        = (1 << 0);
   static const int open_require_all_open = (1 << 1);


### PR DESCRIPTION
This patch tries to implement issue #84 "Sort files by path for a more compact and nicer directory tree".

Unfortunately it makes FileList::create_chunk() and FileList::inc_completed() more expensive. FileList::create_chunk() becomes O(n^2) [was O(n)] where n is the number of files. But the worst case only happens if files are in reverse order in the torrent and verry small. In general it is linear with the number of files. FileList::inc_completed() becomes O(n) [was amortized O(1 + n/num_chunks)].

Can't say I noticed a difference in cpu load in practice but I don't have a torrent with many files, small chunks and high download rate to compare at the moment.