### PR TITLE
Fix honoring "throttle.min_peers*" settings in rtorrent

### DIFF
--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -355,19 +355,14 @@ DownloadMain::receive_tracker_success() {
 
 void
 DownloadMain::receive_tracker_request() {
-  bool should_stop = false;
-  bool should_start = false;
+  if (info()->is_pex_enabled() && info()->size_pex() > 0
+      || connection_list()->size() + peer_list()->available_list()->size() / 2 >= connection_list()->min_size()) {
 
-  if (info()->is_pex_enabled() && info()->size_pex() > 0)
-    should_stop = true;
-
-  if (connection_list()->size() + peer_list()->available_list()->size() / 2 < connection_list()->min_size())
-    should_start = true;
-
-  if (should_stop)
     m_tracker_controller->stop_requesting();
-  else if (should_start)
-    m_tracker_controller->start_requesting();
+    return;
+  }
+
+  m_tracker_controller->start_requesting();
 }
 
 struct SocketAddressCompact_less {


### PR DESCRIPTION
Fix honoring `throttle.min_peers.normal` and `throttle.min_peers.seed` settings in rtorrent:
- the bug was introduced by [this commit](https://github.com/chros73/libtorrent/commit/c2bc7f971ca4dcb1d527816e6333a20ee57d3f6b#diff-cbb03d3a5f231eab88bc2f6a44253a5c) (introduced in `v0.13.4`)
- it never clears the `flag_requesting` flag for private trackers in [torrent/tracker_controller.cc](https://github.com/chros73/libtorrent/blob/f215bda0736589986846100b093406bca071f309/src/torrent/tracker_controller.cc#L341)

Due to this bug, handling `interval` of announce tracker request is broken:
- it never use `interval` but `min interval` instead

Required behavior:
- it will use tracker `interval` if:
  - the client has more than `min_peers - (peer_list_size / 2)` connections for a download
  - or Peer Exchange is enabled and gives connections for a download
- it will use tracker `min interval` otherwise:
  - the client has less than `min_peers - (peer_list_size / 2)` connections for a download and Peer Exchange isn't enabled

Default values for [throttle.min_peers*](https://github.com/rakshasa/rtorrent/blob/master/src/command_throttle.cc#L179) settings: `100`

Fixes: #167, https://github.com/rakshasa/rtorrent/issues/386
Refers to: #168 