### PR TITLE
Fixes https://github.com/rakshasa/rtorrent/issues/731

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -145,13 +145,13 @@ TrackerHttp::send_state(int state) {
   if (!localAddress->is_address_any())
     s << "&ip=" << localAddress->address_str();
   
-  if (localAddress->is_address_any() || localAddress->family() != rak::socket_address::pf_inet6) {
+  if (localAddress->is_address_any() && localAddress->family() == rak::socket_address::pf_inet) {
     rak::socket_address local_v6;
     if (get_local_address(rak::socket_address::af_inet6, &local_v6))
       s << "&ipv6=" << rak::copy_escape_html(local_v6.address_str());
   }
 
-  if (localAddress->is_address_any() || localAddress->family() != rak::socket_address::pf_inet) {
+  if (localAddress->is_address_any() && localAddress->family() == rak::socket_address::pf_inet6) {
     rak::socket_address local_v4;
     if (get_local_address(rak::socket_address::af_inet, &local_v4))
       s << "&ipv4=" << local_v4.address_str();


### PR DESCRIPTION
Logic: 

What the two changed lines are supposed to do is, if the `localAddress` is ipv4, also send the local ipv6 address to the tracker, if any. And, if the `localAddress` is ipv6, also send the local ipv4 address to the tracker, if any.

If that's the intent of this bit of code, it should be clear from the diff why the changes are needed for the correct behavior.

This problem also caused https://github.com/rakshasa/rtorrent/issues/731 as a side effect. Since `localAddress->is_address_any()` is true (at least for people hitting the bug?), the code thinks the `localAddress` is ipv6 and tries to tack on the ipv4 address. It does this "incorrectly", in that it determines the wrong local address for anyone who's behind NAT.

This request still leaves one problem, in that it's possible that someone could be connecting to the tracker via ipv6, and also be behind NAT. I think the correct solution to *that* problem is putting an option to disable adding `&ipv4` and `&ipv6` in the config file. But that's beyond the scope of this request.

Sorry if I've misunderstood anything about how this is supposed to work.