### PR TITLE
Switch to C++11 MRT RNG for random bytes

### DIFF
--- a/rak/string_manip.h
+++ b/rak/string_manip.h
@@ -39,9 +39,13 @@
 
 #include <algorithm>
 #include <cctype>
+#include <climits>
 #include <cstdlib>
+#include <functional>
 #include <iterator>
 #include <locale>
+#include <random>
+
 
 namespace rak {
 
@@ -312,11 +316,13 @@ transform_hex_str(const Sequence& seq) {
 template <typename Sequence>
 Sequence
 generate_random(size_t length) {
+  std::random_device rd;
+  std::mt19937 mt(rd());
+  using bytes_randomizer = std::independent_bits_engine<std::mt19937, CHAR_BIT, uint8_t>;
+  bytes_randomizer bytes(mt);
   Sequence s;
   s.reserve(length);
-
-  std::generate_n(std::back_inserter(s), length, &::random);
-
+  std::generate_n(std::back_inserter(s), length, std::ref(bytes));
   return s;
 }
 


### PR DESCRIPTION
Switching to a better RNG for generating strings will prevent the common peerID collisions the rTorrent client has been seeing for YEARS in https://github.com/rakshasa/rtorrent/issues/440 and https://github.com/rakshasa/rtorrent/issues/318.