### PR TITLE
Display more info on failed tracker bencode parsing

### DIFF
--- a/rak/string_manip.h
+++ b/rak/string_manip.h
@@ -371,6 +371,26 @@ is_all_name(const Sequence& src) {
   return is_all_name(src.begin(), src.end());
 }
 
+template <typename Iterator>
+std::string
+sanitize(Iterator first, Iterator last) {
+  std::string dest;
+  for (; first != last; ++first) {
+    if (std::isprint(*first) && *first != '\r' && *first != '\n' && *first != '\t')
+      dest += *first;
+    else
+      dest += " ";
+  }
+
+  return dest;
+}
+
+template <typename Sequence>
+std::string
+sanitize(const Sequence& src) {
+    return trim(sanitize(src.begin(), src.end()));
+}
+
 }
 
 #endif

--- a/rak/string_manip.h
+++ b/rak/string_manip.h
@@ -391,6 +391,31 @@ sanitize(const Sequence& src) {
     return trim(sanitize(src.begin(), src.end()));
 }
 
+template <typename Iterator>
+std::string striptags(Iterator first, Iterator last) {
+  bool copychar = true;
+  std::string dest;
+
+  for (; first != last; ++first) {
+    if (std::isprint(*first) && *first == '<') {
+      copychar = false;
+    } else if (std::isprint(*first) && *first == '>') {
+      copychar = true;
+      continue;
+    }
+
+    if (copychar)
+      dest += *first;
+  }
+
+  return dest;
+}
+
+template <typename Sequence>
+std::string striptags(const Sequence& src) {
+    return striptags(src.begin(), src.end());
+}
+
 }
 
 #endif

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -288,8 +288,10 @@ TrackerHttp::receive_done() {
   Object b;
   *m_data >> b;
 
-  if (m_data->fail())
-    return receive_failed("Could not parse bencoded data");
+  if (m_data->fail()) {
+    std::string dump = m_data->str();
+    return receive_failed("Could not parse bencoded data: " + rak::sanitize(dump).substr(0,99));
+  }
 
   if (!b.is_map())
     return receive_failed("Root not a bencoded map");

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -290,7 +290,7 @@ TrackerHttp::receive_done() {
 
   if (m_data->fail()) {
     std::string dump = m_data->str();
-    return receive_failed("Could not parse bencoded data: " + rak::sanitize(dump).substr(0,99));
+    return receive_failed("Could not parse bencoded data: " + rak::sanitize(rak::striptags(dump)).substr(0,99));
   }
 
   if (!b.is_map())


### PR DESCRIPTION
Display more info in case of tracker bencoded data parsing failure.
- sanitize output
- also strip tags

Closes: #64 