### PR TITLE
Calculate coverage for coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ language: cpp
 matrix:
   include:
   - compiler: clang
-    env: COMPILER=clang++ SKIP_CHECK=true
+    env: COMPILER=clang++ SKIP_CHECK=true SKIP_COVERAGE=true
   - compiler: clang
-    env: COMPILER=clang++
+    env: COMPILER=clang++ SKIP_COVERAGE=true
     addons:
       apt:
         packages:
         - libcppunit-dev
   - compiler: clang
-    env: COMPILER=clang++-3.6
+    env: COMPILER=clang++-3.6 SKIP_COVERAGE=true
     addons:
       apt:
         sources:
@@ -21,7 +21,7 @@ matrix:
         - clang-3.6
         - libcppunit-dev
   - compiler: clang
-    env: COMPILER=clang++-3.7
+    env: COMPILER=clang++-3.7 SKIP_COVERAGE=true
     addons:
       apt:
         sources:
@@ -31,7 +31,7 @@ matrix:
         - clang-3.7
         - libcppunit-dev
   - compiler: clang
-    env: COMPILER=clang++-3.8
+    env: COMPILER=clang++-3.8 SKIP_COVERAGE=true
     addons:
       apt:
         sources:
@@ -41,14 +41,14 @@ matrix:
         - clang-3.8
         - libcppunit-dev
   - compiler: gcc
-    env: COMPILER=g++-4.7 SKIP_CHECK=true
+    env: COMPILER=g++-4.7 SKIP_CHECK=true SKIP_COVERAGE=true
     addons:
       apt:
         sources: ubuntu-toolchain-r-test
         packages:
         - g++-4.7
   - compiler: gcc
-    env: COMPILER=g++-4.7
+    env: COMPILER=g++-4.7 SKIP_COVERAGE=true
     addons:
       apt:
         sources: ubuntu-toolchain-r-test
@@ -64,6 +64,13 @@ matrix:
         - g++-4.8
         - libcppunit-dev
 
+before_install:
+  - if [ ! $SKIP_COVERAGE ]; then pip install --user cpp-coveralls; fi
+
 script:
+- if [ ! $SKIP_COVERAGE ]; then export CXXFLAGS="-ftest-coverage -fprofile-arcs"; fi
 - ./autogen.sh && CXX="$COMPILER" ./configure && make -j12
 - if [ ! $SKIP_CHECK ]; then make -j12 check; fi
+
+after_success:
+  - if [ ! $SKIP_COVERAGE ]; then coveralls --exclude test --gcov-options '\-lp' --gcov gcov-4.8; fi


### PR DESCRIPTION
If you want to support this, you just need to add the project on https://coveralls.io. Coverage should help with new test creation as it's hard to see what tests to write without coverage data.