### PR TITLE
Fix honoring system.file.allocate.set=0 rtorrent config setting

### DIFF
--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -177,13 +177,14 @@ File::resize_file() {
   if (m_size == SocketFile(m_fd).size())
     return true;
 
-  // For now make it so that the fallocate flag indicates if we want
-  // to do potentially blocking allocation, while FS supported
-  // non-blocking allocation is done always.
-  int flags = SocketFile::flag_fallocate;
+  int flags = 0;
 
-  if (m_flags & flag_fallocate)
+  // Set FS supported non-blocking allocation flag and potentially
+  // blocking allocation flag if fallocate flag is set.
+  if (m_flags & flag_fallocate) {
+    flags |= SocketFile::flag_fallocate;
     flags |= SocketFile::flag_fallocate_blocking;
+  }
 
   return SocketFile(m_fd).set_size(m_size, flags);
 }


### PR DESCRIPTION
Fix honoring `system.file.allocate.set=0` rtorrent config setting.

Fixes: https://github.com/rakshasa/rtorrent/issues/202
Refers to: https://github.com/rakshasa/rtorrent/issues/488

Note: this patch is also good for: 0.13.6, 0.13.4, 0.13.2 .
