### PR TITLE
uniform_rng - Uniform distribution random number generator

### DIFF
--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -9,6 +9,8 @@ libsub_utils_la_SOURCES = \
 	sha1.h \
 	sha_fast.cc \
 	sha_fast.h \
+	uniform_rng.cc \
+	uniform_rng.h \
 	queue_buckets.h
 
 AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/utils/uniform_rng.cc
+++ b/src/utils/uniform_rng.cc
@@ -1,0 +1,93 @@
+// libTorrent - BitTorrent library
+// Copyright (C) 2005-2017, Jari Sundell
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+// In addition, as a special exception, the copyright holders give
+// permission to link the code of portions of this program with the
+// OpenSSL library under certain conditions as described in each
+// individual source file, and distribute linked combinations
+// including the two.
+//
+// You must obey the GNU General Public License in all respects for
+// all of the code used other than OpenSSL.  If you modify file(s)
+// with this exception, you may extend this exception to your version
+// of the file(s), but you are not obligated to do so.  If you do not
+// wish to do so, delete this exception statement from your version.
+// If you delete this exception statement from all source files in the
+// program, then also delete it here.
+//
+// Contact:  Jari Sundell <jaris@ifi.uio.no>
+//
+//           Skomakerveien 33
+//           3185 Skoppum, NORWAY
+
+#include "uniform_rng.h"
+
+#include <climits>
+#include <unistd.h>
+
+#include "config.h"
+#include "globals.h"
+#include "torrent/exceptions.h"
+
+
+namespace torrent {
+
+uniform_rng::uniform_rng() {
+    unsigned int seed = cachedTime.usec() ^ (getpid() << 16) ^ getppid();
+    ::initstate_r(seed, m_state, sizeof(m_state), &m_data);
+}
+
+// return random number in interval [0, RAND_MAX]
+int uniform_rng::rand()
+{
+    int rval;
+    if (::random_r(&m_data, &rval) == -1) {
+        throw torrent::input_error("system.random: random_r() failure!");
+    }
+    return rval;
+}
+
+// return random number in interval [lo, hi]
+int uniform_rng::rand_range(int lo, int hi)
+{
+    if (lo > hi) {
+        throw torrent::input_error("Empty interval passed to rand_range (low > high)");
+    }
+    if (lo < 0 || RAND_MAX < lo) {
+        throw torrent::input_error("Lower bound of rand_range outside 0..RAND_MAX");
+    }
+    if (hi < 0 || RAND_MAX < hi) {
+        throw torrent::input_error("Upper bound of rand_range outside 0..RAND_MAX");
+    }
+
+    int rval;
+    const int64_t range   = 1 + hi - lo;
+    const int64_t buckets = RAND_MAX / range;
+    const int64_t limit   = buckets * range;
+
+    /* Create equal size buckets all in a row, then fire randomly towards
+     * the buckets until you land in one of them. All buckets are equally
+     * likely. If you land off the end of the line of buckets, try again. */
+    do {
+        rval = this->rand();
+    } while (rval >= limit);
+
+    return (int) (lo + (rval / buckets));
+}
+
+
+};

--- a/src/utils/uniform_rng.h
+++ b/src/utils/uniform_rng.h
@@ -1,0 +1,72 @@
+// libTorrent - BitTorrent library
+// Copyright (C) 2005-2017, Jari Sundell
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+// In addition, as a special exception, the copyright holders give
+// permission to link the code of portions of this program with the
+// OpenSSL library under certain conditions as described in each
+// individual source file, and distribute linked combinations
+// including the two.
+//
+// You must obey the GNU General Public License in all respects for
+// all of the code used other than OpenSSL.  If you modify file(s)
+// with this exception, you may extend this exception to your version
+// of the file(s), but you are not obligated to do so.  If you do not
+// wish to do so, delete this exception statement from your version.
+// If you delete this exception statement from all source files in the
+// program, then also delete it here.
+//
+// Contact:  Jari Sundell <jaris@ifi.uio.no>
+//
+//           Skomakerveien 33
+//           3185 Skoppum, NORWAY
+
+#ifndef LIBTORRENT_UNIFORM_RNG_H
+#define LIBTORRENT_UNIFORM_RNG_H
+
+#include <stdlib.h>
+
+namespace torrent {
+
+/*  uniform_rng - Uniform distribution random number generator.
+
+    This class implements a no-shared-state random number generator that
+    emits uniformly distributed numbers with high entropy. It solves the
+    two problems of a simple `random() % limit`, which is a skewed
+    distribution due to RAND_MAX typically not being evenly divisble by
+    the limit, and worse, the lower bits of typical PRNGs having extremly
+    low entropy – the end result are grossly un-random number sequences.
+
+    A `uniform_rng` instance carries its own state, unlike the `random()`
+    function, and is thus thread-safe when no instance is shared between
+    threads. It uses `random_r()` and `initstate_r()` from glibc.
+ */
+class uniform_rng {
+public:
+    uniform_rng();
+
+    int rand();
+    int rand_range(int lo, int hi);
+    int rand_below(int limit) { return this->rand_range(0, limit-1); }
+
+private:
+    char m_state[128];
+    struct ::random_data m_data;
+};
+
+};
+
+#endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,6 +25,10 @@ LibTorrentTest_SOURCES = \
 	rak/allocators_test.h \
 	rak/ranges_test.cc \
 	rak/ranges_test.h \
+	\
+	utils/test_uniform_rng.cc \
+	utils/test_uniform_rng.h \
+	\
 	data/chunk_list_test.cc \
 	data/chunk_list_test.h \
 	data/hash_check_queue_test.cc \

--- a/test/utils/test_uniform_rng.cc
+++ b/test/utils/test_uniform_rng.cc
@@ -1,0 +1,36 @@
+#include "stdlib.h"
+
+#include "config.h"
+#include "test_uniform_rng.h"
+#include "utils/uniform_rng.h"
+
+#define ROUNDS 1000
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestUniformRNG);
+
+static torrent::uniform_rng gen;
+
+void
+TestUniformRNG::test_rand() {
+  for (int i = 0; i < ROUNDS; i++) {
+    int num = gen.rand();
+    CPPUNIT_ASSERT(0 <= num && num <= RAND_MAX);
+  }
+}
+
+void
+TestUniformRNG::test_rand_range() {
+  for (int i = 0; i < ROUNDS; i++) {
+    int num = gen.rand_range(i, 2*i);
+    CPPUNIT_ASSERT(i <= num && num <= 2*i);
+  }
+}
+
+void
+TestUniformRNG::test_rand_below() {
+  for (int i = 1; i < ROUNDS; i++) {
+    int num = gen.rand_below(i);
+    CPPUNIT_ASSERT(0 <= num && num < i);
+  }
+}
+

--- a/test/utils/test_uniform_rng.h
+++ b/test/utils/test_uniform_rng.h
@@ -1,0 +1,17 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+class TestUniformRNG : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(TestUniformRNG);
+  CPPUNIT_TEST(test_rand);
+  CPPUNIT_TEST(test_rand_range);
+  CPPUNIT_TEST(test_rand_below);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void test_rand();
+  void test_rand_range();
+  void test_rand_below();
+};


### PR DESCRIPTION
This is the basis for a `system.rand` rtorrent command, and also a pre-cursor to fix entropy problems the numerous `random() % limit` calls have – namely using the lower low-quality bits of the PRNG, and having potential (or real) thread-safety problems.

:bangbang: When testing the original `system.rand`  implementation based on `random()`, the number sequences were awfully unrandom.