### PR TITLE
checks.m4: Fix fallocate check

### DIFF
--- a/scripts/checks.m4
+++ b/scripts/checks.m4
@@ -172,7 +172,8 @@ AC_DEFUN([TORRENT_WITHOUT_VARIABLE_FDSET], [
 AC_DEFUN([TORRENT_CHECK_FALLOCATE], [
   AC_MSG_CHECKING(for fallocate)
 
-  AC_TRY_LINK([#include <fcntl.h>
+  AC_TRY_LINK([#define _GNU_SOURCE
+               #include <fcntl.h>
                #include <linux/falloc.h>
               ],[ fallocate(0, FALLOC_FL_KEEP_SIZE, 0, 0); return 0;
               ],


### PR DESCRIPTION
fallocate needs _GNU_SOURCE defined