### PR TITLE
Fix BEP7 compatibility with IPv6 trackers and IPv4 peers

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -151,6 +151,12 @@ TrackerHttp::send_state(int state) {
       s << "&ipv6=" << rak::copy_escape_html(local_v6.address_str());
   }
 
+  if (localAddress->is_address_any() || localAddress->family() != rak::socket_address::pf_inet) {
+    rak::socket_address local_v4;
+    if (get_local_address(rak::socket_address::af_inet, &local_v4))
+      s << "&ipv4=" << rak::copy_escape_html(local_v4.address_str());
+  }
+
   if (info->is_compact())
     s << "&compact=1";
 


### PR DESCRIPTION
Currently the BEP7 code in tracker_http supports the case where
a peer is IPv6 ready but the tracker is not, passing its IPv6 IP
as an announce parameter. Unfortunately it does not yet support
the case where both the peer and tracker are running in IPv6 mode
but other peers in the swarm are not yet IPv6 capable. This sort
of situation is occuring with increasing frequency now that IPv6
adoption is taking off.

To correct this, we are now going to send the IPv4 parameter to
the tracker when connecting to the tracker over IPv6, implementing
the remaining portion of this specification amendment.