### PR TITLE
Don't check the HAVE_CXX11 macro

### DIFF
--- a/src/torrent/object.h
+++ b/src/torrent/object.h
@@ -248,7 +248,7 @@ public:
 
   uint32_t            m_flags;
 
-#ifdef HAVE_CXX11
+#ifndef HAVE_STDCXX_0X
   value_type&         _value()             { return t_value; }
   const value_type&   _value() const       { return t_value; }
   string_type&        _string()            { return t_string; }


### PR DESCRIPTION
The macro only gets defined if C++11 is not required, however it is required. Instead check if we're using c++0x as that macro will be defined when using --enable-c++0x