### PR TITLE
BEP7 remove IPv4 escaping

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -154,7 +154,7 @@ TrackerHttp::send_state(int state) {
   if (localAddress->is_address_any() || localAddress->family() != rak::socket_address::pf_inet) {
     rak::socket_address local_v4;
     if (get_local_address(rak::socket_address::af_inet, &local_v4))
-      s << "&ipv4=" << rak::copy_escape_html(local_v4.address_str());
+      s << "&ipv4=" << local_v4.address_str();
   }
 
   if (info->is_compact())


### PR DESCRIPTION
Fix for regression introduced in d0b7724febec620c43babf08fcb5a6f4148af01c

While some trackers automatically handle decoding encoded URL attributes
others (primarily for performance reasons) stick very close to the spec.

When implementing the `&ipv4=` parameter I mistakenly added encoding for
symbols to IPv4 when BEP7 only specified that that should be the case
for IPv6. IPv4 is meant to be sent without encoding according to BEP7
and other client behaviour.