### PR TITLE
Modify configure to prevent unnecessary kqueue checks

### DIFF
--- a/scripts/checks.m4
+++ b/scripts/checks.m4
@@ -88,6 +88,7 @@ AC_DEFUN([TORRENT_CHECK_KQUEUE], [
     [
       AC_DEFINE(USE_KQUEUE, 1, Use kqueue.)
       AC_MSG_RESULT(yes)
+      TORRENT_CHECK_KQUEUE_SOCKET_ONLY
     ], [
       AC_MSG_RESULT(no)
     ])
@@ -137,7 +138,6 @@ AC_DEFUN([TORRENT_WITH_KQUEUE], [
     [
         if test "$withval" = "yes"; then
           TORRENT_CHECK_KQUEUE
-          TORRENT_CHECK_KQUEUE_SOCKET_ONLY
         fi
     ])
 ])
@@ -149,11 +149,9 @@ AC_DEFUN([TORRENT_WITHOUT_KQUEUE], [
     [
       if test "$withval" = "yes"; then
         TORRENT_CHECK_KQUEUE
-        TORRENT_CHECK_KQUEUE_SOCKET_ONLY
       fi
     ], [
         TORRENT_CHECK_KQUEUE
-        TORRENT_CHECK_KQUEUE_SOCKET_ONLY
     ])
 ])
 


### PR DESCRIPTION
By only running the TORRENT_CHECK_KQUEUE_SOCKET_ONLY check if kqueue support is already detected, we increase the number of platforms that we can cross compile on.
Otherwise, the cross compilation fails due to TORRENT_CHECK_KQUEUE_SOCKET_ONLY using AC_RUN_IFELSE, which fails during cross compilation.