### PR TITLE
Fixes to build_bencode callers, READ_ENC_IA, and object_read_bencode_c

### DIFF
--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -394,7 +394,7 @@ ProtocolExtension::send_metadata_piece(size_t piece) {
   if (m_download->info()->is_meta_download() || piece >= pieceEnd) {
     // reject: { "msg_type" => 2, "piece" => ... }
     m_pendingType = UT_METADATA;
-    m_pending = build_bencode(sizeof(size_t) + 36), "d8:msg_typei2e5:piecei%zuee", piece);
+    m_pending = build_bencode(sizeof(size_t) + 36, "d8:msg_typei2e5:piecei%zuee", piece);
     return;
   }
 

--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -394,7 +394,7 @@ ProtocolExtension::send_metadata_piece(size_t piece) {
   if (m_download->info()->is_meta_download() || piece >= pieceEnd) {
     // reject: { "msg_type" => 2, "piece" => ... }
     m_pendingType = UT_METADATA;
-    m_pending = build_bencode(40, "d8:msg_typei2e5:piecei%zuee", piece);
+    m_pending = build_bencode(sizeof(size_t) + 36), "d8:msg_typei2e5:piecei%zuee", piece);
     return;
   }
 
@@ -407,7 +407,7 @@ ProtocolExtension::send_metadata_piece(size_t piece) {
   // data: { "msg_type" => 1, "piece" => ..., "total_size" => ... } followed by piece data (outside of dictionary)
   size_t length = piece == pieceEnd - 1 ? m_download->info()->metadata_size() % metadata_piece_size : metadata_piece_size;
   m_pendingType = UT_METADATA;
-  m_pending = build_bencode(length + 128, "d8:msg_typei1e5:piecei%zue10:total_sizei%zuee", piece, metadataSize);
+  m_pending = build_bencode((2 * sizeof(size_t)) + length + 120, "d8:msg_typei1e5:piecei%zue10:total_sizei%zuee", piece, metadataSize);
 
   memcpy(m_pending.end(), buffer + (piece << metadata_piece_shift), length);
   m_pending.set(m_pending.data(), m_pending.end() + length, m_pending.owned());

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -738,7 +738,7 @@ restart:
         break;
 
       if (m_readBuffer.remaining() > m_encryption.length_ia())
-        throw internal_error("Read past initial payload after incoming encrypted handshake.");
+        throw handshake_error(ConnectionManager::handshake_failed, e_handshake_invalid_value);
 
       if (m_encryption.crypto() != HandshakeEncryption::crypto_rc4)
         m_encryption.info()->set_obfuscated();

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -104,7 +104,8 @@ object_read_bencode_c_string(const char* first, const char* last) {
   while (first != last && *first >= '0' && *first <= '9')
     length = length * 10 + (*first++ - '0');
 
-  if (length + 1 > (unsigned int)std::distance(first, last) || *first++ != ':')
+  if (length + 1 > (unsigned int)std::distance(first, last) || *first++ != ':'
+		  || length + 1 == 0)
     throw torrent::bencode_error("Invalid bencode data.");
   
   return raw_string(first, length);


### PR DESCRIPTION
Calls into build_benocde that use %zu could crash on 64 bit machines due to the size change of size_t 

Someone can force READ_ENC_IA to fail allowing an internal_error to be thrown and bring down the client, throw handshake_error instead 
#98 #89 