### PR TITLE
If during socket creation AF_INET6 failes initialize sockaddr

### DIFF
--- a/src/net/listen.cc
+++ b/src/net/listen.cc
@@ -75,7 +75,10 @@ Listen::open(uint16_t first, uint16_t last, int backlog, const rak::socket_addre
 
   // TODO: Temporary until we refactor:
   if (bindAddress->family() == 0) {
-    sa.sa_inet6()->clear();
+    if (m_ipv6_socket)
+      sa.sa_inet6()->clear();
+    else
+      sa.sa_inet()->clear();
   } else {
     sa.copy(*bindAddress, bindAddress->length());
   }


### PR DESCRIPTION
as AF_INET. Otherwise any bind(2) would fail due to sockaddr
address family not matching socket address family.