### PR TITLE
Replace inttypes.h with proper C++ cinttypes

### DIFF
--- a/extra/corrupt_file.cc
+++ b/extra/corrupt_file.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <stdexcept>
-#include <inttypes.h>
+#include <cinttypes>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>

--- a/rak/file_stat.h
+++ b/rak/file_stat.h
@@ -38,7 +38,7 @@
 #define RAK_FILE_STAT_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include <sys/stat.h>
 
 namespace rak {

--- a/rak/fs_stat.h
+++ b/rak/fs_stat.h
@@ -38,7 +38,7 @@
 #define RAK_FS_STAT_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <rak/error_number.h>
 

--- a/rak/partial_queue.h
+++ b/rak/partial_queue.h
@@ -39,7 +39,7 @@
 
 #include <cstring>
 #include <stdexcept>
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace rak {
 

--- a/rak/socket_address.h
+++ b/rak/socket_address.h
@@ -47,8 +47,6 @@
 #ifndef RAK_SOCKET_ADDRESS_H
 #define RAK_SOCKET_ADDRESS_H
 
-#define __STDC_FORMAT_MACROS
-
 #include <cinttypes>
 #include <cstdint>
 #include <cstring>

--- a/rak/timer.h
+++ b/rak/timer.h
@@ -38,7 +38,7 @@
 #define RAK_TIMER_H
 
 #include <limits>
-#include <inttypes.h>
+#include <cinttypes>
 #include <sys/time.h>
 
 namespace rak {

--- a/src/data/chunk_list.cc
+++ b/src/data/chunk_list.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <rak/error_number.h>
 #include <rak/functional.h>
 

--- a/src/data/chunk_list_node.h
+++ b/src/data/chunk_list_node.h
@@ -37,7 +37,7 @@
 #ifndef LIBTORRENT_DATA_CHUNK_LIST_NODE_H
 #define LIBTORRENT_DATA_CHUNK_LIST_NODE_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <rak/timer.h>
 
 namespace torrent {

--- a/src/data/hash_queue.cc
+++ b/src/data/hash_queue.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <functional>
 #include <rak/functional.h>
 #include <unistd.h>

--- a/src/data/hash_queue_node.h
+++ b/src/data/hash_queue_node.h
@@ -39,7 +39,7 @@
 
 #include <string>
 #include lt_tr1_functional
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "chunk_handle.h"
 #include "hash_chunk.h"

--- a/src/data/hash_torrent.cc
+++ b/src/data/hash_torrent.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include "data/chunk_list.h"
 #include "torrent/exceptions.h"
 #include "torrent/data/download_data.h"

--- a/src/data/hash_torrent.h
+++ b/src/data/hash_torrent.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_DATA_HASH_TORRENT_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include lt_tr1_functional
 #include <rak/priority_queue_default.h>
 

--- a/src/data/memory_chunk.h
+++ b/src/data/memory_chunk.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_DATA_MEMORY_CHUNK_H
 
 #include <algorithm>
-#include <inttypes.h>
+#include <cinttypes>
 #include <sys/mman.h>
 #include <cstddef>
 

--- a/src/data/socket_file.h
+++ b/src/data/socket_file.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_SOCKET_FILE_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include <fcntl.h>
 #include <sys/types.h>
 

--- a/src/download/chunk_selector.h
+++ b/src/download/chunk_selector.h
@@ -37,7 +37,7 @@
 #ifndef LIBTORRENT_DOWNLOAD_CHUNK_SELECTOR_H
 #define LIBTORRENT_DOWNLOAD_CHUNK_SELECTOR_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <rak/partial_queue.h>
 
 #include "torrent/bitfield.h"

--- a/src/download/chunk_statistics.h
+++ b/src/download/chunk_statistics.h
@@ -37,7 +37,7 @@
 #ifndef LIBTORRENT_DOWNLOAD_CHUNK_STATISTICS_H
 #define LIBTORRENT_DOWNLOAD_CHUNK_STATISTICS_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <vector>
 
 namespace torrent {

--- a/src/download/delegator.cc
+++ b/src/download/delegator.cc
@@ -39,7 +39,7 @@
 #include "config.h"
 
 #include <algorithm>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "torrent/exceptions.h"
 #include "torrent/bitfield.h"

--- a/src/download/download_constructor.h
+++ b/src/download/download_constructor.h
@@ -39,7 +39,7 @@
 
 #include <list>
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace torrent {
 

--- a/src/net/data_buffer.h
+++ b/src/net/data_buffer.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_NET_DATA_BUFFER_H
 
 #include <memory>
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace torrent {
 

--- a/src/net/listen.cc
+++ b/src/net/listen.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/src/net/listen.h
+++ b/src/net/listen.h
@@ -37,7 +37,7 @@
 #ifndef LIBTORRENT_LISTEN_H
 #define LIBTORRENT_LISTEN_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include lt_tr1_functional
 #include <rak/socket_address.h>
 

--- a/src/net/protocol_buffer.h
+++ b/src/net/protocol_buffer.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_NET_PROTOCOL_BUFFER_H
 
 #include <memory>
-#include <inttypes.h>
+#include <cinttypes>
 #include <netinet/in.h>
 
 #include "torrent/exceptions.h"

--- a/src/net/socket_base.h
+++ b/src/net/socket_base.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_NET_SOCKET_BASE_H
 
 #include <list>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "torrent/event.h"
 #include "socket_fd.h"

--- a/src/net/socket_set.h
+++ b/src/net/socket_set.h
@@ -39,7 +39,7 @@
 
 #include <list>
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 #include <rak/allocators.h>
 
 #include "torrent/exceptions.h"

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -179,7 +179,7 @@ HandshakeManager::create_outgoing(const rak::socket_address& sa, DownloadMain* d
     encryption_options |= ConnectionManager::encryption_use_proxy;
   }
 
-  auto alloc_fd = []() {
+  auto alloc_fd = [this]() {
     SocketFd fd;
 
     if (!fd.open_stream())

--- a/src/protocol/handshake_manager.h
+++ b/src/protocol/handshake_manager.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_NET_HANDSHAKE_MANAGER_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include lt_tr1_functional
 #include <rak/functional.h>
 #include <rak/unordered_vector.h>

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <cstdio>
 #include <fcntl.h>
 #include <rak/error_number.h>

--- a/src/protocol/request_list.cc
+++ b/src/protocol/request_list.cc
@@ -38,7 +38,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <inttypes.h>
+#include <cinttypes>
 #include <rak/functional.h>
 
 #include "torrent/data/block.h"

--- a/src/torrent/common.h
+++ b/src/torrent/common.h
@@ -37,7 +37,7 @@
 #ifndef LIBTORRENT_COMMON_H
 #define LIBTORRENT_COMMON_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <cstddef>
 
 struct sockaddr;

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <algorithm>
 #include <cstring>
 #include <functional>

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -38,7 +38,7 @@
 
 #define __STDC_FORMAT_MACROS
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "data/block.h"
 #include "data/block_list.h"

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <cinttypes>
 
 #include "data/block.h"

--- a/src/torrent/download/choke_group.h
+++ b/src/torrent/download/choke_group.h
@@ -39,7 +39,7 @@
 
 #include <string>
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 #include <torrent/common.h>
 #include <torrent/download/choke_queue.h>
 

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -41,7 +41,7 @@
 
 #include <list>
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 #include lt_tr1_functional
 #include <torrent/download/group_entry.h>
 

--- a/src/torrent/download/resource_manager.h
+++ b/src/torrent/download/resource_manager.h
@@ -39,7 +39,7 @@
 
 #include <string>
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 #include <torrent/common.h>
 
 namespace torrent {

--- a/src/torrent/download_info.h
+++ b/src/torrent/download_info.h
@@ -39,7 +39,7 @@
 
 #include <list>
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include lt_tr1_functional
 
 #include <torrent/rate.h>

--- a/src/torrent/net/socket_address_key.h
+++ b/src/torrent/net/socket_address_key.h
@@ -5,7 +5,7 @@
 #define LIBTORRENT_UTILS_SOCKET_ADDRESS_KEY_H
 
 #include <cstring>
-#include <inttypes.h>
+#include <cinttypes>
 #include <netinet/in.h>
 
 // Unique key for the socket address, excluding port numbers, etc.

--- a/src/torrent/peer/peer_list.cc
+++ b/src/torrent/peer/peer_list.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <algorithm>
 #include <functional>
 #include <rak/functional.h>

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -38,7 +38,7 @@
 #define LIBTORRENT_TRACKER_H
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include <torrent/common.h>
 
 namespace torrent {

--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include "log.h"
 #include "log_buffer.h"
 

--- a/src/torrent/utils/resume.cc
+++ b/src/torrent/utils/resume.cc
@@ -34,8 +34,6 @@
 //           Skomakerveien 33
 //           3185 Skoppum, NORWAY
 
-#define __STDC_FORMAT_MACROS
-
 #include "config.h"
 
 #include <rak/file_stat.h>

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <iomanip>
 #include <sstream>
 #include <rak/functional.h>

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <sys/types.h>
 
 #include <cstdio>

--- a/src/utils/instrumentation.cc
+++ b/src/utils/instrumentation.cc
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include "instrumentation.h"
 
 namespace torrent {

--- a/src/utils/sha_fast.h
+++ b/src/utils/sha_fast.h
@@ -41,7 +41,7 @@
 #ifndef _SHA_FAST_H_
 #define _SHA_FAST_H_
 
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace torrent {
 

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -1,7 +1,5 @@
 #include "config.h"
 
-#define __STDC_CONSTANT_MACROS
-
 #include <iostream>
 #include <sstream>
 #include <cinttypes>

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -4,7 +4,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <inttypes.h>
+#include <cinttypes>
 #include <torrent/object.h>
 
 #include "object_stream_test.h"

--- a/test/torrent/utils/test_extents.cc
+++ b/test/torrent/utils/test_extents.cc
@@ -2,7 +2,7 @@
 
 #include "test_extents.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <iostream>
 #include <torrent/utils/extents.h>
 

--- a/test/torrent/utils/test_uri_parser.cc
+++ b/test/torrent/utils/test_uri_parser.cc
@@ -2,7 +2,7 @@
 
 #include "test_uri_parser.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <iostream>
 #include <torrent/utils/uri_parser.h>
 


### PR DESCRIPTION
`cinttypes` usually contains workarounds to not require `__STDC_FORMAT_MACROS` and is the proper C++ way to get the C99 defined-width format specifiers.

This fixes https://github.com/rakshasa/libtorrent/issues/140