### PR TITLE
Context for internal_error

### DIFF
--- a/src/torrent/exceptions.h
+++ b/src/torrent/exceptions.h
@@ -46,6 +46,7 @@
 #include <exception>
 #include <string>
 #include <torrent/common.h>
+#include <torrent/hash_string.h>
 
 namespace torrent {
 
@@ -61,6 +62,10 @@ public:
 class LIBTORRENT_EXPORT internal_error : public base_error {
 public:
   internal_error(const char* msg)        { initialize(msg); }
+  internal_error(const char* msg, const std::string& context) {
+    initialize(std::string(msg) + " [" + context + "]"); }
+  internal_error(const char* msg, const HashString& hash) {
+    initialize(std::string(msg) + " [#" + hash_string_to_hex_str(hash) + "]"); }
   internal_error(const std::string& msg) { initialize(msg); }
   virtual ~internal_error() throw() {}
 


### PR DESCRIPTION
With many loaded items, `internal_error`s are almost useless, because you never know which item caused them. This is a start to provide more context, namely the hash of the affected item (for now, just in a single source file as a proof of concept).