### PR TITLE
Prevent loss of m_ipv6_socket attribute

### DIFF
--- a/src/net/socket_fd.cc
+++ b/src/net/socket_fd.cc
@@ -251,7 +251,7 @@ SocketFd::accept(rak::socket_address* sa) {
   socklen_t len = sizeof(rak::socket_address);
 
   if (sa == NULL) {
-    return SocketFd(::accept(m_fd, NULL, &len));
+    return SocketFd(::accept(m_fd, NULL, &len), m_ipv6_socket);
   }
 
   int fd = ::accept(m_fd, sa->c_sockaddr(), &len);
@@ -260,7 +260,7 @@ SocketFd::accept(rak::socket_address* sa) {
     *sa = sa->sa_inet6()->normalize_address();
   }
 
-  return SocketFd(fd);
+  return SocketFd(fd, m_ipv6_socket);
 }
 
 // unsigned int

--- a/src/net/socket_fd.h
+++ b/src/net/socket_fd.h
@@ -51,6 +51,7 @@ public:
 
   SocketFd() : m_fd(-1) {}
   explicit SocketFd(int fd) : m_fd(fd) {}
+  SocketFd(int fd, bool ipv6_socket) : m_fd(fd), m_ipv6_socket(ipv6_socket) {}
 
   bool                is_valid() const                        { return m_fd >= 0; }
   


### PR DESCRIPTION
`SocketFd::accept()` always returns `SocketFd` object with `m_ipv6_socket` flag set to false.
As the result `SocketFd::set_priority()` which called later on the same socket executes
```
setsockopt(m_fd, IPPROTO_IP, IP_TOS, &opt, sizeof(opt))
```
even for IPv6 sockets.

Linux tolerates this, but on FreeBSD such call on IPv6 socket cause error, and as the result following call chain fails:
```
frame #0: 0x0000000800595d72 libtorrent.so.20.0.0`torrent::SocketFd::set_priority(unsigned char) + 114
frame #1: 0x000000080059e05d libtorrent.so.20.0.0`torrent::HandshakeManager::setup_socket(torrent::SocketFd) + 125
frame #2: 0x000000080059deca libtorrent.so.20.0.0`torrent::HandshakeManager::add_incoming(torrent::SocketFd, rak::socket_address const&) + 90
frame #3: 0x000000080059562e libtorrent.so.20.0.0`torrent::Listen::event_read(void) + 94
frame #4: 0x000000080052d974 libtorrent.so.20.0.0`torrent::PollKQueue::perform(void) + 68
frame #5: 0x0000000800561a83 libtorrent.so.20.0.0`torrent::thread_base::event_loop(torrent::thread_base*) + 387
```
what causes immediate drop of any incoming connection right after it has been accept()-ed.

Syscall trace of this case on FreeBSD host:
```
accept(12,{ AF_INET6 [::ffff:127.0.0.1]:28543 },0x7fffffffddfc) = 161 (0xa1)
fcntl(161,F_SETFL,O_RDONLY|O_NONBLOCK)		 = 0 (0x0)
setsockopt(161,IPPROTO_IP,IP_TOS,0x7fffffffdd9c,4) ERR#22 'Invalid argument'
close(161)					 = 0 (0x0)
```

For comparison same trace on CentOS 7 host:
```
[pid 15592] accept(13, {sa_family=AF_INET6, sin6_port=htons(60668), inet_pton(AF_INET6, "::ffff:127.0.0.1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 16
[pid 15592] fcntl(16, F_SETFL, O_RDONLY|O_NONBLOCK) = 0
[pid 15592] setsockopt(16, SOL_IP, IP_TOS, [8], 4) = 0
```

This change fixes https://github.com/rakshasa/rtorrent/issues/786