### PR TITLE
second draft of async DNS resolution via udns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ scripts/lt*.m4
 .#*
 \#*#
 *~
+*.swp
 
 # Packages #
 ############

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       apt:
         packages:
         - libcppunit-dev
+        - libudns-dev
   - compiler: clang
     env: COMPILER=clang++-3.6 SKIP_COVERAGE=true
     addons:
@@ -20,6 +21,7 @@ matrix:
         packages:
         - clang-3.6
         - libcppunit-dev
+        - libudns-dev
   - compiler: clang
     env: COMPILER=clang++-3.7 SKIP_COVERAGE=true
     addons:
@@ -30,6 +32,7 @@ matrix:
         packages:
         - clang-3.7
         - libcppunit-dev
+        - libudns-dev
   - compiler: clang
     env: COMPILER=clang++-3.8 SKIP_COVERAGE=true
     addons:
@@ -40,6 +43,7 @@ matrix:
         packages:
         - clang-3.8
         - libcppunit-dev
+        - libudns-dev
   - compiler: gcc
     env: COMPILER=g++-4.7 SKIP_CHECK=true SKIP_COVERAGE=true
     addons:
@@ -47,6 +51,7 @@ matrix:
         sources: ubuntu-toolchain-r-test
         packages:
         - g++-4.7
+        - libudns-dev
   - compiler: gcc
     env: COMPILER=g++-4.7 SKIP_COVERAGE=true
     addons:
@@ -55,6 +60,7 @@ matrix:
         packages:
         - g++-4.7
         - libcppunit-dev
+        - libudns-dev
   - compiler: gcc
     env: COMPILER=g++-4.8
     addons:
@@ -63,6 +69,7 @@ matrix:
         packages:
         - g++-4.8
         - libcppunit-dev
+        - libudns-dev
 
 before_install:
   - if [ ! $SKIP_COVERAGE ]; then pip install --user cpp-coveralls; fi

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,8 @@ PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])
 
 CFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CFLAGS"
 CXXFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CXXFLAGS"
-LIBS="$PTHREAD_LIBS $CPPUNIT_LIBS $LIBS"
+dnl TODO stub change, add real autoconf changes to link against udns
+LIBS="$PTHREAD_LIBS $CPPUNIT_LIBS $LIBS -ludns"
 
 AC_ARG_ENABLE(openssl,
   [  --disable-openssl       Don't use OpenSSL's SHA1 implementation.],

--- a/src/torrent/common.h
+++ b/src/torrent/common.h
@@ -107,6 +107,9 @@ class TransferList;
   #define LIBTORRENT_EXPORT
 #endif
 
+// TODO this is a stub; make this a real autoconf thing
+#define HAVE_UDNS
+
 }
 
 #endif

--- a/src/torrent/connection_manager.cc
+++ b/src/torrent/connection_manager.cc
@@ -234,7 +234,6 @@ ConnectionManager::cancel_async_resolve(void *query) {
 #ifdef HAVE_UDNS
     m_udnsevent.cancel((UdnsQuery *) query);
 #else
-    // O(n), meh; this should never get called in a non-udns build
     MockResolve *mock_resolve = (MockResolve *) query;
     auto it = std::find(std::begin(m_mock_resolve_queue), std::end(m_mock_resolve_queue), mock_resolve);
     if (it != std::end(m_mock_resolve_queue)) {

--- a/src/torrent/connection_manager.h
+++ b/src/torrent/connection_manager.h
@@ -39,7 +39,6 @@
 #ifndef LIBTORRENT_CONNECTION_MANAGER_H
 #define LIBTORRENT_CONNECTION_MANAGER_H
 
-#include <list>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>

--- a/src/torrent/utils/Makefile.am
+++ b/src/torrent/utils/Makefile.am
@@ -21,6 +21,8 @@ libsub_torrentutils_la_SOURCES = \
 	thread_base.h \
 	thread_interrupt.cc \
 	thread_interrupt.h \
+	udnsevent.cc \
+	udnsevent.h \
 	uri_parser.cc \
 	uri_parser.h
 
@@ -39,4 +41,5 @@ libtorrentinclude_HEADERS = \
 	signal_bitfield.h \
 	thread_base.h \
 	thread_interrupt.h \
+	udnsevent.h \
 	uri_parser.h

--- a/src/torrent/utils/udnsevent.cc
+++ b/src/torrent/utils/udnsevent.cc
@@ -1,0 +1,185 @@
+#include <torrent/common.h>
+#include "config.h"
+
+#ifdef HAVE_UDNS
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "udnsevent.h"
+#include "globals.h"
+#include "manager.h"
+#include "torrent/poll.h"
+
+namespace torrent {
+
+    int udnserror_to_gaierror(int udnserror) {
+        switch (udnserror) {
+            case DNS_E_TEMPFAIL:
+                return EAI_AGAIN;
+            case DNS_E_PROTOCOL:
+                // this isn't quite right
+                return EAI_FAIL;
+            case DNS_E_NXDOMAIN:
+                return EAI_NONAME;
+            case DNS_E_NODATA:
+                return EAI_ADDRFAMILY;
+            case DNS_E_NOMEM:
+                return EAI_MEMORY;
+            case DNS_E_BADQUERY:
+                // again, not quite right
+                return EAI_FAIL;
+            default:
+                return EAI_ADDRFAMILY;
+        }
+    }
+
+    /** Compatibility layers so udns can call std::function callbacks. */
+
+    void a4_callback_wrapper(struct ::dns_ctx *ctx, ::dns_rr_a4 *result, void *data) {
+        struct sockaddr_in sa;
+        const sockaddr *sa_addr = (sockaddr *) &sa;
+        UdnsQuery *query = (UdnsQuery *) data;
+        // udns will free the a4_query after this callback exits
+        query->a4_query = NULL;
+
+        if (result == NULL || result->dnsa4_nrr == 0) {
+            if (query->a6_query == NULL) {
+                // nothing more to do: call the callback with a failure status
+                (*(query->callback))(NULL, udnserror_to_gaierror(::dns_status(ctx)));
+                delete query;
+            }
+            // else: return and wait to see if we get an a6 response
+        } else {
+            sa.sin_family = AF_INET;
+            sa.sin_port = 0;
+            sa.sin_addr = result->dnsa4_addr[0];
+            (*query->callback)(sa_addr, 0);
+            if (query->a6_query != NULL) {
+                ::dns_cancel(ctx, query->a6_query);
+                delete query;
+            }
+        }
+    }
+
+    void a6_callback_wrapper(struct ::dns_ctx *ctx, ::dns_rr_a6 *result, void *data) {
+        struct sockaddr_in6 sa;
+        const sockaddr *sa_addr = (sockaddr *) &sa;
+        UdnsQuery *query = (UdnsQuery *) data;
+        // udns will free the a6_query after this callback exits
+        query->a6_query = NULL;
+
+        if (result == NULL || result->dnsa6_nrr == 0) {
+            if (query->a4_query == NULL) {
+                // nothing more to do: call the callback with a failure status
+                (*(query->callback))(NULL, udnserror_to_gaierror(::dns_status(ctx)));
+                delete query;
+            }
+            // else: return and wait to see if we get an a6 response
+        } else {
+            sa.sin6_family = AF_INET6;
+            sa.sin6_port = 0;
+            sa.sin6_addr = result->dnsa6_addr[0];
+            (*query->callback)(sa_addr, 0);
+            if (query->a4_query != NULL) {
+                ::dns_cancel(ctx, query->a4_query);
+                delete query;
+            }
+        }
+    }
+
+
+    UdnsEvent::UdnsEvent() {
+      // reinitialize the default context, no-op
+      // TODO don't do this here --- do it once in the manager, or in rtorrent
+      ::dns_init(NULL, 0);
+      // thread-safe context isolated to this object:
+      m_ctx = ::dns_new(NULL);
+      int fd = ::dns_init(m_ctx, 1);
+      if (fd > 0) {
+          m_fileDesc = fd;
+      } else {
+          throw internal_error("dns_init failed");
+      }
+
+      m_taskTimeout.slot() = std::bind(&UdnsEvent::process_timeouts, this);
+    }
+
+    UdnsEvent::~UdnsEvent() {
+        priority_queue_erase(&taskScheduler, &m_taskTimeout);
+        ::dns_close(m_ctx);
+        ::dns_free(m_ctx);
+    }
+
+    void UdnsEvent::event_read() {
+        ::dns_ioevent(m_ctx, 0);
+    }
+
+    void UdnsEvent::event_write() {
+    }
+
+    void UdnsEvent::event_error() {
+    }
+
+    struct UdnsQuery *
+    UdnsEvent::enqueue_resolve(const char *name, int family, resolver_callback *callback) {
+        struct UdnsQuery *query = new UdnsQuery;
+        query->a4_query = query->a6_query = NULL;
+        query->callback = callback;
+
+        if (family == AF_INET || family == AF_UNSPEC) {
+            query->a4_query = ::dns_submit_a4(m_ctx, name, 0, a4_callback_wrapper, query);
+            if (query->a4_query == NULL) throw new internal_error("dns_submit_a4 failed");
+        }
+
+        if (family == AF_INET6 || family == AF_UNSPEC) {
+            query->a6_query = ::dns_submit_a6(m_ctx, name, 0, a6_callback_wrapper, query);
+            if (query->a6_query == NULL) throw new internal_error("dns_submit_a6 failed");
+        }
+
+        return query;
+    }
+
+    void
+    UdnsEvent::flush_resolves() {
+        process_timeouts();
+    }
+
+    void
+    UdnsEvent::process_timeouts() {
+        int timeout = ::dns_timeouts(m_ctx, -1, 0);
+        if (timeout != -1) {
+            manager->poll()->insert_read(this);
+            manager->poll()->insert_error(this);
+            priority_queue_erase(&taskScheduler, &m_taskTimeout);
+            priority_queue_insert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(timeout)).round_seconds());
+        } else {
+            // no pending queries
+            manager->poll()->remove_read(this);
+            manager->poll()->remove_error(this);
+        }
+    }
+
+    void
+    UdnsEvent::cancel(struct UdnsQuery *query) {
+        if (query == NULL) {
+            return;
+        }
+        if (query->a4_query != NULL) {
+            ::dns_cancel(m_ctx, query->a4_query);
+        }
+        if (query->a6_query != NULL) {
+            ::dns_cancel(m_ctx, query->a6_query);
+        }
+        delete query;
+    }
+
+    const char *
+    UdnsEvent::type_name() {
+        return "UdnsEvent";
+    }
+
+}
+
+#endif

--- a/src/torrent/utils/udnsevent.cc
+++ b/src/torrent/utils/udnsevent.cc
@@ -28,8 +28,7 @@ namespace torrent {
             case DNS_E_NOMEM:
                 return EAI_MEMORY;
             case DNS_E_BADQUERY:
-                // again, not quite right
-                return EAI_FAIL;
+                return EAI_NONAME;
             default:
                 return EAI_ADDRFAMILY;
         }

--- a/src/torrent/utils/udnsevent.h
+++ b/src/torrent/utils/udnsevent.h
@@ -23,6 +23,7 @@ struct UdnsQuery {
     struct ::dns_query *a4_query;
     struct ::dns_query *a6_query;
     resolver_callback  *callback;
+    int                 error;
 };
 
 class UdnsEvent : public Event {
@@ -48,8 +49,9 @@ public:
 protected:
   void                process_timeouts();
 
-  dns_ctx*            m_ctx;
-  rak::priority_item  m_taskTimeout;
+  dns_ctx*               m_ctx;
+  rak::priority_item     m_taskTimeout;
+  std::list<UdnsQuery *> m_malformed_queries;
 };
 
 }

--- a/src/torrent/utils/udnsevent.h
+++ b/src/torrent/utils/udnsevent.h
@@ -1,0 +1,58 @@
+#ifndef LIBTORRENT_NET_UDNSEVENT_H
+#define LIBTORRENT_NET_UDNSEVENT_H
+
+#include lt_tr1_functional
+
+// The sockaddr argument in the result call is NULL if the resolve failed,
+// and the int holds the error code.
+typedef std::function<void (const sockaddr*, int)> resolver_callback;
+
+#ifdef HAVE_UDNS
+
+#include <list>
+#include <inttypes.h>
+
+#include <udns.h>
+
+#include <rak/priority_queue_default.h>
+#include "torrent/event.h"
+
+namespace torrent {
+
+struct UdnsQuery {
+    struct ::dns_query *a4_query;
+    struct ::dns_query *a6_query;
+    resolver_callback  *callback;
+};
+
+class UdnsEvent : public Event {
+public:
+
+  UdnsEvent();
+  ~UdnsEvent();
+
+  virtual void        event_read();
+  virtual void        event_write();
+  virtual void        event_error();
+  virtual const char* type_name();
+
+  // this wraps udns's dns_submit_a[46] functions. they and it return control immediately,
+  // without either sending outgoing UDP packets or executing callbacks:
+  struct UdnsQuery*   enqueue_resolve(const char *name, int family, resolver_callback *callback);
+  // this wraps the dns_timeouts function. it sends packets and can execute arbitrary
+  // callbacks:
+  void                flush_resolves();
+  // this wraps the dns_cancel function:
+  void                cancel(struct UdnsQuery *query);
+
+protected:
+  void                process_timeouts();
+
+  dns_ctx*            m_ctx;
+  rak::priority_item  m_taskTimeout;
+};
+
+}
+
+#endif
+#endif

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -70,25 +70,22 @@ TrackerUdp::TrackerUdp(TrackerList* parent, const std::string& url, int flags) :
 
   m_port(0),
 
-  m_slot_resolver(NULL),
   m_readBuffer(NULL),
   m_writeBuffer(NULL) {
 
   m_taskTimeout.slot() = std::bind(&TrackerUdp::receive_timeout, this);
+
+  m_resolver_callback = std::bind(&TrackerUdp::start_announce, this, std::placeholders::_1, std::placeholders::_2);
+  m_resolver_query = NULL;
 }
 
 TrackerUdp::~TrackerUdp() {
-  if (m_slot_resolver != NULL) {
-    *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
-  }
-
   close_directly();
 }
   
 bool
 TrackerUdp::is_busy() const {
-  return get_fd().is_valid();
+  return (m_resolver_query != NULL) || get_fd().is_valid();
 }
 
 void
@@ -104,15 +101,12 @@ TrackerUdp::send_state(int state) {
   LT_LOG_TRACKER(DEBUG, "hostname lookup (address:%s)", hostname.data());
 
   m_sendState = state;
-
-  // Because we can only remember one slot, set any pending resolves blocked
-  // so that if this tracker is deleted, the member function won't be called.
-  if (m_slot_resolver != NULL) {
-    *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
-  }
-
-  m_slot_resolver = make_resolver_slot(hostname);
+  m_resolver_query = manager->connection_manager()->enqueue_async_resolve(
+      hostname.data(),
+      AF_UNSPEC,
+      &m_resolver_callback
+  );
+  manager->connection_manager()->flush_async_resolves();
 }
 
 bool
@@ -128,21 +122,9 @@ TrackerUdp::parse_udp_url(const std::string& url, hostname_type& hostname, int& 
   return false;
 }
 
-TrackerUdp::resolver_type*
-TrackerUdp::make_resolver_slot(const hostname_type& hostname) {
-  return manager->connection_manager()->resolver()(hostname.data(), PF_UNSPEC, SOCK_DGRAM,
-                                                   std::bind(&TrackerUdp::start_announce,
-                                                             this,
-                                                             std::placeholders::_1,
-                                                             std::placeholders::_2));
-}
-
 void
 TrackerUdp::start_announce(const sockaddr* sa, int err) {
-  if (m_slot_resolver != NULL) {
-    *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
-  }
+  m_resolver_query = NULL;
 
   if (sa == NULL)
     return receive_failed("could not resolve hostname");
@@ -180,9 +162,6 @@ TrackerUdp::start_announce(const sockaddr* sa, int err) {
 
 void
 TrackerUdp::close() {
-  if (!get_fd().is_valid())
-    return;
-
   LT_LOG_TRACKER(DEBUG, "request cancelled (state:%s url:%s)",
                  option_as_string(OPTION_TRACKER_EVENT, m_latest_event), m_url.c_str());
 
@@ -191,9 +170,6 @@ TrackerUdp::close() {
 
 void
 TrackerUdp::disown() {
-  if (!get_fd().is_valid())
-    return;
-
   LT_LOG_TRACKER(DEBUG, "request disowned (state:%s url:%s)",
                  option_as_string(OPTION_TRACKER_EVENT, m_latest_event), m_url.c_str());
 
@@ -202,6 +178,9 @@ TrackerUdp::disown() {
 
 void
 TrackerUdp::close_directly() {
+  manager->connection_manager()->cancel_async_resolve(m_resolver_query);
+  m_resolver_query = NULL;
+
   if (!get_fd().is_valid())
     return;
 

--- a/src/tracker/tracker_udp.h
+++ b/src/tracker/tracker_udp.h
@@ -56,8 +56,6 @@ public:
   typedef ProtocolBuffer<512> ReadBuffer;
   typedef ProtocolBuffer<512> WriteBuffer;
 
-  typedef ConnectionManager::slot_resolver_result_type resolver_type;
-
   static const uint64_t magic_connection_id = 0x0000041727101980ll;
 
   TrackerUdp(TrackerList* parent, const std::string& url, int flags);
@@ -94,14 +92,14 @@ private:
   bool                process_error_output();
 
   bool                parse_udp_url(const std::string& url, hostname_type& hostname, int& port) const;
-  resolver_type*      make_resolver_slot(const hostname_type& hostname);
 
   rak::socket_address m_connectAddress;
   int                 m_port;
 
   int                 m_sendState;
 
-  resolver_type*      m_slot_resolver;
+  resolver_callback   m_resolver_callback;
+  void*               m_resolver_query;
 
   uint32_t            m_action;
   uint64_t            m_connectionId;


### PR DESCRIPTION
This is the successor to #116.

The main things that have changed:

1. ipv6 support (i.e., support for both A and AAAA queries, in parallel if necessary)
1. support for building without udns
1. a change to the async resolution API (unfortunately adding some complexity)

The new API is because the previous version of this patch had a bug:

````
Caught internal_error: priority_queue_insert(...) called on an already queued item.
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(_ZN7torrent14internal_error10initializeERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x243) [0xb75b8293]
/home/shivaram/workspace/sandbox/bin/rtorrent(_ZN7torrent14internal_errorC2EPKc+0x86) [0x808fe46]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(+0xeab48) [0xb767cb48]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(+0x82f7a) [0xb7614f7a]
/lib/libudns.so.0(+0x340b) [0xb756e40b]
/lib/libudns.so.0(dns_ioevent+0x5ad) [0xb75705dd]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(_ZN7torrent9UdnsEvent10event_readEv+0x1d) [0xb7614ecd]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(_ZN7torrent9PollEPoll7performEv+0x16e) [0xb75cfbfe]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(_ZN7torrent9PollEPoll7do_pollExi+0x67) [0xb75cfca7]
/home/shivaram/workspace/sandbox/lib/libtorrent.so.19(_ZN7torrent11thread_base10event_loopEPS0_+0x1a2) [0xb7614212]
/home/shivaram/workspace/sandbox/bin/rtorrent() [0x80549fe]
/lib/libc.so.6(__libc_start_main+0xf6) [0xb6faa5a6]
/home/shivaram/workspace/sandbox/bin/rtorrent() [0x8055b47]
````

the root cause of which was my attempt to combine the `dns_submit_a4` and `dns_timeouts` operations into one `resolve_in4` operation. Basically:

1. `dns_timeouts` can call arbitrary callbacks
2. The callback `TrackerUdp::start_announce` can call into `TrackerUdp::receive_failed`, and then into `TrackerList::receive_failed` and ultimately into `TrackerController::do_timeout`, which can then make *new* DNS queries via `TrackerUdp::send_state`
3. Under rare circumstances (when a server name becomes resolvable again after a period of failure), this can result in multiple calls to `TrackerUdp::send_state` happening on the same tracker, one on top of the other on the call stack
4. Since in #116, the query identifier doesn't get returned to the client until after `dns_timeouts` finishes executing all callbacks, `TrackerUdp::close_directly` was unable to cancel the redundant query (because it wasn't stored in `m_udns_query` yet)
5. which could finally result in two overlapping calls to `TrackerUdp::start_announce` and the above assertion failure

I came to the conclusion that the only way to make the API safe for re-entry in general is to immediately return the query identifier to the client, before calling any callbacks --- hence splitting the resolve operation into "queue" and "flush" operations, corresponding to the `dns_submit_a4` and `dns_timeouts` operations in udns. This blocks the above bug at step 4.

I have very little experience with autoconf, make, etc. so the current build changes (which enable `HAVE_UDNS` always) are just a stub. They're a separate commit so they can be rebased out.