### PR TITLE
Bug Fixes for 123,124,125,126,129 and 130

### DIFF
--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -743,6 +743,11 @@ DhtServer::event_read() {
       if (!message[key_t].is_raw_string())
         throw dht_error(dht_error_protocol, "No transaction ID");
 
+	  //Check transaction id length to avoid use of it in dht_error if invalid
+	  if(message[key_t].as_string().size() > 20) {
+		  throw network_error();
+	  }
+
       if (!message[key_y].is_raw_string())
         throw dht_error(dht_error_protocol, "No message type");
 

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -597,7 +597,7 @@ void
 DhtServer::create_error(const DhtMessage& req, const rak::socket_address* sa, int num, const char* msg) {
   DhtMessage error;
 
-  if (req[key_t].is_raw_bencode() || req[key_t].is_raw_string())
+  if ((req[key_t].is_raw_bencode() || req[key_t].is_raw_string()) && req[key_t].as_raw_string().size < 20)
     error[key_t] = req[key_t];
 
   error[key_y] = raw_bencode::from_c_str("1:e");
@@ -743,10 +743,10 @@ DhtServer::event_read() {
       if (!message[key_t].is_raw_string())
         throw dht_error(dht_error_protocol, "No transaction ID");
 
-	  //Check transaction id length to avoid use of it in dht_error if invalid
-	  if(message[key_t].as_string().size() > 20) {
-		  throw network_error();
-	  }
+      // Restrict the length of Transaction IDs. We echo them in our replies.
+      if(message[key_t].as_raw_string().size() > 20) {
+		  throw dht_error(dht_error_protocol, "Transaction ID length too long");
+      }
 
       if (!message[key_y].is_raw_string())
         throw dht_error(dht_error_protocol, "No message type");

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -597,8 +597,7 @@ void
 DhtServer::create_error(const DhtMessage& req, const rak::socket_address* sa, int num, const char* msg) {
   DhtMessage error;
 
-  if ((req[key_t].is_raw_bencode() && req[key_t].as_raw_bencode().size() < 20) ||
-		  (req[key_t].is_raw_string() && req[key_t].as_raw_string().size() < 20))
+  if (req[key_t].is_raw_string() && req[key_t].as_raw_string().size() < 67)
     error[key_t] = req[key_t];
 
   error[key_y] = raw_bencode::from_c_str("1:e");

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -597,7 +597,7 @@ void
 DhtServer::create_error(const DhtMessage& req, const rak::socket_address* sa, int num, const char* msg) {
   DhtMessage error;
 
-  if ((req[key_t].is_raw_bencode() || req[key_t].is_raw_string()) && req[key_t].as_raw_string().size < 20)
+  if ((req[key_t].is_raw_bencode() || req[key_t].is_raw_string()) && req[key_t].as_raw_string().size() < 20)
     error[key_t] = req[key_t];
 
   error[key_y] = raw_bencode::from_c_str("1:e");

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -597,7 +597,8 @@ void
 DhtServer::create_error(const DhtMessage& req, const rak::socket_address* sa, int num, const char* msg) {
   DhtMessage error;
 
-  if ((req[key_t].is_raw_bencode() || req[key_t].is_raw_string()) && req[key_t].as_raw_string().size() < 20)
+  if ((req[key_t].is_raw_bencode() && req[key_t].as_raw_bencode().size() < 20) ||
+		  (req[key_t].is_raw_string() && req[key_t].as_raw_string().size() < 20))
     error[key_t] = req[key_t];
 
   error[key_y] = raw_bencode::from_c_str("1:e");

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -492,6 +492,9 @@ DownloadMain::do_peer_exchange() {
 void
 DownloadMain::set_metadata_size(size_t size) {
   if (m_info->is_meta_download()) {
+	if(size == 0)
+		throw communication_error("Peer-supplied metadata size of 0");
+
     if (m_fileList.size_bytes() < 2)
       file_list()->reset_filesize(size);
     else if (size != m_fileList.size_bytes())

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -492,8 +492,8 @@ DownloadMain::do_peer_exchange() {
 void
 DownloadMain::set_metadata_size(size_t size) {
   if (m_info->is_meta_download()) {
-	if(size == 0)
-		throw communication_error("Peer-supplied metadata size of 0");
+	if(size == 0 || size > (1 << 26))
+		throw communication_error("Peer-supplied invalid metadata size.");
 
     if (m_fileList.size_bytes() < 2)
       file_list()->reset_filesize(size);

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -155,9 +155,6 @@ uint64_t
 FileList::left_bytes() const {
   uint64_t left = size_bytes() - completed_bytes();
 
-  if (left > ((uint64_t)1 << 60))
-    throw internal_error("FileList::bytes_left() is too large.", data()->hash());
-
   if (completed_chunks() == size_chunks() && left != 0)
     throw internal_error("FileList::bytes_left() has an invalid size.", data()->hash());
 

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -155,6 +155,9 @@ uint64_t
 FileList::left_bytes() const {
   uint64_t left = size_bytes() - completed_bytes();
 
+  if (left > ((uint64_t)1 << 60))
+    throw internal_error("FileList::bytes_left() is too large.", data()->hash());
+
   if (completed_chunks() == size_chunks() && left != 0)
     throw internal_error("FileList::bytes_left() has an invalid size.", data()->hash());
 

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -59,7 +59,12 @@ object_read_string(std::istream* input, std::string& str) {
   if (input->fail() || input->get() != ':')
     return false;
   
-  str.resize(size);
+  try {
+  	str.resize(size);
+  }
+  catch (std::length_error& e){ 
+	  return false;
+  }
 
   for (std::string::iterator itr = str.begin(); itr != str.end() && input->good(); ++itr)
     *itr = input->get();

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <cmath>
 #include <limits>
+#include <stdexcept>
 #include <rak/algorithm.h>
 #include <rak/string_manip.h>
 

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -109,8 +109,8 @@ object_read_bencode_c_string(const char* first, const char* last) {
   while (first != last && *first >= '0' && *first <= '9')
     length = length * 10 + (*first++ - '0');
 
-  if (length + 1 > (unsigned int)std::distance(first, last) || *first++ != ':'
-		  || length + 1 == 0)
+  if (length + 1 > (unsigned int)std::distance(first, last) || length + 1 == 0
+		  || *first++ != ':')
     throw torrent::bencode_error("Invalid bencode data.");
   
   return raw_string(first, length);

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -356,7 +356,7 @@ TrackerHttp::process_success(const Object& object) {
     }
   }
 
-  if (object.has_key("peers6"))
+  if (object.has_key_string("peers6"))
     l.parse_address_compact_ipv6(object.get_key_string("peers6"));
 
   close_directly();


### PR DESCRIPTION
Fixes for #123 #124 #125 #126 #129 #130 

One that I'm not too sure about is the change to left_bytes where I remove the restriction of left being < 1 << 60. This is to fix #124 where a peer during a meta download can set the size to be very large. I'm not sure which case that restriction was attempting to prevent. 