### PR TITLE
Fix honoring interval of announce tracker request

### DIFF
--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -391,15 +391,16 @@ tracker_next_timeout_promiscuous(Tracker* tracker) {
       !tracker->is_usable())
     return ~uint32_t();
 
-  int32_t interval;
-
-  if (tracker->failed_counter())
-    interval = 5 << std::min<int>(tracker->failed_counter() - 1, 6);
-  else
-    interval = tracker->normal_interval();
-
+  int32_t interval, use_interval;
   int32_t min_interval = std::max(tracker->min_interval(), (uint32_t)300);
-  int32_t use_interval = std::min(interval, min_interval);
+
+  if (tracker->failed_counter()) {
+    interval = 5 << std::min<int>(tracker->failed_counter() - 1, 6);
+    use_interval = std::min(interval, min_interval);
+  } else {
+    interval = tracker->normal_interval();
+    use_interval = std::max(interval, min_interval);
+  }
 
   int32_t since_last = cachedTime.seconds() - (int32_t)tracker->activity_time_last();
 


### PR DESCRIPTION
Fix honoring `interval` of announce tracker request:
- `interval` is ignored currently and always `min interval` is used instead if it exists or `300` seconds.

Fixes: #167, https://github.com/rakshasa/rtorrent/issues/386

The following unit tests are failing due to this change:
```
tracker_controller_features.cc:49:Assertion
Test name: tracker_controller_features::test_requesting_basic
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval() - 30)

tracker_controller_features.cc:259:Assertion
Test name: tracker_controller_features::test_groups_requesting
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval() - 30)

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_success
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_success_long_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_success_short_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_failure
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_failure_long_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:47:Assertion
Test name: tracker_controller_requesting::test_hammering_basic_failure_short_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, tracker_0_0->min_inte
rval())

tracker_controller_requesting.cc:145:Assertion
Test name: tracker_controller_requesting::test_hammering_multi_success
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, next_tracker->min_int
erval() - 30)

tracker_controller_requesting.cc:142:Assertion
Test name: tracker_controller_requesting::test_hammering_multi_success_long_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, next_tracker->min_int
erval() - 30)

tracker_controller_requesting.cc:136:Assertion
Test name: tracker_controller_requesting::test_hammering_multi_success_short_timeout
assertion failed
- Expression: test_goto_next_timeout(&tracker_controller, next_tracker->min_int
erval() - 30)

tracker_timeout_test.cc:141:Assertion
Test name: tracker_timeout_test::test_timeout_requesting
assertion failed
- Expression: torrent::tracker_next_timeout(&tracker, flags) == 600
```