### PR TITLE
"Warning message" from some trackers when a torrent isn't registered.

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -272,6 +272,17 @@ TrackerHttp::receive_done() {
 
   // If no failures, set intervals to defaults prior to processing
 
+  if (b.has_key("warning message") && b.get_key("warning message").is_string()){
+
+    std::string msg=b.get_key_string("warning message");
+
+    if ( (msg.find(" not registered")!=std::string::npos) ||
+    		(msg.find("unregistered")!=std::string::npos) ||
+     		(msg.find("torrent cannot be found")!=std::string::npos) )
+
+       return receive_failed("Warning message \"" + msg + "\"");
+  }
+
   if (m_latest_event == EVENT_SCRAPE)
     process_scrape(b);
   else


### PR DESCRIPTION
Some trackers send "warning message" instead of a failure when a torrent is not registered on the tracker. Looks like this: 

> d8:intervali3030e12:min intervali3030e5:peers6:S‹™жЊЄ15:warning message22:Torrent not registerede

The change will turn this warning into an error.
