### PR TITLE
Fix honoring system.file.allocate.set=1 rtorrent config setting - clean base

### DIFF
--- a/src/download/download_wrapper.h
+++ b/src/download/download_wrapper.h
@@ -64,7 +64,7 @@ public:
   ChunkList*          chunk_list()                            { return m_main->chunk_list(); }
 
   // Initialize hash checker and various download stuff.
-  void                initialize(const std::string& hash, const std::string& id);
+  void                initialize(const std::string& hash, const std::string& id, int flags = 0);
 
   void                close();
 
@@ -91,7 +91,7 @@ public:
   // Internal:
   //
 
-  void                receive_initial_hash();
+  void                receive_initial_hash(int flags = 0);
   void                receive_hash_done(ChunkHandle handle, const char* hash);
 
   void                check_chunk_hash(ChunkHandle handle);
@@ -102,7 +102,7 @@ public:
 
   void                receive_tick(uint32_t ticks);
 
-  void                receive_update_priorities();
+  void                receive_update_priorities(int flags = 0);
 
 private:
   DownloadWrapper(const DownloadWrapper&);

--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -184,6 +184,7 @@ File::resize_file() {
   if (m_flags & flag_fallocate) {
     flags |= SocketFile::flag_fallocate;
     flags |= SocketFile::flag_fallocate_blocking;
+    m_flags &= ~flag_fallocate;
   }
 
   return SocketFile(m_fd).set_size(m_size, flags);

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -68,7 +68,10 @@ public:
 
   bool                is_create_queued() const                 { return m_flags & flag_create_queued; }
   bool                is_resize_queued() const                 { return m_flags & flag_resize_queued; }
+  bool                is_fallocatable() const                  { return m_flags & flag_fallocate; }
   bool                is_previously_created() const            { return m_flags & flag_previously_created; }
+
+  bool                is_fallocatable_file()                   { return has_flags(flag_resize_queued) && has_flags(flag_fallocate); }
 
   bool                has_flags(int flags)                     { return m_flags & flags; }
 

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -249,7 +249,7 @@ FileList::allocatable_size_bytes() const {
   if (areAllFilesAllocatable)
     return m_torrentSize;
 
-  allocatableSizeBytes = (uint64_t)(allocatableSizeChunks * m_chunkSize);
+  allocatableSizeBytes = (uint64_t)allocatableSizeChunks * (uint64_t)m_chunkSize;
 
   // Dealing with size of last chunk as it's usually smaller than the rest.
   uint64_t reminder = m_torrentSize % (uint64_t)m_chunkSize;

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -198,9 +198,9 @@ FileList::set_max_file_size(uint64_t size) {
 uint64_t
 FileList::free_diskspace() const {
   uint64_t freeDiskspace = std::numeric_limits<uint64_t>::max();
+  rak::fs_stat stat;
 
   for (path_list::const_iterator itr = m_indirectLinks.begin(), last = m_indirectLinks.end(); itr != last; ++itr) {
-    rak::fs_stat stat;
 
     if (!stat.update(*itr))
       continue;
@@ -208,7 +208,72 @@ FileList::free_diskspace() const {
     freeDiskspace = std::min<uint64_t>(freeDiskspace, stat.bytes_avail());
   }
 
+  // Check the base directory of download if files haven't been created yet
+  if (freeDiskspace == std::numeric_limits<uint64_t>::max()) {
+    std::string dirPath = is_multi_file() ? m_rootDir.substr(0, m_rootDir.find_last_of("\\/")) : m_rootDir;
+
+    if (stat.update(dirPath))
+      freeDiskspace = std::min<uint64_t>(freeDiskspace, stat.bytes_avail());
+  }
+
   return freeDiskspace != std::numeric_limits<uint64_t>::max() ? freeDiskspace : 0;
+}
+
+uint64_t
+FileList::allocatable_size_bytes() const {
+  uint64_t allocatableSizeBytes = 0;
+
+  if (data()->is_partially_done())
+    return allocatableSizeBytes;
+
+  uint32_t allocatableSizeChunks = 0;
+  uint32_t prevChunk = -1;
+  bool areAllFilesAllocatable = true;
+  bool isLastFileAllocatable = false;
+
+  for (FileList::const_iterator itr = begin(), last = end(); itr != last; itr++) {
+
+    // Checks flag_fallocate and flag_resize_queued as well, it will take care of restarting client.
+    if ((*itr)->is_fallocatable_file()) {
+      allocatableSizeChunks += (*itr)->size_chunks() - ((*itr)->range_first() == prevChunk ? 1 : 0);
+      prevChunk = (*itr)->range_second() - 1;
+
+      if (itr == end() - 1)
+        isLastFileAllocatable = true;
+    } else {
+      areAllFilesAllocatable = false;
+    }
+
+  }
+
+  if (areAllFilesAllocatable)
+    return m_torrentSize;
+
+  allocatableSizeBytes = (uint64_t)(allocatableSizeChunks * m_chunkSize);
+
+  // Dealing with size of last chunk as it's usually smaller than the rest.
+  uint64_t reminder = m_torrentSize % (uint64_t)m_chunkSize;
+
+  if (isLastFileAllocatable && reminder != 0)
+    allocatableSizeBytes = allocatableSizeBytes - (uint64_t)m_chunkSize + reminder;
+
+  return allocatableSizeBytes;
+}
+
+bool
+FileList::is_enough_diskspace() const {
+  uint64_t allocatable_size = allocatable_size_bytes();
+
+  if (allocatable_size > 0) {
+    uint64_t free_disk_space = free_diskspace();
+
+    if (free_disk_space < allocatable_size) {
+      LT_LOG_FL(INFO, "File allocation is set and not enough disk space to start torrent: allocatable size:%i free space:%i", allocatable_size, free_disk_space);
+      return false;
+    }
+  }
+
+  return true;
 }
 
 FileList::iterator_range
@@ -580,7 +645,12 @@ FileList::open_file(File* node, const Path& lastPath, int flags) {
     return false;
   }
 
-  return node->prepare(MemoryChunk::prot_read, 0);
+  // File allocation will be done if fallocate flag is set,
+  // create zero-length file otherwise.
+  if (node->has_flags(File::flag_fallocate))
+    return node->prepare(MemoryChunk::prot_write, 0);
+  else
+    return node->prepare(MemoryChunk::prot_read, 0);
 }
 
 MemoryChunk

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -107,6 +107,7 @@ public:
 
   size_t              size_files() const                              { return base_type::size(); }
   uint64_t            size_bytes() const                              { return m_torrentSize; }
+  uint64_t            allocatable_size_bytes() const;
   uint32_t            size_chunks() const                             { return bitfield()->size_bits(); }
 
   uint32_t            completed_chunks() const                        { return bitfield()->size_set(); }
@@ -131,6 +132,10 @@ public:
   // If the files span multiple disks, the one with the least amount
   // of free diskspace will be returned.
   uint64_t            free_diskspace() const;
+
+  // Determines whether there is enough disk space for fallocating
+  // selected files.
+  bool                is_enough_diskspace() const;
 
   // List of directories in the torrent that might be on different
   // volumes as they are links, including the root directory. Used by

--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -195,7 +195,7 @@ public:
   // Call this when you want the modifications of the download priorities
   // in the entries to take effect. It is slightly expensive as it rechecks
   // all the peer bitfields to see if we are still interested.
-  void                update_priorities();
+  void                update_priorities(int flags = 0);
 
   void                add_peer(const sockaddr* addr, int port);
 

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -164,7 +164,7 @@ encoding_list() {
 }
 
 Download
-download_add(Object* object) {
+download_add(Object* object, int flags) {
   std::auto_ptr<DownloadWrapper> download(new DownloadWrapper);
 
   DownloadConstructor ctor;
@@ -190,7 +190,7 @@ download_add(Object* object) {
   }
 
   download->set_hash_queue(manager->hash_queue());
-  download->initialize(infoHash, PEER_NAME + rak::generate_random<std::string>(20 - std::string(PEER_NAME).size()));
+  download->initialize(infoHash, PEER_NAME + rak::generate_random<std::string>(20 - std::string(PEER_NAME).size()), flags);
 
   // Add trackers, etc, after setting the info hash so that log
   // entries look sane.

--- a/src/torrent/torrent.h
+++ b/src/torrent/torrent.h
@@ -93,7 +93,7 @@ EncodingList*       encoding_list() LIBTORRENT_EXPORT;
 // is done by 'download_remove'.
 //
 // Might consider redesigning that...
-Download            download_add(Object* s) LIBTORRENT_EXPORT;
+Download            download_add(Object* s, int flags = 0) LIBTORRENT_EXPORT;
 void                download_remove(Download d) LIBTORRENT_EXPORT;
 
 // Add all downloads to dlist. The client is responsible for clearing


### PR DESCRIPTION
For more info: https://github.com/rakshasa/rtorrent/pull/604

Depended by: https://github.com/rakshasa/rtorrent/pull/604
Probably clashes with: #147 (it depends on it)

Refers to: https://github.com/rakshasa/libtorrent/pull/109