### PR TITLE
Add space to fmt str in log_gz_file_write

### DIFF
--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -381,7 +381,7 @@ log_gz_file_write(std::shared_ptr<log_gz_output>& outfile, const char* data, siz
 
   // Normal groups are nul-terminated strings.
   if (group >= 0) {
-    const char* fmt = (group >= LOG_NON_CASCADING) ? ("%" PRIi32 " ") : ("%" PRIi32 " %c");
+    const char* fmt = (group >= LOG_NON_CASCADING) ? ("%" PRIi32 " ") : ("%" PRIi32 " %c ");
 
     int buffer_length = snprintf(buffer, 64, fmt,
                                  cachedTime.seconds(),


### PR DESCRIPTION
Without this space, the log level identifier ('D', 'I', etc.)
would be right next to actual content.

Before: `<timestamp> Depoll->pcb(17): Open event.`
After: `<timestamp> D epoll->pcb(17): Open event.`