### PR TITLE
Get rid of NULL

### DIFF
--- a/extra/corrupt_file.cc
+++ b/extra/corrupt_file.cc
@@ -1,8 +1,8 @@
 #include <iostream>
 #include <stdexcept>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
 #include <fcntl.h>
 
 #include "../rak/file_stat.h"

--- a/extra/test_sockaddr.cc
+++ b/extra/test_sockaddr.cc
@@ -21,7 +21,7 @@ lookup_address(const char* name) {
     return false;
   }
 
-  for (rak::address_info* itr = result; itr != NULL; itr = itr->next()) {
+  for (rak::address_info* itr = result; itr != nullptr; itr = itr->next()) {
     std::cout << "Flags: " << itr->flags() << std::endl;
     std::cout << "Family: " << itr->family() << std::endl;
     std::cout << "Socket Type: " << itr->socket_type() << std::endl;

--- a/rak/address_info.h
+++ b/rak/address_info.h
@@ -90,7 +90,7 @@ address_info::get_address_info(const char* node, int pfamily, int stype, address
   hints.set_family(pfamily);
   hints.set_socket_type(stype);
   
-  return ::getaddrinfo(node, NULL, hints.c_addrinfo(), reinterpret_cast<addrinfo**>(ai));
+  return ::getaddrinfo(node, nullptr, hints.c_addrinfo(), reinterpret_cast<addrinfo**>(ai));
 }
 
 }

--- a/rak/allocators.h
+++ b/rak/allocators.h
@@ -73,7 +73,7 @@ public:
 
   size_type max_size () const throw() { return std::numeric_limits<size_t>::max() / sizeof(T); }
 
-  pointer allocate(size_type num, const_void_pointer hint = 0) { return alloc_size(num*sizeof(T)); }
+  pointer allocate(size_type num, const_void_pointer hint = NULL) { return alloc_size(num*sizeof(T)); }
 
   static pointer alloc_size(size_type size) {
     pointer ptr = NULL;

--- a/rak/allocators.h
+++ b/rak/allocators.h
@@ -40,8 +40,8 @@
 #define RAK_ALLOCATORS_H
 
 #include <cstddef>
+#include <cstdlib>
 #include <limits>
-#include <stdlib.h>
 #include <sys/types.h>
 
 namespace rak {
@@ -73,10 +73,10 @@ public:
 
   size_type max_size () const throw() { return std::numeric_limits<size_t>::max() / sizeof(T); }
 
-  pointer allocate(size_type num, const_void_pointer hint = NULL) { return alloc_size(num*sizeof(T)); }
+  pointer allocate(size_type num, const_void_pointer hint = nullptr) { return alloc_size(num*sizeof(T)); }
 
   static pointer alloc_size(size_type size) {
-    pointer ptr = NULL;
+    pointer ptr = nullptr;
     int __UNUSED result = posix_memalign((void**)&ptr, LT_SMP_CACHE_BYTES, size);
 
     return ptr;

--- a/rak/functional.h
+++ b/rak/functional.h
@@ -481,7 +481,7 @@ public:
   typedef Ret result_type;
   typedef Ret (Object::*Function)();
 
-  mem_fun0() : m_object(NULL) {}
+  mem_fun0() : m_object(nullptr) {}
   mem_fun0(Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool is_valid() const { return m_object; }
@@ -499,7 +499,7 @@ public:
   typedef Ret result_type;
   typedef Ret (Object::*Function)() const;
 
-  const_mem_fun0() : m_object(NULL) {}
+  const_mem_fun0() : m_object(nullptr) {}
   const_mem_fun0(const Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool is_valid() const { return m_object; }
@@ -517,7 +517,7 @@ public:
   typedef Ret result_type;
   typedef Ret (Object::*Function)(Arg1);
 
-  mem_fun1() : m_object(NULL) {}
+  mem_fun1() : m_object(nullptr) {}
   mem_fun1(Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool is_valid() const { return m_object; }
@@ -535,7 +535,7 @@ public:
   typedef Ret result_type;
   typedef Ret (Object::*Function)(Arg1) const;
 
-  const_mem_fun1() : m_object(NULL) {}
+  const_mem_fun1() : m_object(nullptr) {}
   const_mem_fun1(const Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool is_valid() const { return m_object; }
@@ -554,7 +554,7 @@ public:
   typedef Ret (Object::*Function)(Arg1, Arg2);
   typedef Object object_type;
 
-  mem_fun2() : m_object(NULL) {}
+  mem_fun2() : m_object(nullptr) {}
   mem_fun2(Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool         is_valid() const { return m_object; }
@@ -575,7 +575,7 @@ public:
   typedef Ret result_type;
   typedef Ret (Object::*Function)(Arg1, Arg2, Arg3);
 
-  mem_fun3() : m_object(NULL) {}
+  mem_fun3() : m_object(nullptr) {}
   mem_fun3(Object* o, Function f) : m_object(o), m_function(f) {}
 
   bool is_valid() const { return m_object; }

--- a/rak/partial_queue.h
+++ b/rak/partial_queue.h
@@ -58,13 +58,13 @@ public:
 
   static const size_type num_layers = 8;
 
-  partial_queue() : m_data(NULL), m_maxLayerSize(0) {}
+  partial_queue() : m_data(nullptr), m_maxLayerSize(0) {}
   ~partial_queue() { disable(); }
 
   bool                is_full() const                         { return m_ceiling == 0; }
   bool                is_layer_full(size_type l) const        { return m_layers[l].second >= m_maxLayerSize; }
 
-  bool                is_enabled() const                      { return m_data != NULL; }
+  bool                is_enabled() const                      { return m_data != nullptr; }
 
   // Add check to see if we can add more. Also make it possible to
   // check how full we are in the lower parts so the caller knows when
@@ -124,14 +124,14 @@ partial_queue::enable(size_type ls) {
 inline void
 partial_queue::disable() {
   delete [] m_data;
-  m_data = NULL;
+  m_data = nullptr;
 
   m_maxLayerSize = 0;
 }
 
 inline void
 partial_queue::clear() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     return;
 
   m_index = 0;

--- a/rak/path.h
+++ b/rak/path.h
@@ -52,7 +52,7 @@ path_expand(const std::string& path) {
 
   char* home = std::getenv("HOME");
 
-  if (home == NULL)
+  if (home == nullptr)
     return path;
   
   return home + path.substr(1);
@@ -88,7 +88,7 @@ path_expand(const char* src, char* first, char* last) {
   if (*src == '~') {
     char* home = std::getenv("HOME");
 
-    if (home == NULL)
+    if (home == nullptr)
       return first;
 
     first += strlcpy(first, home, std::distance(first, last));

--- a/rak/priority_queue.h
+++ b/rak/priority_queue.h
@@ -118,7 +118,7 @@ class queue_pop_iterator
 public:
   typedef Queue container_type;
 
-  queue_pop_iterator() : m_queue(NULL) {}
+  queue_pop_iterator() : m_queue(nullptr) {}
   queue_pop_iterator(Queue* q, Compare c) : m_queue(q), m_compare(c) {}
 
   queue_pop_iterator& operator ++ ()                     { m_queue->pop(); return *this; }

--- a/rak/timer.h
+++ b/rak/timer.h
@@ -100,7 +100,7 @@ class timer {
 inline timer
 timer::current() {
   timeval t;
-  gettimeofday(&t, 0);
+  gettimeofday(&t, NULL);
   
   return timer(t);
 }

--- a/rak/timer.h
+++ b/rak/timer.h
@@ -100,7 +100,7 @@ class timer {
 inline timer
 timer::current() {
   timeval t;
-  gettimeofday(&t, NULL);
+  gettimeofday(&t, nullptr);
   
   return timer(t);
 }

--- a/src/data/chunk.cc
+++ b/src/data/chunk.cc
@@ -263,7 +263,7 @@ Chunk::from_buffer(const void* buffer, uint32_t position, uint32_t length) {
       throw storage_error("no space left on disk");
   }
 
-  sigaction(SIGBUS, &oldact, NULL);
+  sigaction(SIGBUS, &oldact, nullptr);
   
   return true;
 }

--- a/src/data/chunk_handle.h
+++ b/src/data/chunk_handle.h
@@ -47,15 +47,15 @@ class ChunkListNode;
 
 class ChunkHandle {
 public:
-  ChunkHandle(ChunkListNode* c = NULL, bool wr = false, bool blk = false) :
+  ChunkHandle(ChunkListNode* c = nullptr, bool wr = false, bool blk = false) :
     m_node(c), m_writable(wr), m_blocking(blk) {}
 
-  bool                is_valid() const                      { return m_node != NULL; }
-  bool                is_loaded() const                     { return m_node != NULL && m_node->is_valid(); }
+  bool                is_valid() const                      { return m_node != nullptr; }
+  bool                is_loaded() const                     { return m_node != nullptr && m_node->is_valid(); }
   bool                is_writable() const                   { return m_writable; }
   bool                is_blocking() const                   { return m_blocking; }
   
-  void                clear()                               { m_node = NULL; m_writable = false; m_blocking = false; }
+  void                clear()                               { m_node = nullptr; m_writable = false; m_blocking = false; }
 
   rak::error_number   error_number() const                  { return m_errorNumber; }
   void                set_error_number(rak::error_number e) { m_errorNumber = e; }

--- a/src/data/chunk_list.cc
+++ b/src/data/chunk_list.cc
@@ -149,7 +149,7 @@ ChunkList::get(size_type index, int flags) {
 
     Chunk* chunk = m_slot_create_chunk(index, prot_flags);
 
-    if (chunk == NULL) {
+    if (chunk == nullptr) {
       rak::error_number current_error = rak::error_number::current();
 
       LT_LOG_THIS(DEBUG, "Could not create: memory:%" PRIu64 " block:%" PRIu32 " errno:%i errmsg:%s.",
@@ -172,7 +172,7 @@ ChunkList::get(size_type index, int flags) {
 
     Chunk* chunk = m_slot_create_chunk(index, prot_flags);
 
-    if (chunk == NULL)
+    if (chunk == nullptr)
       return ChunkHandle::from_error(rak::error_number::current().is_valid() ? rak::error_number::current() : rak::error_number::e_noent);
 
     delete node->chunk();
@@ -255,7 +255,7 @@ ChunkList::clear_chunk(ChunkListNode* node, int flags) {
     throw internal_error("ChunkList::clear_chunk(...) !node->is_valid().");
 
   delete node->chunk();
-  node->set_chunk(NULL);
+  node->set_chunk(nullptr);
 
   m_manager->deallocate(m_chunk_size, (flags & get_dont_log) ? ChunkManager::allocate_dont_log : 0);
 }

--- a/src/data/chunk_list.h
+++ b/src/data/chunk_list.h
@@ -91,7 +91,7 @@ public:
 
   static const int flag_active       = (1 << 0);
 
-  ChunkList() : m_data(NULL), m_manager(NULL), m_flags(0), m_chunk_size(0) {}
+  ChunkList() : m_data(nullptr), m_manager(nullptr), m_flags(0), m_chunk_size(0) {}
   ~ChunkList() { clear(); }
 
   int                 flags() const                       { return m_flags; }

--- a/src/data/chunk_list_node.h
+++ b/src/data/chunk_list_node.h
@@ -57,7 +57,7 @@ public:
 
   ChunkListNode() :
     m_index(invalid_index),
-    m_chunk(NULL),
+    m_chunk(nullptr),
     m_references(0),
     m_writable(0),
     m_blocking(0),

--- a/src/data/chunk_part.h
+++ b/src/data/chunk_part.h
@@ -51,7 +51,7 @@ public:
   } mapped_type;
 
   ChunkPart(mapped_type mapped, const MemoryChunk& c, uint32_t pos) :
-    m_mapped(mapped), m_chunk(c), m_position(pos), m_file(NULL), m_file_offset(0) {}
+    m_mapped(mapped), m_chunk(c), m_position(pos), m_file(nullptr), m_file_offset(0) {}
 
   bool                is_valid() const                      { return m_chunk.is_valid(); }
   bool                is_contained(uint32_t p) const        { return p >= m_position && p < m_position + size(); }

--- a/src/data/hash_check_queue.cc
+++ b/src/data/hash_check_queue.cc
@@ -45,7 +45,7 @@
 namespace torrent {
 
 HashCheckQueue::HashCheckQueue() {
-  pthread_mutex_init(&m_lock, NULL);
+  pthread_mutex_init(&m_lock, nullptr);
 }
 
 HashCheckQueue::~HashCheckQueue() {
@@ -55,7 +55,7 @@ HashCheckQueue::~HashCheckQueue() {
 // Always poke thread_disk after calling this.
 void
 HashCheckQueue::push_back(HashChunk* hash_chunk) {
-  if (hash_chunk == NULL || !hash_chunk->chunk()->is_loaded() || !hash_chunk->chunk()->is_blocking())
+  if (hash_chunk == nullptr || !hash_chunk->chunk()->is_loaded() || !hash_chunk->chunk()->is_blocking())
     throw internal_error("Invalid hash chunk passed to HashCheckQueue.");
 
   pthread_mutex_lock(&m_lock);

--- a/src/data/hash_queue.cc
+++ b/src/data/hash_queue.cc
@@ -84,7 +84,7 @@ struct HashQueueWillneed {
 HashQueue::HashQueue(thread_disk* thread) :
   m_thread_disk(thread) {
 
-  pthread_mutex_init(&m_done_chunks_lock, NULL);
+  pthread_mutex_init(&m_done_chunks_lock, nullptr);
   m_thread_disk->hash_queue()->slot_chunk_done() = std::bind(&HashQueue::chunk_done, this, std::placeholders::_1, std::placeholders::_2);
 }
 
@@ -145,7 +145,7 @@ HashQueue::remove(HashQueueNode::id_type id) {
       pthread_mutex_unlock(&m_done_chunks_lock);
     }
 
-    itr->slot_done()(*hash_chunk->chunk(), NULL);
+    itr->slot_done()(*hash_chunk->chunk(), nullptr);
     itr->clear();
 
     itr = erase(itr);

--- a/src/data/hash_queue_node.cc
+++ b/src/data/hash_queue_node.cc
@@ -50,7 +50,7 @@ HashQueueNode::get_index() const {
 void
 HashQueueNode::clear() {
   delete m_chunk;
-  m_chunk = NULL;
+  m_chunk = nullptr;
 }
 
 uint32_t

--- a/src/data/memory_chunk.cc
+++ b/src/data/memory_chunk.cc
@@ -87,8 +87,8 @@ MemoryChunk::MemoryChunk(char* ptr, char* begin, char* end, int prot, int flags)
   m_prot(prot),
   m_flags(flags) {
 
-  if (ptr == NULL)
-    throw internal_error("MemoryChunk::MemoryChunk(...) received ptr == NULL");
+  if (ptr == nullptr)
+    throw internal_error("MemoryChunk::MemoryChunk(...) received ptr == nullptr");
 
   if (page_align() >= m_pagesize)
     throw internal_error("MemoryChunk::MemoryChunk(...) received an page alignment >= page size");

--- a/src/data/memory_chunk.h
+++ b/src/data/memory_chunk.h
@@ -75,7 +75,7 @@ class MemoryChunk {
   MemoryChunk() { clear(); }
   ~MemoryChunk() { clear(); }
 
-  // Doesn't allow ptr == NULL, use the default ctor instead.
+  // Doesn't allow ptr == nullptr, use the default ctor instead.
   MemoryChunk(char* ptr, char* begin, char* end, int prot, int flags);
 
   bool                is_valid() const                                     { return m_ptr; }
@@ -135,7 +135,7 @@ MemoryChunk::is_valid_range(uint32_t offset, uint32_t length) const {
 
 inline void
 MemoryChunk::clear() {
-  m_ptr = m_begin = m_end = NULL; m_flags = PROT_NONE;
+  m_ptr = m_begin = m_end = nullptr; m_flags = PROT_NONE;
 }
 
 inline uint32_t

--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -48,7 +48,9 @@
 #include <sys/types.h>
 
 #ifdef HAVE_FALLOCATE
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <linux/falloc.h>
 #endif
 

--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -164,7 +164,7 @@ SocketFile::create_chunk(uint64_t offset, uint32_t length, int prot, int flags) 
 
   uint64_t align = offset % MemoryChunk::page_size();
 
-  char* ptr = (char*)mmap(NULL, length + align, prot, flags, m_fd, offset - align);
+  char* ptr = (char*)mmap(nullptr, length + align, prot, flags, m_fd, offset - align);
   
   if (ptr == MAP_FAILED)
     return MemoryChunk();

--- a/src/dht/dht_bucket.cc
+++ b/src/dht/dht_bucket.cc
@@ -44,8 +44,8 @@
 namespace torrent {
 
 DhtBucket::DhtBucket(const HashString& begin, const HashString& end) :
-  m_parent(NULL),
-  m_child(NULL),
+  m_parent(nullptr),
+  m_child(nullptr),
 
   m_lastChanged(cachedTime.seconds()),
 
@@ -184,7 +184,7 @@ DhtBucket::split(const HashString& id) {
 
   } else {
     // We become other's child, other becomes our parent's child.
-    if (parent() != NULL) {
+    if (parent() != nullptr) {
       parent()->m_child = other;
       other->m_parent = parent();
     }
@@ -211,7 +211,7 @@ DhtBucket::build_full_cache() {
           throw internal_error("DhtRouter::store_closest_nodes wrote past buffer end.");
       }
     }
-  } while (pos < m_fullCache + sizeof(m_fullCache) && chain.next() != NULL);
+  } while (pos < m_fullCache + sizeof(m_fullCache) && chain.next() != nullptr);
 
   m_fullCacheLength = pos - m_fullCache;
 }

--- a/src/dht/dht_bucket.h
+++ b/src/dht/dht_bucket.h
@@ -183,15 +183,15 @@ inline const DhtBucket*
 DhtBucketChain::next() {
   // m_restart is clear when we're done recursing into the children and
   // follow the parents instead.
-  if (m_restart == NULL) {
+  if (m_restart == nullptr) {
     m_cur = m_cur->parent();
 
   } else {
     m_cur = m_cur->child();
 
-    if (m_cur == NULL) {
+    if (m_cur == nullptr) {
       m_cur = m_restart->parent();
-      m_restart = NULL;
+      m_restart = nullptr;
     }
   }
 

--- a/src/dht/dht_node.cc
+++ b/src/dht/dht_node.cc
@@ -56,7 +56,7 @@ DhtNode::DhtNode(const HashString& id, const rak::socket_address* sa) :
   m_lastSeen(0),
   m_recentlyActive(false),
   m_recentlyInactive(0),
-  m_bucket(NULL) {
+  m_bucket(nullptr) {
 
   // TODO: Change this to use the id hash similar to how peer info
   // hash'es are logged.
@@ -71,7 +71,7 @@ DhtNode::DhtNode(const std::string& id, const Object& cache) :
   HashString(*HashString::cast_from(id.c_str())),
   m_recentlyActive(false),
   m_recentlyInactive(0),
-  m_bucket(NULL) {
+  m_bucket(nullptr) {
 
   // TODO: Check how DHT handles inet6.
   rak::socket_address_inet* sa = m_socketAddress.sa_inet();

--- a/src/dht/dht_node.h
+++ b/src/dht/dht_node.h
@@ -108,7 +108,7 @@ private:
 
 inline void
 DhtNode::set_good() {
-  if (m_bucket != NULL && !is_good())
+  if (m_bucket != nullptr && !is_good())
     m_bucket->node_now_good(is_bad());
 
   m_lastSeen = cachedTime.seconds();
@@ -118,7 +118,7 @@ DhtNode::set_good() {
 
 inline void
 DhtNode::set_bad() {
-  if (m_bucket != NULL && !is_bad())
+  if (m_bucket != nullptr && !is_bad())
     m_bucket->node_now_bad(is_good());
 
   m_recentlyInactive = max_failed_replies;

--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -63,7 +63,7 @@ HashString DhtRouter::zero_id;
 DhtRouter::DhtRouter(const Object& cache, const rak::socket_address* sa) :
   DhtNode(zero_id, sa),  // actual ID is set later
   m_server(this),
-  m_contacts(NULL),
+  m_contacts(nullptr),
   m_numRefresh(0),
   m_curToken(random()),
   m_prevToken(random()) {
@@ -165,7 +165,7 @@ DhtRouter::announce(DownloadInfo* info, TrackerDht* tracker) {
 }
 
 // Cancel any running requests from the given tracker.
-// If info or tracker is not NULL, only cancel matching requests.
+// If info or tracker is not nullptr, only cancel matching requests.
 void
 DhtRouter::cancel_announce(DownloadInfo* info, const TrackerDht* tracker) {
   m_server.cancel_announce(info, tracker);
@@ -179,7 +179,7 @@ DhtRouter::get_tracker(const HashString& hash, bool create) {
     return itr.tracker();
 
   if (!create)
-    return NULL;
+    return nullptr;
 
   std::pair<DhtTrackerList::accessor, bool> res = m_trackers.insert(std::make_pair(hash, new DhtTracker()));
 
@@ -210,7 +210,7 @@ DhtRouter::get_node(const HashString& id) {
     if (id == this->id())
       return this;
     else
-      return NULL;
+      return nullptr;
   }
 
   return itr.node();
@@ -235,7 +235,7 @@ void
 DhtRouter::add_contact(const std::string& host, int port) {
   // Externally obtained nodes are added to the contact list, but only if
   // we're still bootstrapping. We don't contact external nodes after that.
-  if (m_contacts != NULL) {
+  if (m_contacts != nullptr) {
     if (m_contacts->size() >= num_bootstrap_contacts)
       m_contacts->pop_front();
 
@@ -259,18 +259,18 @@ DhtNode*
 DhtRouter::node_queried(const HashString& id, const rak::socket_address* sa) {
   DhtNode* node = get_node(id);
 
-  if (node == NULL) {
+  if (node == nullptr) {
     if (want_node(id))
       m_server.ping(id, sa);
 
-    return NULL;
+    return nullptr;
   }
 
   // If we know the ID but the address is different, don't set the original node
   // active, but neither use this new address to prevent rogue nodes from polluting
   // our routing table with fake source addresses.
   if (node->address()->sa_inet()->address_n() != sa->sa_inet()->address_n())
-    return NULL;
+    return nullptr;
 
   node->queried();
   if (node->is_good())
@@ -286,19 +286,19 @@ DhtNode*
 DhtRouter::node_replied(const HashString& id, const rak::socket_address* sa) {
   DhtNode* node = get_node(id);
 
-  if (node == NULL) {
+  if (node == nullptr) {
     if (!want_node(id))
-      return NULL;
+      return nullptr;
 
     // New node, create it. It's a good node (it replied!) so add it to a bucket.
     node = m_nodes.add_node(new DhtNode(id, sa));
 
     if (!add_node_to_bucket(node))   // deletes the node if it fails
-      return NULL;
+      return nullptr;
   }
 
   if (node->address()->sa_inet()->address_n() != sa->sa_inet()->address_n())
-    return NULL;
+    return nullptr;
 
   node->replied();
   node->bucket()->touch();
@@ -313,14 +313,14 @@ DhtRouter::node_inactive(const HashString& id, const rak::socket_address* sa) {
 
   // If not found add it to some blacklist so we won't try contacting it again immediately?
   if (itr == m_nodes.end())
-    return NULL;
+    return nullptr;
 
   // Check source address. Normally node_inactive is called if we DON'T receive a reply,
   // however it can also be called if a node replied with an malformed response packet,
   // so check that the address matches so that a rogue node cannot cause other nodes
   // to be considered bad by sending malformed packets.
   if (itr.node()->address()->sa_inet()->address_n() != sa->sa_inet()->address_n())
-    return NULL;
+    return nullptr;
 
   itr.node()->inactive();
 
@@ -329,7 +329,7 @@ DhtRouter::node_inactive(const HashString& id, const rak::socket_address* sa) {
   // chances to reply again instead of removing all nodes instantly.
   if (itr.node()->is_bad() && itr.node()->age() >= timeout_remove_node) {
     delete_node(itr);
-    return NULL;
+    return nullptr;
   }
 
   return itr.node();
@@ -341,7 +341,7 @@ void
 DhtRouter::node_invalid(const HashString& id) {
   DhtNode* node = get_node(id);
 
-  if (node == NULL || node == this)
+  if (node == nullptr || node == this)
     return;
 
   delete_node(m_nodes.find(&node->id()));
@@ -359,7 +359,7 @@ DhtRouter::store_cache(Object* container) const {
   }
 
   // Insert contacts, if we have any.
-  if (m_contacts != NULL) {
+  if (m_contacts != nullptr) {
     Object& contacts = container->insert_key("contacts", Object::create_list());
 
     for (std::deque<contact_t>::const_iterator itr = m_contacts->begin(); itr != m_contacts->end(); ++itr) {
@@ -412,7 +412,7 @@ DhtRouter::receive_timeout_bootstrap() {
   // to a less aggressive non-bootstrap mode of collecting nodes that contact us
   // and through doing normal torrent announces.
   if (m_nodes.size() < num_bootstrap_complete) {
-    if (m_contacts == NULL)
+    if (m_contacts == nullptr)
       throw internal_error("DhtRouter::receive_timeout_bootstrap called without contact list.");
 
     if (!m_nodes.empty() || !m_contacts->empty())
@@ -425,7 +425,7 @@ DhtRouter::receive_timeout_bootstrap() {
   } else {
     // We won't be needing external contacts after this.
     delete m_contacts;
-    m_contacts = NULL;
+    m_contacts = nullptr;
 
     m_taskTimeout.slot() = std::bind(&DhtRouter::receive_timeout, this);
 
@@ -530,7 +530,7 @@ DhtRouter::find_node(const rak::socket_address* sa) {
     if (itr.node()->address()->sa_inet()->address_n() == sa->sa_inet()->address_n())
       return itr.node();
 
-  return NULL;
+  return nullptr;
 }
 
 DhtRouter::DhtBucketList::iterator
@@ -540,7 +540,7 @@ DhtRouter::split_bucket(const DhtBucketList::iterator& itr, DhtNode* node) {
   DhtBucket* newBucket = itr->second->split(id());
 
   // If our bucket has a child now (the new bucket), move ourself into it.
-  if (bucket()->child() != NULL)
+  if (bucket()->child() != nullptr)
     set_bucket(bucket()->child());
 
   if (!bucket()->is_in_range(id()))
@@ -599,7 +599,7 @@ DhtRouter::delete_node(const DhtNodeList::accessor& itr) {
   if (itr == m_nodes.end())
     throw internal_error("DhtRouter::delete_node called with invalid iterator.");
 
-  if (itr.node()->bucket() != NULL)
+  if (itr.node()->bucket() != nullptr)
     itr.node()->bucket()->remove_node(itr.node());
 
   delete itr.node();
@@ -611,7 +611,7 @@ struct contact_node_t {
   contact_node_t(DhtRouter* router, int port) : m_router(router), m_port(port) { }
 
   void operator() (const sockaddr* sa, int err)
-    { if (sa != NULL) m_router->contact(rak::socket_address::cast_from(sa), m_port); }
+    { if (sa != nullptr) m_router->contact(rak::socket_address::cast_from(sa), m_port); }
 
   DhtRouter* m_router;
   int        m_port;

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -262,7 +262,7 @@ DhtServer::cancel_announce(DownloadInfo* info, const TrackerDht* tracker) {
     if (itr->second->is_search() && itr->second->as_search()->search()->is_announce()) {
       DhtAnnounce* announce = static_cast<DhtAnnounce*>(itr->second->as_search()->search());
 
-      if ((info == NULL || announce->target() == info->hash()) && (tracker == NULL || announce->tracker() == tracker)) {
+      if ((info == nullptr || announce->target() == info->hash()) && (tracker == nullptr || announce->tracker() == tracker)) {
         drop_packet(itr->second->packet());
         delete itr->second;
         m_transactions.erase(itr++);
@@ -666,7 +666,7 @@ DhtServer::failed_transaction(transaction_itr itr, bool quick) {
   // throttling, so don't blame the remote node for not replying.
   // Finally, if we haven't received anything whatsoever so far, assume the entire
   // network is down and so we can't blame the node either.
-  if (!quick && m_networkUp && transaction->packet() == NULL && transaction->id() != m_router->zero_id)
+  if (!quick && m_networkUp && transaction->packet() == nullptr && transaction->id() != m_router->zero_id)
     m_router->node_inactive(transaction->id(), transaction->address());
 
   if (transaction->type() == DhtTransaction::DHT_FIND_NODE) {
@@ -719,7 +719,7 @@ DhtServer::event_read() {
     rak::socket_address sa;
     int type = '?';
     DhtMessage message;
-    const HashString* nodeId = NULL;
+    const HashString* nodeId = nullptr;
 
     try {
       char buffer[2048];
@@ -781,7 +781,7 @@ DhtServer::event_read() {
         throw dht_error(dht_error_protocol, "Invalid transaction ID type/length.");
 
       // Stupid broken implementations.
-      if (nodeId != NULL && *nodeId == m_router->id())
+      if (nodeId != nullptr && *nodeId == m_router->id())
         throw dht_error(dht_error_protocol, "Send your own ID, not mine");
 
       switch (type) {
@@ -805,7 +805,7 @@ DhtServer::event_read() {
     // so that if it repeatedly sends malformed replies we will drop it instead of propagating it
     // to other nodes.
     } catch (bencode_error& e) {
-      if ((type == 'r' || type == 'e') && nodeId != NULL) {
+      if ((type == 'r' || type == 'e') && nodeId != nullptr) {
         m_router->node_inactive(*nodeId, &sa);
       } else {
         snprintf(message.data_end, message.data + message.data_size - message.data_end - 1, "Malformed packet: %s", e.what());
@@ -814,7 +814,7 @@ DhtServer::event_read() {
       }
 
     } catch (dht_error& e) {
-      if ((type == 'r' || type == 'e') && nodeId != NULL)
+      if ((type == 'r' || type == 'e') && nodeId != nullptr)
         m_router->node_inactive(*nodeId, &sa);
       else
         create_error(message, &sa, e.code(), e.what());
@@ -883,7 +883,7 @@ DhtServer::process_queue(packet_queue& queue, uint32_t* quota) {
       // here transaction can be already deleted by failed_transaction.
       transaction_itr itr = m_transactions.find(transactionKey);
       if (itr != m_transactions.end())
-        packet->transaction()->set_packet(NULL);
+        packet->transaction()->set_packet(nullptr);
     }
 
     delete packet;

--- a/src/dht/dht_transaction.cc
+++ b/src/dht/dht_transaction.cc
@@ -211,7 +211,7 @@ DhtAnnounce::~DhtAnnounce() {
   if (!complete())
     throw internal_error("DhtAnnounce::~DhtAnnounce called while announce not complete.");
 
-  const char* failure = NULL;
+  const char* failure = nullptr;
 
   if (m_tracker->get_state() != TrackerDht::state_announcing) {
     if (!m_contacted)
@@ -226,7 +226,7 @@ DhtAnnounce::~DhtAnnounce() {
       failure = "Announce failed";
   }
 
-  if (failure != NULL)
+  if (failure != nullptr)
     m_tracker->receive_failed(failure);
   else
     m_tracker->receive_success();
@@ -255,7 +255,7 @@ DhtAnnounce::start_announce() {
 void
 DhtTransactionPacket::build_buffer(const DhtMessage& msg) {
   char buffer[1500];  // If the message would exceed an Ethernet frame, something went very wrong.
-  object_buffer_t result = static_map_write_bencode_c(object_write_to_buffer, NULL, std::make_pair(buffer, buffer + sizeof(buffer)), msg);
+  object_buffer_t result = static_map_write_bencode_c(object_write_to_buffer, nullptr, std::make_pair(buffer, buffer + sizeof(buffer)), msg);
 
   m_length = result.second - buffer;
   m_data = new char[m_length];
@@ -268,12 +268,12 @@ DhtTransaction::DhtTransaction(int quick_timeout, int timeout, const HashString&
     m_sa(*sa),
     m_timeout(cachedTime.seconds() + timeout),
     m_quickTimeout(cachedTime.seconds() + quick_timeout),
-    m_packet(NULL) {
+    m_packet(nullptr) {
 
 }
 
 DhtTransaction::~DhtTransaction() {
-  if (m_packet != NULL)
+  if (m_packet != nullptr)
     m_packet->set_failed();
 }
 

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -243,7 +243,7 @@ public:
 
   // non-transaction packet
   DhtTransactionPacket(const rak::socket_address* s, const DhtMessage& d)
-    : m_sa(*s), m_id(-cachedTime.seconds()), m_transaction(NULL) { build_buffer(d); };
+    : m_sa(*s), m_id(-cachedTime.seconds()), m_transaction(nullptr) { build_buffer(d); };
 
   ~DhtTransactionPacket()                               { delete[] m_data; }
 

--- a/src/download/available_list.cc
+++ b/src/download/available_list.cc
@@ -36,7 +36,7 @@
 
 #include "config.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <iterator>
 

--- a/src/download/chunk_selector.cc
+++ b/src/download/chunk_selector.cc
@@ -37,7 +37,7 @@
 #include "config.h"
 
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
 #include <rak/functional.h>
 
 #include "protocol/peer_chunks.h"
@@ -69,7 +69,7 @@ ChunkSelector::initialize(ChunkStatistics* cs) {
 void
 ChunkSelector::cleanup() {
   m_data->mutable_untouched_bitfield()->clear();
-  m_statistics = NULL;
+  m_statistics = nullptr;
 }
 
 // Consider if ChunksSelector::not_using_index(...) needs to be

--- a/src/download/delegator.cc
+++ b/src/download/delegator.cc
@@ -57,7 +57,7 @@ struct DelegatorCheckAffinity {
     m_delegator(delegator), m_target(target), m_index(index), m_peerInfo(peerInfo) {}
 
   bool operator () (BlockList* d) {
-    return m_index == d->index() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != NULL;
+    return m_index == d->index() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != nullptr;
   }
 
   Delegator*          m_delegator;
@@ -71,7 +71,7 @@ struct DelegatorCheckSeeder {
     m_delegator(delegator), m_target(target), m_peerInfo(peerInfo) {}
 
   bool operator () (BlockList* d) {
-    return d->by_seeder() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != NULL;
+    return d->by_seeder() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != nullptr;
   }
 
   Delegator*          m_delegator;
@@ -87,7 +87,7 @@ struct DelegatorCheckPriority {
     return
       m_priority == d->priority() &&
       m_peerChunks->bitfield()->get(d->index()) &&
-      (*m_target = m_delegator->delegate_piece(d, m_peerChunks->peer_info())) != NULL;
+      (*m_target = m_delegator->delegate_piece(d, m_peerChunks->peer_info())) != nullptr;
   }
 
   Delegator*          m_delegator;
@@ -106,11 +106,11 @@ struct DelegatorCheckAggressive {
 
     if (!m_peerChunks->bitfield()->get(d->index()) ||
         d->priority() == PRIORITY_OFF ||
-        (tmp = m_delegator->delegate_aggressive(d, m_overlapp, m_peerChunks->peer_info())) == NULL)
+        (tmp = m_delegator->delegate_aggressive(d, m_overlapp, m_peerChunks->peer_info())) == nullptr)
       return false;
 
     *m_target = tmp;
-    return m_overlapp == 0;
+    return m_overlapp == nullptr;
   }
 
   Delegator*          m_delegator;
@@ -123,7 +123,7 @@ BlockTransfer*
 Delegator::delegate(PeerChunks* peerChunks, int affinity) {
   // TODO: Make sure we don't queue the same piece several time on the same peer when
   // it timeout cancels them.
-  Block* target = NULL;
+  Block* target = nullptr;
 
   // Find piece with same index as affinity. This affinity should ensure that we
   // never start another piece while the chunk this peer used to download is still
@@ -135,7 +135,7 @@ Delegator::delegate(PeerChunks* peerChunks, int affinity) {
       != m_transfers.end())
     return target->insert(peerChunks->peer_info());
 
-  if (peerChunks->is_seeder() && (target = delegate_seeder(peerChunks)) != NULL)
+  if (peerChunks->is_seeder() && (target = delegate_seeder(peerChunks)) != nullptr)
     return target->insert(peerChunks->peer_info());
 
   // High priority pieces.
@@ -156,7 +156,7 @@ Delegator::delegate(PeerChunks* peerChunks, int affinity) {
     return target->insert(peerChunks->peer_info());
 
   if (!m_aggressive)
-    return NULL;
+    return nullptr;
 
   // Aggressive mode, look for possible downloads that already have
   // one or more queued.
@@ -166,12 +166,12 @@ Delegator::delegate(PeerChunks* peerChunks, int affinity) {
 
   std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckAggressive(this, &target, &overlapped, peerChunks));
 
-  return target ? target->insert(peerChunks->peer_info()) : NULL;
+  return target ? target->insert(peerChunks->peer_info()) : nullptr;
 }
   
 Block*
 Delegator::delegate_seeder(PeerChunks* peerChunks) {
-  Block* target = NULL;
+  Block* target = nullptr;
 
   if (std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckSeeder(this, &target, peerChunks->peer_info()))
       != m_transfers.end())
@@ -183,7 +183,7 @@ Delegator::delegate_seeder(PeerChunks* peerChunks) {
   if ((target = new_chunk(peerChunks, false)))
     return target;
 
-  return NULL;
+  return nullptr;
 }
 
 Block*
@@ -191,7 +191,7 @@ Delegator::new_chunk(PeerChunks* pc, bool highPriority) {
   uint32_t index = m_slot_chunk_find(pc, highPriority);
 
   if (index == ~(uint32_t)0)
-    return NULL;
+    return nullptr;
 
   TransferList::iterator itr = m_transfers.insert(Piece(index, 0, m_slot_chunk_size(index)), block_size);
 
@@ -207,7 +207,7 @@ Delegator::new_chunk(PeerChunks* pc, bool highPriority) {
 
 Block*
 Delegator::delegate_piece(BlockList* c, const PeerInfo* peerInfo) {
-  Block* p = NULL;
+  Block* p = nullptr;
 
   for (BlockList::iterator i = c->begin(); i != c->end(); ++i) {
     if (i->is_finished() || !i->is_stalled())
@@ -217,7 +217,7 @@ Delegator::delegate_piece(BlockList* c, const PeerInfo* peerInfo) {
       // No one is downloading this, assign.
       return &*i;
 
-    } else if (p == NULL && i->find(peerInfo) == NULL) {
+    } else if (p == nullptr && i->find(peerInfo) == nullptr) {
       // Stalled but we really want to finish this piece. Check 'p' so
       // that we don't end up queuing the pieces in reverse.
       p = &*i;
@@ -229,10 +229,10 @@ Delegator::delegate_piece(BlockList* c, const PeerInfo* peerInfo) {
 
 Block*
 Delegator::delegate_aggressive(BlockList* c, uint16_t* overlapped, const PeerInfo* peerInfo) {
-  Block* p = NULL;
+  Block* p = nullptr;
 
   for (BlockList::iterator i = c->begin(); i != c->end() && *overlapped != 0; ++i)
-    if (!i->is_finished() && i->size_not_stalled() < *overlapped && i->find(peerInfo) == NULL) {
+    if (!i->is_finished() && i->size_not_stalled() < *overlapped && i->find(peerInfo) == nullptr) {
       p = &*i;
       *overlapped = i->size_not_stalled();
     }

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -185,7 +185,7 @@ DownloadConstructor::parse_info(const Object& b) {
 
 void
 DownloadConstructor::parse_tracker(const Object& b) {
-  const Object::list_type* announce_list = NULL;
+  const Object::list_type* announce_list = nullptr;
 
   if (b.has_key_list("announce-list") &&
 
@@ -389,13 +389,13 @@ parse_base32_sha1(const char* pos, HashString& hash) {
     else if (c == '&')
       break;
     else
-      return NULL;
+      return nullptr;
 
     decoded |= (value << shift);
     if (shift <= 8) {
       // Too many characters for a base32 SHA1.
       if (hashItr == hash.end())
-        return NULL;
+        return nullptr;
 
       *hashItr++ = (decoded >> 8);
       decoded <<= 8;
@@ -405,7 +405,7 @@ parse_base32_sha1(const char* pos, HashString& hash) {
     }
   }
 
-  return hashItr != hash.end() || shift != base_shift ? NULL : pos;
+  return hashItr != hash.end() || shift != base_shift ? nullptr : pos;
 }
 
 void
@@ -436,7 +436,7 @@ DownloadConstructor::parse_magnet_uri(Object& b, const std::string& uri) {
       pos += 9;
 
       const char* nextPos = parse_base32_sha1(pos, hash);
-      if (nextPos != NULL) {
+      if (nextPos != nullptr) {
         pos = nextPos;
         hashValid = true;
         continue;

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -38,7 +38,6 @@
 
 #include <cstdio>
 #include <cstring>
-#include <string.h>
 #include <rak/functional.h>
 #include <rak/string_manip.h>
 

--- a/src/download/download_constructor.h
+++ b/src/download/download_constructor.h
@@ -52,7 +52,7 @@ typedef std::list<std::string> EncodingList;
 
 class DownloadConstructor {
 public:
-  DownloadConstructor() : m_download(NULL), m_encodingList(NULL) {}
+  DownloadConstructor() : m_download(nullptr), m_encodingList(nullptr) {}
 
   void                initialize(Object& b);
 

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -93,14 +93,14 @@ DownloadInfo::DownloadInfo() :
 DownloadMain::DownloadMain() :
   m_info(new DownloadInfo),
 
-  m_choke_group(NULL),
+  m_choke_group(nullptr),
   m_chunkList(new ChunkList),
   m_chunkSelector(new ChunkSelector(file_list()->mutable_data())),
   m_chunkStatistics(new ChunkStatistics),
 
-  m_initialSeeding(NULL),
-  m_uploadThrottle(NULL),
-  m_downloadThrottle(NULL) {
+  m_initialSeeding(nullptr),
+  m_uploadThrottle(nullptr),
+  m_downloadThrottle(nullptr) {
 
   m_tracker_list = new TrackerList();
   m_tracker_controller = new TrackerController(m_tracker_list);
@@ -155,13 +155,13 @@ DownloadMain::~DownloadMain() {
 
 std::pair<ThrottleList*, ThrottleList*>
 DownloadMain::throttles(const sockaddr* sa) {
-  ThrottlePair pair = ThrottlePair(NULL, NULL);
+  ThrottlePair pair = ThrottlePair(nullptr, nullptr);
 
   if (manager->connection_manager()->address_throttle())
     pair = manager->connection_manager()->address_throttle()(sa);
 
-  return std::make_pair(pair.first == NULL ? upload_throttle() : pair.first->throttle_list(),
-                        pair.second == NULL ? download_throttle() : pair.second->throttle_list());
+  return std::make_pair(pair.first == nullptr ? upload_throttle() : pair.first->throttle_list(),
+                        pair.second == nullptr ? download_throttle() : pair.second->throttle_list());
 }
 
 void
@@ -232,7 +232,7 @@ DownloadMain::stop() {
   connection_list()->erase_remaining(connection_list()->begin(), ConnectionList::disconnect_available);
 
   delete m_initialSeeding;
-  m_initialSeeding = NULL;
+  m_initialSeeding = nullptr;
 
   priority_queue_erase(&taskScheduler, &m_delayDisconnectPeers);
   priority_queue_erase(&taskScheduler, &m_taskTrackerRequest);
@@ -252,7 +252,7 @@ DownloadMain::start_initial_seeding() {
 
 void
 DownloadMain::initial_seeding_done(PeerConnectionBase* pcb) {
-  if (m_initialSeeding == NULL)
+  if (m_initialSeeding == nullptr)
     throw internal_error("DownloadMain::initial_seeding_done called when not initial seeding.");
 
   // Close all connections but the currently active one (pcb), that
@@ -277,7 +277,7 @@ DownloadMain::initial_seeding_done(PeerConnectionBase* pcb) {
   m_connectionList->slot_new_connection(&createPeerConnectionSeed);
 
   delete m_initialSeeding;
-  m_initialSeeding = NULL;
+  m_initialSeeding = nullptr;
 
   // And close the current connection.
   throw close_connection();

--- a/src/download/download_wrapper.cc
+++ b/src/download/download_wrapper.cc
@@ -37,7 +37,7 @@
 #include "config.h"
 
 #include <iterator>
-#include <stdlib.h>
+#include <cstdlib>
 #include <rak/file_stat.h>
 
 #include "data/chunk_list.h"
@@ -70,8 +70,8 @@ namespace torrent {
 DownloadWrapper::DownloadWrapper() :
   m_main(new DownloadMain),
 
-  m_bencode(NULL),
-  m_hashChecker(NULL),
+  m_bencode(nullptr),
+  m_hashChecker(nullptr),
   m_connectionType(0) {
 
   m_main->delay_download_done().slot()       = std::bind(&download_data::call_download_done, data());
@@ -189,7 +189,7 @@ DownloadWrapper::receive_hash_done(ChunkHandle handle, const char* hash) {
 
   if (m_hashChecker->is_checking()) {
     
-    if (hash == NULL) {
+    if (hash == nullptr) {
       m_hashChecker->receive_chunk_cleared(handle.index());
 
     } else {
@@ -203,10 +203,10 @@ DownloadWrapper::receive_hash_done(ChunkHandle handle, const char* hash) {
     return;
   }
 
-  // If hash == NULL we're clearing the queue, so do nothing.
-  if (hash != NULL) {
+  // If hash == nullptr we're clearing the queue, so do nothing.
+  if (hash != nullptr) {
     if (!m_hashChecker->is_checked())
-      throw internal_error("DownloadWrapper::receive_hash_done(...) Was not expecting non-NULL hash.");
+      throw internal_error("DownloadWrapper::receive_hash_done(...) Was not expecting non-nullptr hash.");
 
     // Receiving chunk hashes after stopping the torrent should be
     // safe.

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -62,7 +62,7 @@
 
 namespace torrent {
 
-Manager* manager = NULL;
+Manager* manager = nullptr;
 
 Manager::Manager() :
   m_downloadManager(new DownloadManager),

--- a/src/net/data_buffer.h
+++ b/src/net/data_buffer.h
@@ -44,17 +44,17 @@ namespace torrent {
 
 // Recipient must call clear() when done with the buffer.
 struct DataBuffer {
-  DataBuffer()                        : m_data(NULL), m_end(NULL), m_owned(true) {}
+  DataBuffer()                        : m_data(nullptr), m_end(nullptr), m_owned(true) {}
   DataBuffer(char* data, char* end)   : m_data(data), m_end(end),  m_owned(true) {}
 
   DataBuffer          clone() const        { DataBuffer d = *this; d.m_owned = false; return d; }
-  DataBuffer          release()            { DataBuffer d = *this; set(NULL, NULL, false); return d; }
+  DataBuffer          release()            { DataBuffer d = *this; set(nullptr, nullptr, false); return d; }
 
   char*               data() const         { return m_data; }
   char*               end() const          { return m_end; }
 
   bool                owned() const        { return m_owned; }
-  bool                empty() const        { return m_data == NULL; }
+  bool                empty() const        { return m_data == nullptr; }
   size_t              length() const       { return m_end - m_data; }
 
   void                clear();
@@ -74,7 +74,7 @@ DataBuffer::clear() {
   if (!empty() && m_owned)
     delete[] m_data;
 
-  m_data = m_end = NULL;
+  m_data = m_end = nullptr;
   m_owned = false;
 }
 

--- a/src/net/local_addr.cc
+++ b/src/net/local_addr.cc
@@ -36,10 +36,10 @@
 
 #include "config.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <rak/socket_address.h>
 #include <sys/types.h>
-#include <errno.h>
+#include <cerrno>
 
 #ifdef __linux__
 #include <linux/netlink.h>

--- a/src/net/socket_base.cc
+++ b/src/net/socket_base.cc
@@ -36,7 +36,7 @@
 
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <sys/types.h>
 #include <sys/socket.h>
 

--- a/src/net/socket_datagram.cc
+++ b/src/net/socket_datagram.cc
@@ -55,7 +55,7 @@ SocketDatagram::read_datagram(void* buffer, unsigned int length, rak::socket_add
   int r;
   socklen_t fromlen;
 
-  if (sa != NULL) {
+  if (sa != nullptr) {
     fromlen = sizeof(rak::socket_address);
     r = ::recvfrom(m_fileDesc, buffer, length, 0, sa->c_sockaddr(), &fromlen);
   } else {
@@ -72,7 +72,7 @@ SocketDatagram::write_datagram(const void* buffer, unsigned int length, rak::soc
 
   int r;
 
-  if (sa != NULL) {
+  if (sa != nullptr) {
     if (m_ipv6_socket && sa->family() == rak::socket_address::pf_inet) {
       rak::socket_address_inet6 sa_mapped = sa->sa_inet()->to_mapped_address();
       r = ::sendto(m_fileDesc, buffer, length, 0, sa_mapped.c_sockaddr(), sizeof(rak::socket_address_inet6));

--- a/src/net/socket_datagram.h
+++ b/src/net/socket_datagram.h
@@ -46,8 +46,8 @@ public:
 
   // TODO: Make two seperate functions depending on whetever sa is
   // used.
-  int                 read_datagram(void* buffer, unsigned int length, rak::socket_address* sa = NULL);
-  int                 write_datagram(const void* buffer, unsigned int length, rak::socket_address* sa = NULL);
+  int                 read_datagram(void* buffer, unsigned int length, rak::socket_address* sa = nullptr);
+  int                 write_datagram(const void* buffer, unsigned int length, rak::socket_address* sa = nullptr);
 };
 
 }

--- a/src/net/socket_fd.cc
+++ b/src/net/socket_fd.cc
@@ -36,7 +36,7 @@
 
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/src/net/socket_fd.cc
+++ b/src/net/socket_fd.cc
@@ -250,8 +250,8 @@ SocketFd::accept(rak::socket_address* sa) {
   check_valid();
   socklen_t len = sizeof(rak::socket_address);
 
-  if (sa == NULL) {
-    return SocketFd(::accept(m_fd, NULL, &len), m_ipv6_socket);
+  if (sa == nullptr) {
+    return SocketFd(::accept(m_fd, nullptr, &len), m_ipv6_socket);
   }
 
   int fd = ::accept(m_fd, sa->c_sockaddr(), &len);

--- a/src/net/socket_set.cc
+++ b/src/net/socket_set.cc
@@ -47,7 +47,7 @@ const SocketSet::size_type SocketSet::npos;
 
 inline void
 SocketSet::_replace_with_last(size_type idx) {
-  while (!base_type::empty() && base_type::back() == NULL)
+  while (!base_type::empty() && base_type::back() == nullptr)
     base_type::pop_back();
 
   if (idx >= m_table.size())

--- a/src/net/socket_set.h
+++ b/src/net/socket_set.h
@@ -131,7 +131,7 @@ SocketSet::erase(Event* s) {
 
   _index(s) = npos;
 
-  *(begin() + idx) = NULL;
+  *(begin() + idx) = nullptr;
   m_erased.push_back(idx);
 }
 

--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -154,7 +154,7 @@ ProtocolExtension::generate_handshake_message() {
 
   char buffer[1024];
   object_buffer_t result = static_map_write_bencode_c(object_write_to_buffer,
-                                                      NULL,
+                                                      nullptr,
                                                       std::make_pair(buffer, buffer + sizeof(buffer)),
                                                       message);
 
@@ -220,7 +220,7 @@ ProtocolExtension::read_start(int type, uint32_t length, bool skip) {
   if (is_default() || (type >= FIRST_INVALID) || length > (1 << 15))
     throw communication_error("Received invalid extension message.");
 
-  if (m_read != NULL || (int32_t)length < 0)
+  if (m_read != nullptr || (int32_t)length < 0)
     throw internal_error("ProtocolExtension::read_start called in inconsistent state.");
 
   m_readLeft = length;
@@ -258,7 +258,7 @@ ProtocolExtension::read_done() {
   }
 
   delete [] m_read;
-  m_read = NULL;
+  m_read = nullptr;
 
   m_readType = FIRST_INVALID;
   m_flags |= flag_received_ext;
@@ -368,17 +368,17 @@ ProtocolExtension::parse_ut_metadata() {
     break;
 
   case 1:
-    if (m_connection == NULL)
+    if (m_connection == nullptr)
       break;
 
     m_connection->receive_metadata_piece(message[key_piece].as_value(), dataStart, m_readPos - dataStart);
     break;
 
   case 2:
-    if (m_connection == NULL)
+    if (m_connection == nullptr)
       break;
 
-    m_connection->receive_metadata_piece(message[key_piece].as_value(), NULL, 0);
+    m_connection->receive_metadata_piece(message[key_piece].as_value(), nullptr, 0);
     break;
   };
 
@@ -401,7 +401,7 @@ ProtocolExtension::send_metadata_piece(size_t piece) {
   // These messages will be rare, so we'll just build the
   // metadata here instead of caching it uselessly.
   char* buffer = new char[metadataSize];
-  object_write_bencode_c(object_write_to_buffer, NULL, object_buffer_t(buffer, buffer + metadataSize), 
+  object_write_bencode_c(object_write_to_buffer, nullptr, object_buffer_t(buffer, buffer + metadataSize), 
                          &(*manager->download_manager()->find(m_download->info()))->bencode()->get_key("info"));
 
   // data: { "msg_type" => 1, "piece" => ..., "total_size" => ... } followed by piece data (outside of dictionary)

--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -37,8 +37,7 @@
 #include "config.h"
 
 #include <limits>
-#include <stdarg.h>
-
+#include <cstdarg>
 #include <cstdio>
 
 #include "download/available_list.h"

--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -218,11 +218,11 @@ ProtocolExtension::ProtocolExtension() :
   // Set HANDSHAKE as enabled and supported. Those bits should not be
   // touched.
   m_flags(flag_local_enabled_base | flag_remote_supported_base | flag_initial_handshake),
-  m_peerInfo(NULL),
-  m_download(NULL),
-  m_connection(NULL),
+  m_peerInfo(nullptr),
+  m_download(nullptr),
+  m_connection(nullptr),
   m_readType(FIRST_INVALID),
-  m_read(NULL),
+  m_read(nullptr),
   m_pendingType(HANDSHAKE) {
 
   reset();

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -81,8 +81,8 @@ Handshake::Handshake(SocketFd fd, HandshakeManager* m, int encryptionOptions) :
   m_state(INACTIVE),
 
   m_manager(m),
-  m_peerInfo(NULL),
-  m_download(NULL),
+  m_peerInfo(nullptr),
+  m_download(nullptr),
 
   // Use global throttles until we know which download it is.
   m_uploadThrottle(manager->upload_throttle()->throttle_list()),
@@ -173,7 +173,7 @@ Handshake::release_connection() {
     throw internal_error("Handshake::release_connection called but m_fd is not open.");
 
   m_peerInfo->unset_flags(PeerInfo::flag_handshake);
-  m_peerInfo = NULL;
+  m_peerInfo = nullptr;
 
   get_fd().clear();
 }
@@ -188,13 +188,13 @@ Handshake::destroy_connection() {
   get_fd().close();
   get_fd().clear();
 
-  if (m_peerInfo == NULL)
+  if (m_peerInfo == nullptr)
     return;
 
   m_download->peer_list()->disconnected(m_peerInfo, 0);
 
   m_peerInfo->unset_flags(PeerInfo::flag_handshake);
-  m_peerInfo = NULL;
+  m_peerInfo = nullptr;
 
   if (!m_extensions->is_default()) {
     m_extensions->cleanup();
@@ -493,7 +493,7 @@ Handshake::read_info() {
 
   // Check the info hash.
   if (m_incoming) {
-    if (m_download != NULL) {
+    if (m_download != nullptr) {
       // Have the download from the encrypted handshake, make sure it
       // matches the BT handshake.
       if (m_download->info()->hash().not_equal_to((char*)m_readBuffer.position()))
@@ -540,7 +540,7 @@ Handshake::read_peer() {
 
   // The download is just starting so we're not sending any
   // bitfield. Pretend we wrote it already.
-  if (m_download->file_list()->bitfield()->is_all_unset() || m_download->initial_seeding() != NULL) {
+  if (m_download->file_list()->bitfield()->is_all_unset() || m_download->initial_seeding() != nullptr) {
     m_writePos = m_download->file_list()->bitfield()->size_bytes();
     m_writeBuffer.write_32(0);
 
@@ -668,7 +668,7 @@ Handshake::read_done() {
   // still reading the bitfield/extension and postponed it. If we had no
   // bitfield to send, we need to send a keep-alive now.
   if (m_writePos == m_download->file_list()->bitfield()->size_bytes())
-    prepare_post_handshake(m_download->file_list()->bitfield()->is_all_unset() || m_download->initial_seeding() != NULL);
+    prepare_post_handshake(m_download->file_list()->bitfield()->is_all_unset() || m_download->initial_seeding() != nullptr);
 
   if (m_writeDone)
     throw handshake_succeeded();
@@ -883,7 +883,7 @@ Handshake::fill_read_buffer(int size) {
 
 inline void
 Handshake::validate_download() {
-  if (m_download == NULL)
+  if (m_download == nullptr)
     throw handshake_error(ConnectionManager::handshake_dropped, e_handshake_unknown_download);
   if (!m_download->info()->is_active())
     throw handshake_error(ConnectionManager::handshake_dropped, e_handshake_inactive_download);
@@ -1063,13 +1063,13 @@ Handshake::prepare_peer_info() {
 
   // PeerInfo handling for outgoing connections needs to be moved to
   // HandshakeManager.
-  if (m_peerInfo == NULL) {
+  if (m_peerInfo == nullptr) {
     if (!m_incoming)
       throw internal_error("Handshake::prepare_peer_info() !m_incoming.");
 
     m_peerInfo = m_download->peer_list()->connected(m_address.c_sockaddr(), PeerList::connect_incoming);
 
-    if (m_peerInfo == NULL)
+    if (m_peerInfo == nullptr)
       throw handshake_error(ConnectionManager::handshake_failed, e_handshake_network_error);
 
     if (m_peerInfo->failed_counter() > m_manager->max_failed)

--- a/src/protocol/handshake_encryption.cc
+++ b/src/protocol/handshake_encryption.cc
@@ -79,7 +79,7 @@ HandshakeEncryption::initialize() {
 void
 HandshakeEncryption::cleanup() {
   delete m_key;
-  m_key = NULL;
+  m_key = nullptr;
 }
 
 bool

--- a/src/protocol/handshake_encryption.h
+++ b/src/protocol/handshake_encryption.h
@@ -66,7 +66,7 @@ public:
   static const unsigned int  vc_length = 8;
 
   HandshakeEncryption(int options) :
-    m_key(NULL),
+    m_key(nullptr),
     m_options(options),
     m_crypto(0),
     m_retry(RETRY_NONE),

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -95,7 +95,7 @@ HandshakeManager::erase(Handshake* handshake) {
 
 struct handshake_manager_equal : std::binary_function<const rak::socket_address*, const Handshake*, bool> {
   bool operator () (const rak::socket_address* sa1, const Handshake* p2) const {
-    return p2->peer_info() != NULL && *sa1 == *rak::socket_address::cast_from(p2->peer_info()->socket_address());
+    return p2->peer_info() != nullptr && *sa1 == *rak::socket_address::cast_from(p2->peer_info()->socket_address());
   }
 };
 
@@ -150,7 +150,7 @@ HandshakeManager::create_outgoing(const rak::socket_address& sa, DownloadMain* d
 
   PeerInfo* peerInfo = download->peer_list()->connected(sa.c_sockaddr(), connection_options);
 
-  if (peerInfo == NULL || peerInfo->failed_counter() > max_failed)
+  if (peerInfo == nullptr || peerInfo->failed_counter() > max_failed)
     return;
 
   SocketFd fd;
@@ -210,7 +210,7 @@ HandshakeManager::receive_succeeded(Handshake* handshake) {
                                                  handshake->get_fd(),
                                                  handshake->bitfield(),
                                                  handshake->encryption()->info(),
-                                                 handshake->extensions())) != NULL) {
+                                                 handshake->extensions())) != nullptr) {
     
     manager->client_list()->retrieve_id(&handshake->peer_info()->mutable_client_info(), handshake->peer_info()->id());
     LT_LOG_SA_C(INFO, handshake->peer_info()->socket_address(), "Handshake success.", 0);

--- a/src/protocol/initial_seed.cc
+++ b/src/protocol/initial_seed.cc
@@ -78,7 +78,7 @@ InitialSeeding::clear_peer(PeerInfo* peer) {
   peer->unset_flags(PeerInfo::flag_blocked);
 
   // If peer is still connected, offer new piece right away.
-  if (peer->connection() != NULL)
+  if (peer->connection() != nullptr)
     peer->connection()->write_insert_poll_safe();
 }
 

--- a/src/protocol/initial_seed.cc
+++ b/src/protocol/initial_seed.cc
@@ -36,7 +36,7 @@
 
 #include "config.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "torrent/download/choke_group.h"
 #include "torrent/download/choke_queue.h"

--- a/src/protocol/peer_chunks.h
+++ b/src/protocol/peer_chunks.h
@@ -109,7 +109,7 @@ private:
 
 inline
 PeerChunks::PeerChunks() :
-  m_peerInfo(NULL),
+  m_peerInfo(nullptr),
 
   m_usingCounter(false),
 

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -95,7 +95,7 @@ log_mincore_stats_func(bool is_incore, bool new_index, bool& continous) {
 }
 
 PeerConnectionBase::PeerConnectionBase() :
-  m_download(NULL),
+  m_download(nullptr),
   
   m_down(new ProtocolRead()),
   m_up(new ProtocolWrite()),
@@ -110,12 +110,12 @@ PeerConnectionBase::PeerConnectionBase() :
   m_tryRequest(true),
   m_sendPEXMask(0),
 
-  m_encryptBuffer(NULL),
-  m_extensions(NULL),
+  m_encryptBuffer(nullptr),
+  m_extensions(nullptr),
 
   m_incoreContinous(false) {
 
-  m_peerInfo = NULL;
+  m_peerInfo = nullptr;
 }
 
 PeerConnectionBase::~PeerConnectionBase() {
@@ -124,7 +124,7 @@ PeerConnectionBase::~PeerConnectionBase() {
 
   delete m_encryptBuffer;
 
-  if (m_extensions != NULL && !m_extensions->is_default())
+  if (m_extensions != nullptr && !m_extensions->is_default())
     delete m_extensions;
 
   m_extensionMessage.clear();
@@ -175,9 +175,9 @@ PeerConnectionBase::initialize(DownloadMain* download, PeerInfo* peerInfo, Socke
 
   } catch (close_connection& e) {
     // The handshake manager closes the socket for us.
-    m_peerInfo = NULL;
-    m_download = NULL;
-    m_extensions = NULL;
+    m_peerInfo = nullptr;
+    m_download = nullptr;
+    m_extensions = nullptr;
 
     get_fd().clear();
     return;
@@ -208,8 +208,8 @@ PeerConnectionBase::cleanup() {
   if (!get_fd().is_valid())
     return;
 
-  if (m_download == NULL)
-    throw internal_error("PeerConnection::~PeerConnection() m_fd is valid but m_state and/or m_net is NULL");
+  if (m_download == nullptr)
+    throw internal_error("PeerConnection::~PeerConnection() m_fd is valid but m_state and/or m_net is nullptr");
 
   // TODO: Verify that transfer counter gets modified by this...
   m_request_list.clear();
@@ -243,7 +243,7 @@ PeerConnectionBase::cleanup() {
   m_up->set_state(ProtocolWrite::INTERNAL_ERROR);
   m_down->set_state(ProtocolRead::INTERNAL_ERROR);
 
-  m_download = NULL;
+  m_download = nullptr;
 }
 
 void
@@ -385,7 +385,7 @@ PeerConnectionBase::load_up_chunk() {
   if (!m_upChunk.is_valid())
     throw storage_error("File chunk read error: " + std::string(m_upChunk.error_number().c_str()));
 
-  if (is_encrypted() && m_encryptBuffer == NULL) {
+  if (is_encrypted() && m_encryptBuffer == nullptr) {
     m_encryptBuffer = new EncryptBuffer();
     m_encryptBuffer->reset();
   }
@@ -732,8 +732,8 @@ PeerConnectionBase::down_extension() {
 
 inline uint32_t
 PeerConnectionBase::up_chunk_encrypt(uint32_t quota) {
-  if (m_encryptBuffer == NULL)
-    throw internal_error("PeerConnectionBase::up_chunk: m_encryptBuffer is NULL.");
+  if (m_encryptBuffer == nullptr)
+    throw internal_error("PeerConnectionBase::up_chunk: m_encryptBuffer is nullptr.");
 
   if (quota <= m_encryptBuffer->remaining())
     return quota;
@@ -977,7 +977,7 @@ PeerConnectionBase::try_request_pieces() {
 
     const Piece* p = request_list()->delegate();
 
-    if (p == NULL)
+    if (p == nullptr)
       break;
 
     if (!m_download->file_list()->is_valid_piece(*p) || !m_peerChunks.bitfield()->get(p->index()))

--- a/src/protocol/peer_connection_leech.cc
+++ b/src/protocol/peer_connection_leech.cc
@@ -66,7 +66,7 @@ namespace torrent {
 
 template<Download::ConnectionType type>
 PeerConnection<type>::~PeerConnection() {
-//   if (m_download != NULL && m_down->get_state() != ProtocolRead::READ_BITFIELD)
+//   if (m_download != nullptr && m_down->get_state() != ProtocolRead::READ_BITFIELD)
 //     m_download->bitfield_counter().dec(m_peerChunks.bitfield()->bitfield());
 
 //   priority_queue_erase(&taskScheduler, &m_taskSendChoke);
@@ -76,7 +76,7 @@ template<Download::ConnectionType type>
 void
 PeerConnection<type>::initialize_custom() {
   if (type == Download::CONNECTION_INITIAL_SEED) {
-    if (m_download->initial_seeding() == NULL)
+    if (m_download->initial_seeding() == nullptr)
       throw close_connection();
 
     m_download->initial_seeding()->new_peer(this);
@@ -503,12 +503,12 @@ PeerConnection<type>::fill_write_buffer() {
       up_chunk_release();
       m_peerChunks.upload_queue()->clear();
 
-      if (m_encryptBuffer != NULL) {
+      if (m_encryptBuffer != nullptr) {
         if (m_encryptBuffer->remaining())
           throw internal_error("Deleting encryptBuffer with encrypted data remaining.");
 
         delete m_encryptBuffer;
-        m_encryptBuffer = NULL;
+        m_encryptBuffer = nullptr;
       }
 
     } else {

--- a/src/protocol/peer_connection_metadata.cc
+++ b/src/protocol/peer_connection_metadata.cc
@@ -438,7 +438,7 @@ PeerConnectionMetadata::try_request_metadata_pieces() {
 
   const Piece* p = request_list()->delegate();
 
-  if (p == NULL)
+  if (p == nullptr)
     return false;
 
   if (!m_download->file_list()->is_valid_piece(*p) || !m_peerChunks.bitfield()->get(p->index()))
@@ -456,7 +456,7 @@ PeerConnectionMetadata::try_request_metadata_pieces() {
 
 void
 PeerConnectionMetadata::receive_metadata_piece(uint32_t piece, const char* data, uint32_t length) {
-  if (data == NULL) {
+  if (data == nullptr) {
     // Length is not set in a reject message.
     length = ProtocolExtension::metadata_piece_size;
 
@@ -478,7 +478,7 @@ PeerConnectionMetadata::receive_metadata_piece(uint32_t piece, const char* data,
     down_chunk_process(data, length);
   }
 
-  if (m_request_list.transfer() != NULL && !m_request_list.transfer()->is_finished())
+  if (m_request_list.transfer() != nullptr && !m_request_list.transfer()->is_finished())
     throw internal_error("PeerConnectionMetadata::receive_metadata_piece did not have complete piece.");
 
   m_tryRequest = true;

--- a/src/protocol/protocol_base.h
+++ b/src/protocol/protocol_base.h
@@ -84,7 +84,7 @@ public:
   ProtocolBase() :
     m_state(IDLE),
     m_lastCommand(NONE),
-    m_throttle(NULL) {
+    m_throttle(nullptr) {
 
     m_buffer.reset();
   }

--- a/src/protocol/request_list.cc
+++ b/src/protocol/request_list.cc
@@ -114,8 +114,8 @@ struct request_list_keep_request {
 };
 
 RequestList::~RequestList() {
-  if (m_transfer != NULL)
-    throw internal_error("request dtor m_transfer != NULL");
+  if (m_transfer != nullptr)
+    throw internal_error("request dtor m_transfer != nullptr");
 
   if (!m_queues.empty())
     throw internal_error("request dtor m_queues not empty");
@@ -130,8 +130,8 @@ RequestList::delegate() {
 
   instrumentation_update(INSTRUMENTATION_TRANSFER_REQUESTS_DELEGATED, 1);
 
-  if (transfer == NULL)
-    return NULL;
+  if (transfer == nullptr)
+    return nullptr;
 
   m_affinity = transfer->index();
   m_queues.push_back(bucket_queued, transfer);
@@ -149,7 +149,7 @@ RequestList::stall_initial() {
 
 void
 RequestList::stall_prolonged() {
-  if (m_transfer != NULL)
+  if (m_transfer != nullptr)
     Block::stalled(m_transfer);
 
   queue_bucket_for_all_in_queue(m_queues, bucket_queued, std::ptr_fun(&Block::stalled));
@@ -245,8 +245,8 @@ RequestList::clear() {
 
 bool
 RequestList::downloading(const Piece& piece) {
-  if (m_transfer != NULL)
-    throw internal_error("RequestList::downloading(...) m_transfer != NULL.");
+  if (m_transfer != nullptr)
+    throw internal_error("RequestList::downloading(...) m_transfer != nullptr.");
 
   instrumentation_update(INSTRUMENTATION_TRANSFER_REQUESTS_DOWNLOADING, 1);
 
@@ -330,7 +330,7 @@ RequestList::finished() {
     throw internal_error("RequestList::finished() called but transfer is invalid.");
 
   BlockTransfer* transfer = m_transfer;
-  m_transfer = NULL;
+  m_transfer = nullptr;
 
   m_delegator->transfer_list()->finished(transfer);
 
@@ -343,7 +343,7 @@ RequestList::skipped() {
     throw internal_error("RequestList::skip() called but no transfer is in progress.");
 
   Block::release(m_transfer);
-  m_transfer = NULL;
+  m_transfer = nullptr;
 
   instrumentation_update(INSTRUMENTATION_TRANSFER_REQUESTS_SKIPPED, 1);
 }

--- a/src/protocol/request_list.h
+++ b/src/protocol/request_list.h
@@ -98,7 +98,7 @@ public:
 
   void                 transfer_dissimilar();
 
-  bool                 is_downloading()                   { return m_transfer != NULL; }
+  bool                 is_downloading()                   { return m_transfer != nullptr; }
   bool                 is_interested_in_active() const;
 
   // bool                 has_index(uint32_t i);
@@ -150,9 +150,9 @@ private:
 
 inline
 RequestList::RequestList() :
-  m_delegator(NULL),
-  m_peerChunks(NULL),
-  m_transfer(NULL),
+  m_delegator(nullptr),
+  m_peerChunks(nullptr),
+  m_transfer(nullptr),
   m_affinity(-1),
   m_last_unordered_position(0) {
   m_delay_remove_choked.slot() = std::bind(&RequestList::delay_remove_choked, this);

--- a/src/torrent/bitfield.cc
+++ b/src/torrent/bitfield.cc
@@ -48,15 +48,15 @@ namespace torrent {
 
 void
 Bitfield::set_size_bits(size_type s) {
-  if (m_data != NULL)
-    throw internal_error("Bitfield::set_size_bits(size_type s) m_data != NULL.");
+  if (m_data != nullptr)
+    throw internal_error("Bitfield::set_size_bits(size_type s) m_data != nullptr.");
 
   m_size = s;
 }
 
 void
 Bitfield::set_size_set(size_type s) {
-  if (s > m_size || m_data != NULL)
+  if (s > m_size || m_data != nullptr)
     throw internal_error("Bitfield::set_size_set(size_type s) s > m_size.");
 
   m_set = s;
@@ -64,7 +64,7 @@ Bitfield::set_size_set(size_type s) {
 
 void
 Bitfield::allocate() { 
-  if (m_data != NULL)
+  if (m_data != nullptr)
     return;
 
   m_data = new value_type[size_bytes()];
@@ -74,11 +74,11 @@ Bitfield::allocate() {
 
 void
 Bitfield::unallocate() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     return;
 
   delete [] m_data;
-  m_data = NULL;
+  m_data = nullptr;
 
   instrumentation_update(INSTRUMENTATION_MEMORY_BITFIELDS, -(int64_t)size_bytes());
 }
@@ -110,8 +110,8 @@ Bitfield::copy(const Bitfield& bf) {
   m_size = bf.m_size;
   m_set = bf.m_set;
 
-  if (bf.m_data == NULL) {
-    m_data = NULL;
+  if (bf.m_data == nullptr) {
+    m_data = nullptr;
   } else {
     allocate();
     std::memcpy(m_data, bf.m_data, size_bytes());

--- a/src/torrent/bitfield.h
+++ b/src/torrent/bitfield.h
@@ -50,10 +50,10 @@ public:
   typedef value_type*           iterator;
   typedef const value_type*     const_iterator;
 
-  Bitfield() : m_size(0), m_set(0), m_data(NULL)    {}
+  Bitfield() : m_size(0), m_set(0), m_data(nullptr)    {}
   ~Bitfield()                                       { clear(); }
 
-  bool                empty() const                 { return m_data == NULL; }
+  bool                empty() const                 { return m_data == nullptr; }
 
   bool                is_all_set() const            { return m_set == m_size; }
   bool                is_all_unset() const          { return m_set == 0; }

--- a/src/torrent/chunk_manager.cc
+++ b/src/torrent/chunk_manager.cc
@@ -137,7 +137,7 @@ ChunkManager::erase(ChunkList* chunkList) {
   std::iter_swap(itr, --base_type::end());
   base_type::pop_back();
 
-  chunkList->set_manager(NULL);
+  chunkList->set_manager(nullptr);
 }
 
 bool

--- a/src/torrent/connection_manager.cc
+++ b/src/torrent/connection_manager.cc
@@ -63,8 +63,8 @@ resolve_host(const char* host, int family, int socktype, ConnectionManager::slot
     if (manager->main_thread_main()->is_current())
       thread_base::acquire_global_lock();
 
-    slot(NULL, err);
-    return NULL;
+    slot(nullptr, err);
+    return nullptr;
   }
 
   rak::socket_address sa;
@@ -75,7 +75,7 @@ resolve_host(const char* host, int family, int socktype, ConnectionManager::slot
     thread_base::acquire_global_lock();
   
   slot(sa.c_sockaddr(), 0);
-  return NULL;
+  return nullptr;
 }
 
 ConnectionManager::ConnectionManager() :

--- a/src/torrent/data/block.cc
+++ b/src/torrent/data/block.cc
@@ -56,13 +56,13 @@ Block::~Block() {
     throw internal_error("Block dtor with 'm_state != STATE_INCOMPLETE && m_state != STATE_COMPLETED'");
 
   if (m_state == STATE_COMPLETED) {
-    if (m_leader == NULL)
-      throw internal_error("Block dtor with 'm_state == STATE_COMPLETED && m_leader == NULL'");
+    if (m_leader == nullptr)
+      throw internal_error("Block dtor with 'm_state == STATE_COMPLETED && m_leader == nullptr'");
 
-    m_leader->set_peer_info(NULL);
+    m_leader->set_peer_info(nullptr);
   }
 
-  m_leader = NULL;
+  m_leader = nullptr;
   m_state = STATE_INVALID;
 
   std::for_each(m_queued.begin(), m_queued.end(), std::bind1st(std::mem_fun(&Block::invalidate_transfer), this));
@@ -103,8 +103,8 @@ Block::erase(BlockTransfer* transfer) {
   if (transfer->is_erased())
     throw internal_error("Block::erase(...) transfer already erased");
 
-  if (transfer->peer_info() != NULL)
-    throw internal_error("Block::erase(...) transfer has non-null peer info");
+  if (transfer->peer_info() != nullptr)
+    throw internal_error("Block::erase(...) transfer has non-nullptr peer info");
 
   m_notStalled -= transfer->stall() == 0;
 
@@ -147,7 +147,7 @@ Block::erase(BlockTransfer* transfer) {
         m_leader = *newLeader;
         m_leader->set_state(BlockTransfer::STATE_LEADER);
       } else {
-        m_leader = NULL;
+        m_leader = nullptr;
 
         // If we have no new leader, remove the erased (dissimilar)
         // transfers so they can get another shot. They cannot be
@@ -161,16 +161,16 @@ Block::erase(BlockTransfer* transfer) {
     throw internal_error("Block::erase(...) Transfer is finished.");
   }
 
-  // Check if we need to check for peer_info not being null.
+  // Check if we need to check for peer_info not being nullptr.
 
-  transfer->set_block(NULL);
+  transfer->set_block(nullptr);
   delete transfer;
 }
 
 bool
 Block::transfering(BlockTransfer* transfer) {
   if (!transfer->is_valid())
-    throw internal_error("Block::transfering(...) transfer->block() == NULL.");
+    throw internal_error("Block::transfering(...) transfer->block() == nullptr.");
 
   transfer_list_type::iterator itr = std::find(m_queued.begin(), m_queued.end(), transfer);
 
@@ -185,7 +185,7 @@ Block::transfering(BlockTransfer* transfer) {
   // transfering, it will (a) take over as the leader if the data is
   // the same or (b) erase itself from this block if the data does not
   // match.
-  if (m_leader != NULL) {
+  if (m_leader != nullptr) {
     transfer->set_state(BlockTransfer::STATE_NOT_LEADER);
     return false;
 
@@ -202,7 +202,7 @@ Block::transfering(BlockTransfer* transfer) {
 bool
 Block::completed(BlockTransfer* transfer) {
   if (!transfer->is_valid())
-    throw internal_error("Block::completed(...) transfer->block() == NULL.");
+    throw internal_error("Block::completed(...) transfer->block() == nullptr.");
 
   if (!transfer->is_leader())
     throw internal_error("Block::completed(...) transfer is not the leader.");
@@ -224,7 +224,7 @@ Block::completed(BlockTransfer* transfer) {
 
   m_notStalled -= transfer->stall() == 0;
 
-  transfer->set_block(NULL);
+  transfer->set_block(nullptr);
   transfer->set_stall(~uint32_t());
 
   // Currently just throw out the queued transfers. In case the hash
@@ -271,7 +271,7 @@ Block::transfer_dissimilar(BlockTransfer* transfer) {
   
   transfer->set_state(BlockTransfer::STATE_ERASED);
   transfer->set_position(0);
-  transfer->set_block(NULL);
+  transfer->set_block(nullptr);
 }
 
 void
@@ -296,7 +296,7 @@ Block::change_leader(BlockTransfer* transfer) {
   if (is_finished())
     throw internal_error("Block::change_leader(...) is_finished().");
 
-  if (m_leader != NULL)
+  if (m_leader != nullptr)
     m_leader->set_state(BlockTransfer::STATE_NOT_LEADER);
 
   m_leader = transfer;
@@ -308,9 +308,9 @@ Block::failed_leader() {
   if (!is_finished())
     throw internal_error("Block::failed_leader(...) !is_finished().");
 
-  m_leader = NULL;
+  m_leader = nullptr;
 
-  if (m_failedList != NULL)
+  if (m_failedList != nullptr)
     m_failedList->set_current(BlockFailed::invalid_index);
 }
 
@@ -318,7 +318,7 @@ void
 Block::create_dummy(BlockTransfer* transfer, PeerInfo* peerInfo, const Piece& piece) {
   transfer->set_peer_info(peerInfo);
 
-  transfer->set_block(NULL);
+  transfer->set_block(nullptr);
   transfer->set_piece(piece);
   transfer->set_state(BlockTransfer::STATE_ERASED);
 
@@ -329,7 +329,7 @@ Block::create_dummy(BlockTransfer* transfer, PeerInfo* peerInfo, const Piece& pi
 
 void
 Block::release(BlockTransfer* transfer) {
-  transfer->set_peer_info(NULL);
+  transfer->set_peer_info(nullptr);
 
   if (!transfer->is_valid())
     delete transfer;
@@ -349,9 +349,9 @@ Block::invalidate_transfer(BlockTransfer* transfer) {
 
   // Check if the block is this.
 
-  transfer->set_block(NULL);
+  transfer->set_block(nullptr);
 
-  if (transfer->peer_info() == NULL) {
+  if (transfer->peer_info() == nullptr) {
     delete transfer;
     return; // Consider if this should be an exception.
   }
@@ -359,7 +359,7 @@ Block::invalidate_transfer(BlockTransfer* transfer) {
   m_notStalled -= (transfer->stall() == 0);
 
   // Do the canceling magic here. 
-  if (transfer->peer_info()->connection() != NULL)
+  if (transfer->peer_info()->connection() != nullptr)
     transfer->peer_info()->connection()->cancel_transfer(transfer);
 }
 
@@ -384,7 +384,7 @@ Block::find_queued(const PeerInfo* p) {
   transfer_list_type::iterator itr = std::find_if(m_queued.begin(), m_queued.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
 
   if (itr == m_queued.end())
-    return NULL;
+    return nullptr;
   else
     return *itr;
 }
@@ -394,7 +394,7 @@ Block::find_queued(const PeerInfo* p) const {
   transfer_list_type::const_iterator itr = std::find_if(m_queued.begin(), m_queued.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
 
   if (itr == m_queued.end())
-    return NULL;
+    return nullptr;
   else
     return *itr;
 }
@@ -404,7 +404,7 @@ Block::find_transfer(const PeerInfo* p) {
   transfer_list_type::iterator itr = std::find_if(m_transfers.begin(), m_transfers.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
 
   if (itr == m_transfers.end())
-    return NULL;
+    return nullptr;
   else
     return *itr;
 }
@@ -414,7 +414,7 @@ Block::find_transfer(const PeerInfo* p) const {
   transfer_list_type::const_iterator itr = std::find_if(m_transfers.begin(), m_transfers.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
 
   if (itr == m_transfers.end())
-    return NULL;
+    return nullptr;
   else
     return *itr;
 }

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -65,11 +65,11 @@ public:
   ~Block();
 
   bool                      is_stalled() const                           { return m_notStalled == 0; }
-  bool                      is_finished() const                          { return m_leader != NULL && m_leader->is_finished(); }
-  bool                      is_transfering() const                       { return m_leader != NULL && !m_leader->is_finished(); }
+  bool                      is_finished() const                          { return m_leader != nullptr && m_leader->is_finished(); }
+  bool                      is_transfering() const                       { return m_leader != nullptr && !m_leader->is_finished(); }
 
-  bool                      is_peer_queued(const PeerInfo* p) const      { return find_queued(p) != NULL; }
-  bool                      is_peer_transfering(const PeerInfo* p) const { return find_transfer(p) != NULL; }
+  bool                      is_peer_queued(const PeerInfo* p) const      { return find_queued(p) != nullptr; }
+  bool                      is_peer_transfering(const PeerInfo* p) const { return find_transfer(p) != nullptr; }
 
   size_type                 size_all() const                             { return m_queued.size() + m_transfers.size(); }
   size_type                 size_not_stalled() const                     { return m_notStalled; }
@@ -123,7 +123,7 @@ public:
 
   // If the queued or transfering is already removed from the block it
   // will just delete the object. Made static so it can be called when
-  // block == NULL.
+  // block == nullptr.
   static void               release(BlockTransfer* transfer);
 
 private:
@@ -153,14 +153,14 @@ inline
 Block::Block() :
   m_state(STATE_INCOMPLETE),
   m_notStalled(0),
-  m_leader(NULL),
-  m_failedList(NULL) { }
+  m_leader(nullptr),
+  m_failedList(nullptr) { }
 
 inline BlockTransfer*
 Block::find(const PeerInfo* p) {
   BlockTransfer* transfer;
 
-  if ((transfer = find_queued(p)) != NULL)
+  if ((transfer = find_queued(p)) != nullptr)
     return transfer;
   else
     return find_transfer(p);
@@ -170,7 +170,7 @@ inline const BlockTransfer*
 Block::find(const PeerInfo* p) const {
   const BlockTransfer* transfer;
 
-  if ((transfer = find_queued(p)) != NULL)
+  if ((transfer = find_queued(p)) != nullptr)
     return transfer;
   else
     return find_transfer(p);

--- a/src/torrent/data/block_list.h
+++ b/src/torrent/data/block_list.h
@@ -56,7 +56,7 @@ public:
   typedef value_type*       iterator;
   typedef const value_type* const_iterator;
 
-  no_copy_vector() : m_size(0), m_values(NULL) {}
+  no_copy_vector() : m_size(0), m_values(nullptr) {}
   ~no_copy_vector() { clear(); }
 
   size_type size() const { return m_size; }
@@ -64,7 +64,7 @@ public:
 
   void resize(size_type s) { clear(); m_size = s; m_values = new value_type[s]; }
 
-  void clear() { delete [] m_values; m_values = NULL; m_size = 0; }
+  void clear() { delete [] m_values; m_values = nullptr; m_size = 0; }
 
   iterator       begin() { return m_values; }
   const_iterator begin() const { return m_values; }

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -62,7 +62,7 @@ public:
   ~BlockTransfer();
 
   // TODO: Do we need to also check for peer_info?...
-  bool                is_valid() const              { return m_block != NULL; }
+  bool                is_valid() const              { return m_block != nullptr; }
 
   bool                is_erased() const             { return m_state == STATE_ERASED; }
   bool                is_queued() const             { return m_state == STATE_QUEUED; }
@@ -118,28 +118,28 @@ private:
 
 inline
 BlockTransfer::BlockTransfer() :
-  m_peer_info(NULL),
-  m_block(NULL)
+  m_peer_info(nullptr),
+  m_block(nullptr)
 {
 }
 
 inline
 BlockTransfer::~BlockTransfer() {
-  if (m_block != NULL)
-    throw internal_error("BlockTransfer::~BlockTransfer() block not NULL");
+  if (m_block != nullptr)
+    throw internal_error("BlockTransfer::~BlockTransfer() block not nullptr");
 
-  if (m_peer_info != NULL)
-    throw internal_error("BlockTransfer::~BlockTransfer() peer_info not NULL");
+  if (m_peer_info != nullptr)
+    throw internal_error("BlockTransfer::~BlockTransfer() peer_info not nullptr");
 }
 
 inline void
 BlockTransfer::set_peer_info(key_type p) {
-  if (m_peer_info != NULL)
+  if (m_peer_info != nullptr)
     m_peer_info->dec_transfer_counter();
 
   m_peer_info = p;
 
-  if (m_peer_info != NULL)
+  if (m_peer_info != nullptr)
     m_peer_info->inc_transfer_counter();
 }
 

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -231,7 +231,7 @@ FileList::split(iterator position, split_type* first, split_type* last) {
   size_type index = std::distance(begin(), position);
   size_type length = std::distance(first, last);
 
-  base_type::insert(position, length - 1, NULL);
+  base_type::insert(position, length - 1, nullptr);
   position = begin() + index;
 
   iterator itr = position;
@@ -617,7 +617,7 @@ FileList::create_chunk(uint64_t offset, uint32_t length, int prot) {
     MemoryChunk mc = create_chunk_part(itr, offset, length, prot);
 
     if (!mc.is_valid())
-      return NULL;
+      return nullptr;
 
     if (mc.size() == 0)
       throw internal_error("FileList::create_chunk(...) mc.size() == 0.", data()->hash());
@@ -633,7 +633,7 @@ FileList::create_chunk(uint64_t offset, uint32_t length, int prot) {
   }
 
   if (chunk->empty())
-    return NULL;
+    return nullptr;
 
   return chunk.release();
 }

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -119,7 +119,7 @@ FileManager::close(value_type file) {
 }
 
 struct FileManagerActivity {
-  FileManagerActivity() : m_last(rak::timer::max().usec()), m_file(NULL) {}
+  FileManagerActivity() : m_last(rak::timer::max().usec()), m_file(nullptr) {}
 
   void operator ()(File* f) {
     if (f->is_open() && f->last_touched() <= m_last) {

--- a/src/torrent/data/transfer_list.cc
+++ b/src/torrent/data/transfer_list.cc
@@ -214,7 +214,7 @@ TransferList::update_failed(BlockList* blockList, Chunk* chunk) {
 
   for (BlockList::iterator itr = blockList->begin(), last = blockList->end(); itr != last; ++itr) {
     
-    if (itr->failed_list() == NULL)
+    if (itr->failed_list() == nullptr)
       itr->set_failed_list(new BlockFailed());
 
     BlockFailed::iterator failedItr = std::find_if(itr->failed_list()->begin(), itr->failed_list()->end(),

--- a/src/torrent/dht_manager.cc
+++ b/src/torrent/dht_manager.cc
@@ -61,7 +61,7 @@ DhtManager::initialize(const Object& dhtCache) {
 
   LT_LOG_THIS("initializing (bind_address:%s)", bind_address->pretty_address_str().c_str());
 
-  if (m_router != NULL)
+  if (m_router != nullptr)
     throw internal_error("DhtManager::initialize called with DHT already active.");
 
   try {
@@ -75,7 +75,7 @@ bool
 DhtManager::start(port_type port) {
   LT_LOG_THIS("starting (port:%d)", port);
 
-  if (m_router == NULL)
+  if (m_router == nullptr)
     throw internal_error("DhtManager::start called without initializing first.");
 
   m_port = port;
@@ -92,7 +92,7 @@ DhtManager::start(port_type port) {
 
 void
 DhtManager::stop() {
-  if (m_router == NULL)
+  if (m_router == nullptr)
     return;
 
   LT_LOG_THIS("stopping", 0);
@@ -101,24 +101,24 @@ DhtManager::stop() {
 
 bool
 DhtManager::is_active() const {
-  return m_router != NULL && m_router->is_active();
+  return m_router != nullptr && m_router->is_active();
 }
 
 void
 DhtManager::add_node(const sockaddr* addr, int port) {
-  if (m_router != NULL)
+  if (m_router != nullptr)
     m_router->contact(rak::socket_address::cast_from(addr), port);
 }
 
 void
 DhtManager::add_node(const std::string& host, int port) {
-  if (m_router != NULL)
+  if (m_router != nullptr)
     m_router->add_contact(host, port);
 }
 
 Object*
 DhtManager::store_cache(Object* container) const {
-  if (m_router == NULL)
+  if (m_router == nullptr)
     throw internal_error("DhtManager::store_cache called but DHT not initialized.");
 
   return m_router->store_cache(container);

--- a/src/torrent/dht_manager.h
+++ b/src/torrent/dht_manager.h
@@ -77,7 +77,7 @@ public:
     statistics_type(const Rate& up, const Rate& down) : up_rate(up), down_rate(down) { }
   };
 
-  DhtManager() : m_router(NULL), m_portSent(0), m_canReceive(true) { };
+  DhtManager() : m_router(nullptr), m_portSent(0), m_canReceive(true) { };
   ~DhtManager();
 
   void                initialize(const Object& dhtCache);

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -320,7 +320,7 @@ Download::chunks_hashed() const {
 
 const uint8_t*
 Download::chunks_seen() const {
-  return !m_ptr->main()->chunk_statistics()->empty() ? &*m_ptr->main()->chunk_statistics()->begin() : NULL;
+  return !m_ptr->main()->chunk_statistics()->empty() ? &*m_ptr->main()->chunk_statistics()->begin() : nullptr;
 }
 
 void
@@ -554,7 +554,7 @@ Download::set_connection_type(ConnectionType t) {
     m_ptr->main()->connection_list()->slot_new_connection(&createPeerConnectionSeed);
     break;
   case CONNECTION_INITIAL_SEED:
-    if (info()->is_active() && m_ptr->main()->initial_seeding() == NULL)
+    if (info()->is_active() && m_ptr->main()->initial_seeding() == nullptr)
       throw input_error("Can't switch to initial seeding: download is active.");
     m_ptr->main()->connection_list()->slot_new_connection(&createPeerConnectionInitialSeed);
     break;

--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -69,7 +69,7 @@ public:
 
   static const int stop_skip_tracker     = (1 << 0);
 
-  Download(DownloadWrapper* d = NULL) : m_ptr(d) {}
+  Download(DownloadWrapper* d = nullptr) : m_ptr(d) {}
 
   const DownloadInfo*  info() const;
   const download_data* data() const;

--- a/src/torrent/download/choke_group.cc
+++ b/src/torrent/download/choke_group.cc
@@ -53,7 +53,7 @@ namespace torrent {
 choke_group::choke_group() :
   m_tracker_mode(TRACKER_MODE_NORMAL),
   m_down_queue(choke_queue::flag_unchoke_all_new),
-  m_first(NULL), m_last(NULL) { }
+  m_first(nullptr), m_last(nullptr) { }
 
 uint64_t
 choke_group::up_rate() const {

--- a/src/torrent/download/choke_queue.cc
+++ b/src/torrent/download/choke_queue.cc
@@ -425,7 +425,7 @@ choke_queue::disconnected(PeerConnectionBase* pc, choke_status* base) {
 // care of things.
 void
 choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain* download, group_entry* base) {
-  if (src != NULL) {
+  if (src != nullptr) {
     group_container_type::iterator itr = std::find(src->m_group_container.begin(), src->m_group_container.end(), base);
 
     if (itr == src->m_group_container.end()) throw internal_error("choke_queue::move_connections(...) could not find group.");
@@ -434,11 +434,11 @@ choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain*
     src->m_group_container.pop_back();
   }
 
-  if (dest != NULL) {
+  if (dest != nullptr) {
     dest->m_group_container.push_back(base);
   }
 
-  if (src == NULL || dest == NULL)
+  if (src == nullptr || dest == nullptr)
     return;
 
   src->modify_currently_queued(-base->queued()->size());

--- a/src/torrent/download/download_manager.cc
+++ b/src/torrent/download/download_manager.cc
@@ -99,7 +99,7 @@ DownloadManager::find_main(const char* hash) {
                                                          rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
 
   if (itr == end())
-    return NULL;
+    return nullptr;
   else
     return (*itr)->main();
 }
@@ -110,7 +110,7 @@ DownloadManager::find_main_obfuscated(const char* hash) {
                                                          rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash_obfuscated))));
 
   if (itr == end())
-    return NULL;
+    return nullptr;
   else
     return (*itr)->main();
 }

--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -95,8 +95,8 @@ ResourceManager::insert(const resource_manager_entry& entry) {
     std::for_each(++group_itr, choke_base_type::end(), std::mem_fun(&choke_group::inc_iterators));
   }
 
-  choke_queue::move_connections(NULL, group_at(entry.group())->up_queue(), download, download->up_group_entry());
-  choke_queue::move_connections(NULL, group_at(entry.group())->down_queue(), download, download->down_group_entry());
+  choke_queue::move_connections(nullptr, group_at(entry.group())->up_queue(), download, download->up_group_entry());
+  choke_queue::move_connections(nullptr, group_at(entry.group())->down_queue(), download, download->down_group_entry());
 
   return itr;
 }
@@ -140,8 +140,8 @@ ResourceManager::erase(DownloadMain* d) {
   if (itr == end())
     throw internal_error("ResourceManager::erase() itr == end().");
 
-  choke_queue::move_connections(group_at(itr->group())->up_queue(), NULL, d, d->up_group_entry());
-  choke_queue::move_connections(group_at(itr->group())->down_queue(), NULL, d, d->down_group_entry());
+  choke_queue::move_connections(group_at(itr->group())->up_queue(), nullptr, d, d->up_group_entry());
+  choke_queue::move_connections(group_at(itr->group())->down_queue(), nullptr, d, d->down_group_entry());
 
   choke_base_type::iterator group_itr = choke_base_type::begin() + itr->group();
   (*group_itr)->set_last((*group_itr)->last() - 1);

--- a/src/torrent/download/resource_manager.h
+++ b/src/torrent/download/resource_manager.h
@@ -62,7 +62,7 @@ class LIBTORRENT_EXPORT resource_manager_entry {
 public:
   friend class ResourceManager;
 
-  resource_manager_entry(DownloadMain* d = NULL, uint16_t pri = 0, uint16_t grp = 0) :
+  resource_manager_entry(DownloadMain* d = nullptr, uint16_t pri = 0, uint16_t grp = 0) :
     m_download(d), m_priority(pri), m_group(grp) {}
 
   DownloadMain*       download()         { return m_download; }

--- a/src/torrent/http.cc
+++ b/src/torrent/http.cc
@@ -62,7 +62,7 @@ Http::trigger_done() {
 
   if (should_delete_stream) {
     delete m_stream;
-    m_stream = NULL;
+    m_stream = nullptr;
   }
 
   if (should_delete_self)
@@ -81,7 +81,7 @@ Http::trigger_failed(const std::string& message) {
 
   if (should_delete_stream) {
     delete m_stream;
-    m_stream = NULL;
+    m_stream = nullptr;
   }
 
   if (should_delete_self)

--- a/src/torrent/http.h
+++ b/src/torrent/http.h
@@ -61,7 +61,7 @@ class LIBTORRENT_EXPORT Http {
   static const int flag_delete_self   = 0x1;
   static const int flag_delete_stream = 0x2;
 
-  Http() : m_flags(0), m_stream(NULL), m_timeout(0) {}
+  Http() : m_flags(0), m_stream(nullptr), m_timeout(0) {}
   virtual ~Http();
 
   // Start must never throw on bad input. Calling start/stop on an

--- a/src/torrent/net/socket_address_key.h
+++ b/src/torrent/net/socket_address_key.h
@@ -46,7 +46,7 @@ private:
 
 inline bool
 socket_address_key::is_comparable_sockaddr(const sockaddr* sa) {
-  return sa != NULL && (sa->sa_family == AF_INET || sa->sa_family == AF_INET6);
+  return sa != nullptr && (sa->sa_family == AF_INET || sa->sa_family == AF_INET6);
 }
 
 // TODO: Require socket length?
@@ -59,7 +59,7 @@ socket_address_key::from_sockaddr(const sockaddr* sa) {
 
   result.m_family = AF_UNSPEC;
 
-  if (sa == NULL)
+  if (sa == nullptr)
     return result;
 
   switch (sa->sa_family) {

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -802,7 +802,7 @@ static_map_write_bencode_c_values(object_write_data_t* output,
                                  const static_map_entry_type* entry_values,
                                  const static_map_mapping_type* first_key,
                                  const static_map_mapping_type* last_key) {
-  const char* prev_key = NULL;
+  const char* prev_key = nullptr;
 
   static_map_stack_type stack[8];
   static_map_stack_type* stack_itr = stack;

--- a/src/torrent/peer/choke_status.h
+++ b/src/torrent/peer/choke_status.h
@@ -46,7 +46,7 @@ class group_entry;
 class choke_status {
 public:
   choke_status() :
-    m_group_entry(NULL),
+    m_group_entry(nullptr),
 
     m_queued(false),
     m_unchoked(false),

--- a/src/torrent/peer/client_list.cc
+++ b/src/torrent/peer/client_list.cc
@@ -47,7 +47,7 @@
 namespace torrent {
 
 ClientList::ClientList() {
-  insert(ClientInfo::TYPE_UNKNOWN, NULL, NULL, NULL);
+  insert(ClientInfo::TYPE_UNKNOWN, nullptr, nullptr, nullptr);
 
   // Move this to a seperate initialize function in libtorrent.
 
@@ -55,59 +55,59 @@ ClientList::ClientList() {
   // biased by my own prejudices, and not at all based on facts.
 
   // First batch of clients.
-  insert_helper(ClientInfo::TYPE_AZUREUS, "AZ", NULL, NULL, "Azureus");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BC", NULL, NULL, "BitComet");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "CD", NULL, NULL, "Enhanced CTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "KT", NULL, NULL, "KTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "LT", NULL, NULL, "libtorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "lt", NULL, NULL, "libTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "UM", NULL, NULL, "uTorrent Mac");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "UT", NULL, NULL, "uTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "AZ", nullptr, nullptr, "Azureus");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BC", nullptr, nullptr, "BitComet");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "CD", nullptr, nullptr, "Enhanced CTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "KT", nullptr, nullptr, "KTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "LT", nullptr, nullptr, "libtorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "lt", nullptr, nullptr, "libTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "UM", nullptr, nullptr, "uTorrent Mac");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "UT", nullptr, nullptr, "uTorrent");
 
-  insert_helper(ClientInfo::TYPE_MAINLINE, "M", NULL, NULL, "Mainline");
+  insert_helper(ClientInfo::TYPE_MAINLINE, "M", nullptr, nullptr, "Mainline");
 
-  insert_helper(ClientInfo::TYPE_COMPACT, "T", NULL, NULL, "BitTornado");
+  insert_helper(ClientInfo::TYPE_COMPACT, "T", nullptr, nullptr, "BitTornado");
 
   // Second batch of clients.
-  insert_helper(ClientInfo::TYPE_AZUREUS, "AR", NULL, NULL, "Arctic");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BB", NULL, NULL, "BitBuddy");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BX", NULL, NULL, "Bittorrent X");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BS", NULL, NULL, "BTSlave");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BT", NULL, NULL, "BBTor");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "CT", NULL, NULL, "CTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "DE", NULL, NULL, "DelugeTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "ES", NULL, NULL, "Electric Sheep");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "LP", NULL, NULL, "Lphant");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "MT", NULL, NULL, "MoonlightTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "MP", NULL, NULL, "MooPolice");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "QT", NULL, NULL, "Qt 4 Torrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "RT", NULL, NULL, "Retriever");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "SZ", NULL, NULL, "Shareaza");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "SS", NULL, NULL, "SwarmScope");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "SB", NULL, NULL, "Swiftbit");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "TN", NULL, NULL, "TorrentDotNET");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "TS", NULL, NULL, "Torrentstorm");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "TR", NULL, NULL, "Transmission");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "XT", NULL, NULL, "XanTorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "ZT", NULL, NULL, "ZipTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "AR", nullptr, nullptr, "Arctic");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BB", nullptr, nullptr, "BitBuddy");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BX", nullptr, nullptr, "Bittorrent X");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BS", nullptr, nullptr, "BTSlave");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BT", nullptr, nullptr, "BBTor");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "CT", nullptr, nullptr, "CTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "DE", nullptr, nullptr, "DelugeTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "ES", nullptr, nullptr, "Electric Sheep");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "LP", nullptr, nullptr, "Lphant");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "MT", nullptr, nullptr, "MoonlightTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "MP", nullptr, nullptr, "MooPolice");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "QT", nullptr, nullptr, "Qt 4 Torrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "RT", nullptr, nullptr, "Retriever");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "SZ", nullptr, nullptr, "Shareaza");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "SS", nullptr, nullptr, "SwarmScope");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "SB", nullptr, nullptr, "Swiftbit");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "TN", nullptr, nullptr, "TorrentDotNET");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "TS", nullptr, nullptr, "Torrentstorm");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "TR", nullptr, nullptr, "Transmission");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "XT", nullptr, nullptr, "XanTorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "ZT", nullptr, nullptr, "ZipTorrent");
 
-  insert_helper(ClientInfo::TYPE_COMPACT, "A", NULL, NULL, "ABC");
-  insert_helper(ClientInfo::TYPE_COMPACT, "S", NULL, NULL, "Shadow's client");
-  insert_helper(ClientInfo::TYPE_COMPACT, "U", NULL, NULL, "UPnP NAT BitTorrent");
-  insert_helper(ClientInfo::TYPE_COMPACT, "O", NULL, NULL, "Osprey Permaseed");
+  insert_helper(ClientInfo::TYPE_COMPACT, "A", nullptr, nullptr, "ABC");
+  insert_helper(ClientInfo::TYPE_COMPACT, "S", nullptr, nullptr, "Shadow's client");
+  insert_helper(ClientInfo::TYPE_COMPACT, "U", nullptr, nullptr, "UPnP NAT BitTorrent");
+  insert_helper(ClientInfo::TYPE_COMPACT, "O", nullptr, nullptr, "Osprey Permaseed");
 
   // Third batch of clients.
-  insert_helper(ClientInfo::TYPE_AZUREUS, "AX", NULL, NULL, "BitPump");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BF", NULL, NULL, "BitFlu");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BG", NULL, NULL, "BTG");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "BR", NULL, NULL, "BitRocket");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "EB", NULL, NULL, "EBit");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "HL", NULL, NULL, "Halite");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "qB", NULL, NULL, "qBittorrent");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "UL", NULL, NULL, "uLeecher!");
-  insert_helper(ClientInfo::TYPE_AZUREUS, "XL", NULL, NULL, "XeiLun");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "AX", nullptr, nullptr, "BitPump");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BF", nullptr, nullptr, "BitFlu");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BG", nullptr, nullptr, "BTG");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "BR", nullptr, nullptr, "BitRocket");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "EB", nullptr, nullptr, "EBit");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "HL", nullptr, nullptr, "Halite");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "qB", nullptr, nullptr, "qBittorrent");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "UL", nullptr, nullptr, "uLeecher!");
+  insert_helper(ClientInfo::TYPE_AZUREUS, "XL", nullptr, nullptr, "XeiLun");
 
-  insert_helper(ClientInfo::TYPE_COMPACT, "R", NULL, NULL, "Tribler");
+  insert_helper(ClientInfo::TYPE_COMPACT, "R", nullptr, nullptr, "Tribler");
 }
 
 ClientList::~ClientList() {
@@ -128,17 +128,17 @@ ClientList::insert(ClientInfo::id_type type, const char* key, const char* versio
 
   std::memset(clientInfo.mutable_key(), 0, ClientInfo::max_key_size);
 
-  if (key == NULL)
+  if (key == nullptr)
     std::memset(clientInfo.mutable_key(), 0, ClientInfo::max_key_size);
   else
     std::strncpy(clientInfo.mutable_key(), key, ClientInfo::max_key_size);
     
-  if (version != NULL)
+  if (version != nullptr)
     std::memcpy(clientInfo.mutable_version(), version, ClientInfo::max_version_size);
   else
     std::memset(clientInfo.mutable_version(), 0, ClientInfo::max_version_size);
 
-  if (upperVersion != NULL)
+  if (upperVersion != nullptr)
     std::memcpy(clientInfo.mutable_upper_version(), upperVersion, ClientInfo::max_version_size);
   else
     std::memset(clientInfo.mutable_upper_version(), -1, ClientInfo::max_version_size);

--- a/src/torrent/peer/connection_list.cc
+++ b/src/torrent/peer/connection_list.cc
@@ -79,7 +79,7 @@ ConnectionList::clear() {
 
 bool
 ConnectionList::want_connection(PeerInfo* p, Bitfield* bitfield) {
-  if (m_download->file_list()->is_done() || m_download->initial_seeding() != NULL)
+  if (m_download->file_list()->is_done() || m_download->initial_seeding() != nullptr)
     return !bitfield->is_all_set();
 
   if (!m_download->info()->is_accepting_seeders())
@@ -91,12 +91,12 @@ ConnectionList::want_connection(PeerInfo* p, Bitfield* bitfield) {
 PeerConnectionBase*
 ConnectionList::insert(PeerInfo* peerInfo, const SocketFd& fd, Bitfield* bitfield, EncryptionInfo* encryptionInfo, ProtocolExtension* extensions) {
   if (size() >= m_maxSize)
-    return NULL;
+    return nullptr;
 
   PeerConnectionBase* peerConnection = m_slotNewConnection(encryptionInfo->is_encrypted());
 
-  if (peerConnection == NULL || bitfield == NULL)
-    throw internal_error("ConnectionList::insert(...) received a NULL pointer.");
+  if (peerConnection == nullptr || bitfield == nullptr)
+    throw internal_error("ConnectionList::insert(...) received a nullptr pointer.");
 
   peerInfo->set_connection(peerConnection);
   peerInfo->set_last_connection(cachedTime.seconds());
@@ -104,7 +104,7 @@ ConnectionList::insert(PeerInfo* peerInfo, const SocketFd& fd, Bitfield* bitfiel
 
   if (!peerConnection->get_fd().is_valid()) {
     delete peerConnection;
-    return NULL;
+    return nullptr;
   }
 
   base_type::push_back(peerConnection);
@@ -140,7 +140,7 @@ ConnectionList::erase(iterator pos, int flags) {
 
   // Before of after the signal?
   peerConnection->cleanup();
-  peerConnection->mutable_peer_info()->set_connection(NULL);
+  peerConnection->mutable_peer_info()->set_connection(nullptr);
 
   m_download->peer_list()->disconnected(peerConnection->mutable_peer_info(), PeerList::disconnect_set_time);
 

--- a/src/torrent/peer/peer.cc
+++ b/src/torrent/peer/peer.cc
@@ -80,14 +80,14 @@ uint32_t Peer::chunks_done() const         { return c_ptr()->c_peer_chunks()->bi
 
 const BlockTransfer*
 Peer::transfer() const {
-  if (c_ptr()->request_list()->transfer() != NULL)
+  if (c_ptr()->request_list()->transfer() != nullptr)
     return c_ptr()->request_list()->transfer();
 
   else if (!c_ptr()->request_list()->queued_empty())
     return c_ptr()->request_list()->queued_front();
 
   else
-    return NULL;
+    return nullptr;
 }
 
 void

--- a/src/torrent/peer/peer_info.cc
+++ b/src/torrent/peer/peer_info.cc
@@ -60,7 +60,7 @@ PeerInfo::PeerInfo(const sockaddr* address) :
   m_lastHandshake(0),
   m_listenPort(0),
 
-  m_connection(NULL)
+  m_connection(nullptr)
 {
   rak::socket_address* sa = new rak::socket_address();
   *sa = *rak::socket_address::cast_from(address);

--- a/src/torrent/peer/peer_list.cc
+++ b/src/torrent/peer/peer_list.cc
@@ -108,7 +108,7 @@ PeerList::~PeerList() {
   std::for_each(begin(), end(), rak::on(rak::mem_ref(&value_type::second), rak::call_delete<PeerInfo>()));
   base_type::clear();
 
-  m_info = NULL;
+  m_info = nullptr;
   delete m_available_list;
 }
 
@@ -126,7 +126,7 @@ PeerList::insert_address(const sockaddr* sa, int flags) {
   if (sock_key.is_valid() &&
       !socket_address_key::is_comparable_sockaddr(sa)) {
     LT_LOG_EVENTS("address not comparable", 0);
-    return NULL;
+    return nullptr;
   }
 
   const rak::socket_address* address = rak::socket_address::cast_from(sa);
@@ -141,7 +141,7 @@ PeerList::insert_address(const sockaddr* sa, int flags) {
   if (range.first != range.second) {
     LT_LOG_EVENTS("address already exists " LT_LOG_SA_FMT,
                   address->address_str().c_str(), address->port());
-    return NULL;
+    return nullptr;
   }
 
   PeerInfo* peerInfo = new PeerInfo(sa);
@@ -224,7 +224,7 @@ PeerList::insert_available(const void* al) {
       if (peerInfo->listen_port() == 0)
         peerInfo->set_port(itr->port());
 
-      if (peerInfo->connection() != NULL ||
+      if (peerInfo->connection() != nullptr ||
           peerInfo->last_handshake() + 600 > (uint32_t)cachedTime.seconds()) {
         updated++;
         continue;
@@ -266,7 +266,7 @@ PeerList::connected(const sockaddr* sa, int flags) {
 
   if (!sock_key.is_valid() ||
       !socket_address_key::is_comparable_sockaddr(sa))
-    return NULL;
+    return nullptr;
 
   uint32_t host_byte_order_ipv4_addr = address->sa_inet()->address_h();
   int filter_value = 0;
@@ -285,7 +285,7 @@ PeerList::connected(const sockaddr* sa, int flags) {
 
     lt_log_print(LOG_PEER_INFO, "Peer %s is unwanted: preventing connection", ipv4_str);
 
-    return NULL;
+    return nullptr;
   }
 
   PeerInfo* peerInfo;
@@ -315,12 +315,12 @@ PeerList::connected(const sockaddr* sa, int flags) {
         rak::socket_address::cast_from(range.first->second->socket_address())->port() != address->port())
       m_available_list->buffer()->push_back(*address);
 
-    return NULL;
+    return nullptr;
   }
 
   if (flags & connect_filter_recent &&
       peerInfo->last_handshake() + 600 > (uint32_t)cachedTime.seconds())
-    return NULL;
+    return nullptr;
 
   if (!(flags & connect_incoming))
     peerInfo->set_listen_port(address->port());

--- a/src/torrent/poll_epoll.cc
+++ b/src/torrent/poll_epoll.cc
@@ -120,7 +120,7 @@ PollEPoll::create(int maxOpenSockets) {
   int fd = epoll_create(maxOpenSockets);
 
   if (fd == -1)
-    return NULL;
+    return nullptr;
 
   return new PollEPoll(fd, 1024, maxOpenSockets);
 }
@@ -169,23 +169,23 @@ PollEPoll::perform() {
 
     Table::iterator evItr = m_table.begin() + itr->data.fd;
 
-    // Each branch must check for data.ptr != NULL to allow the socket
+    // Each branch must check for data.ptr != nullptr to allow the socket
     // to remove itself between the calls.
     //
     // TODO: Make it so that it checks that read/write is wanted, that
     // it wasn't removed from one of them but not closed.
 
-    if (itr->events & EPOLLERR && evItr->second != NULL && evItr->first & EPOLLERR) {
+    if (itr->events & EPOLLERR && evItr->second != nullptr && evItr->first & EPOLLERR) {
       count++;
       evItr->second->event_error();
     }
 
-    if (itr->events & EPOLLIN && evItr->second != NULL && evItr->first & EPOLLIN) {
+    if (itr->events & EPOLLIN && evItr->second != nullptr && evItr->first & EPOLLIN) {
       count++;
       evItr->second->event_read();
     }
 
-    if (itr->events & EPOLLOUT && evItr->second != NULL && evItr->first & EPOLLOUT) {
+    if (itr->events & EPOLLOUT && evItr->second != nullptr && evItr->first & EPOLLOUT) {
       count++;
       evItr->second->event_write();
     }
@@ -338,7 +338,7 @@ PollEPoll::remove_error(Event* event) {
 
 #else // USE_EPOLL
 
-PollEPoll* PollEPoll::create(int maxOpenSockets) { return NULL; }
+PollEPoll* PollEPoll::create(int maxOpenSockets) { return nullptr; }
 PollEPoll::~PollEPoll() {}
 
 int PollEPoll::poll(int msec) { throw internal_error("An PollEPoll function was called, but it is disabled."); }

--- a/src/torrent/poll_kqueue.cc
+++ b/src/torrent/poll_kqueue.cc
@@ -102,7 +102,7 @@ PollKQueue::modify(Event* event, unsigned short op, short mask) {
 
   // Flush the changed filters to the kernel if the buffer is full.
   if (m_changedEvents == m_maxEvents) {
-    if (kevent(m_fd, m_changes, m_changedEvents, NULL, 0, NULL) == -1)
+    if (kevent(m_fd, m_changes, m_changedEvents, nullptr, 0, nullptr) == -1)
       throw internal_error("PollKQueue::modify() error: " + std::string(rak::error_number::current().c_str()));
 
     m_changedEvents = 0;
@@ -119,7 +119,7 @@ PollKQueue::create(int maxOpenSockets) {
   int fd = kqueue();
 
   if (fd == -1)
-    return NULL;
+    return nullptr;
 
   return new PollKQueue(fd, 1024, maxOpenSockets);
 }
@@ -129,7 +129,7 @@ PollKQueue::PollKQueue(int fd, int maxEvents, int maxOpenSockets) :
   m_maxEvents(maxEvents),
   m_waitingEvents(0),
   m_changedEvents(0),
-  m_stdinEvent(NULL) {
+  m_stdinEvent(nullptr) {
 
   m_events = new struct kevent[m_maxEvents];
   m_changes = new struct kevent[maxOpenSockets];
@@ -148,7 +148,7 @@ PollKQueue::~PollKQueue() {
 int
 PollKQueue::poll(int msec) {
 #if KQUEUE_SOCKET_ONLY
-  if (m_stdinEvent != NULL) {
+  if (m_stdinEvent != nullptr) {
     // Flush all changes to the kqueue poll before we start select
     // polling, so that they get included.
     if (m_changedEvents != 0)
@@ -201,7 +201,7 @@ PollKQueue::poll_select(int msec) {
   FD_SET(0,    readSet);
   FD_SET(m_fd, readSet);
 
-  int nfds = select(m_fd + 1, readSet, NULL, NULL, &selectTimeout);
+  int nfds = select(m_fd + 1, readSet, nullptr, nullptr, &selectTimeout);
 
   if (nfds == -1)
     return nfds;
@@ -230,7 +230,7 @@ PollKQueue::perform() {
 
     Table::iterator evItr = m_table.begin() + itr->ident;
 
-    if ((itr->flags & EV_ERROR) && evItr->second != NULL) {
+    if ((itr->flags & EV_ERROR) && evItr->second != nullptr) {
       if (evItr->first & flag_error)
         evItr->second->event_error();
 
@@ -240,12 +240,12 @@ PollKQueue::perform() {
 
     // Also check current mask.
 
-    if (itr->filter == EVFILT_READ && evItr->second != NULL && evItr->first & flag_read) {
+    if (itr->filter == EVFILT_READ && evItr->second != nullptr && evItr->first & flag_read) {
       count++;
       evItr->second->event_read();
     }
 
-    if (itr->filter == EVFILT_WRITE && evItr->second != NULL && evItr->first & flag_write) {
+    if (itr->filter == EVFILT_WRITE && evItr->second != nullptr && evItr->first & flag_write) {
       count++;
       evItr->second->event_write();
     }
@@ -302,7 +302,7 @@ PollKQueue::close(Event* event) {
 
 #if KQUEUE_SOCKET_ONLY
   if (event->file_descriptor() == 0) {
-    m_stdinEvent = NULL;
+    m_stdinEvent = nullptr;
     return;
   }
 #endif
@@ -315,7 +315,7 @@ PollKQueue::close(Event* event) {
   // Shouldn't be needed anymore.
   for (struct kevent *itr = m_events, *last = m_events + m_waitingEvents; itr != last; ++itr)
     if (itr->udata == event)
-      itr->udata = NULL;
+      itr->udata = nullptr;
 
   m_changedEvents = std::remove_if(m_changes, m_changes + m_changedEvents,
                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
@@ -327,7 +327,7 @@ PollKQueue::closed(Event* event) {
 
 #if KQUEUE_SOCKET_ONLY
   if (event->file_descriptor() == 0) {
-    m_stdinEvent = NULL;
+    m_stdinEvent = nullptr;
     return;
   }
 #endif
@@ -341,7 +341,7 @@ PollKQueue::closed(Event* event) {
   // Shouldn't be needed anymore.
   for (struct kevent *itr = m_events, *last = m_events + m_waitingEvents; itr != last; ++itr)
     if (itr->udata == event)
-      itr->udata = NULL;
+      itr->udata = nullptr;
 
   m_changedEvents = std::remove_if(m_changes, m_changes + m_changedEvents,
                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
@@ -407,7 +407,7 @@ PollKQueue::remove_read(Event* event) {
 
 #if KQUEUE_SOCKET_ONLY
   if (event->file_descriptor() == 0) {
-    m_stdinEvent = NULL;
+    m_stdinEvent = nullptr;
     return;
   }
 #endif
@@ -434,7 +434,7 @@ PollKQueue::remove_error(Event* event) {
 
 PollKQueue*
 PollKQueue::create(__UNUSED int maxOpenSockets) {
-  return NULL;
+  return nullptr;
 }
 
 PollKQueue::~PollKQueue() {

--- a/src/torrent/poll_select.cc
+++ b/src/torrent/poll_select.cc
@@ -68,7 +68,7 @@ struct poll_check_t {
   bool operator () (Event* s) {
     // This check is nessesary as other events may remove a socket
     // from the set.
-    if (s == NULL)
+    if (s == nullptr)
       return false;
 
     // This check is not nessesary, just for debugging.
@@ -106,8 +106,8 @@ struct poll_mark {
 
   void operator () (Event* s) {
     // Neither of these checks are nessesary, just for debugging.
-    if (s == NULL)
-      throw internal_error("poll_mark: s == NULL");
+    if (s == nullptr)
+      throw internal_error("poll_mark: s == nullptr");
 
     if (s->file_descriptor() < 0)
       throw internal_error("poll_mark: s->fd < 0");
@@ -176,7 +176,7 @@ PollSelect::~PollSelect() {
 //   delete m_writeSet;
 //   delete m_exceptSet;
 
-  m_readSet = m_writeSet = m_exceptSet = NULL;
+  m_readSet = m_writeSet = m_exceptSet = nullptr;
 }
 
 uint32_t

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -93,7 +93,7 @@ calculate_reserved(uint32_t openMax) {
 
 void
 initialize() {
-  if (manager != NULL)
+  if (manager != nullptr)
     throw internal_error("torrent::initialize(...) called but the library has already been initialized");
 
   cachedTime = rak::timer::current();
@@ -116,18 +116,18 @@ initialize() {
 // them to finish is not required, but recommended.
 void
 cleanup() {
-  if (manager == NULL)
+  if (manager == nullptr)
     throw internal_error("torrent::cleanup() called but the library is not initialized.");
 
   manager->main_thread_disk()->stop_thread_wait();
 
   delete manager;
-  manager = NULL;
+  manager = nullptr;
 }
 
 bool
 is_inactive() {
-  return manager == NULL ||
+  return manager == nullptr ||
     std::find_if(manager->download_manager()->begin(), manager->download_manager()->end(), std::not1(std::mem_fun(&DownloadWrapper::is_stopped)))
     == manager->download_manager()->end();
 }

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -552,7 +552,7 @@ TrackerController::receive_failure(Tracker* tb, const std::string& msg) {
     return;
   }
 
-  if (tb == NULL) {
+  if (tb == nullptr) {
     LT_LOG_TRACKER(INFO, "Received failure msg:'%s'.", msg.c_str());
     m_slot_failure(msg);
     return;

--- a/src/torrent/tracker_list.cc
+++ b/src/torrent/tracker_list.cc
@@ -58,7 +58,7 @@
 namespace torrent {
 
 TrackerList::TrackerList() :
-  m_info(NULL),
+  m_info(nullptr),
   m_state(DownloadInfo::STOPPED),
 
   m_key(0),

--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -39,7 +39,7 @@
 #include "directory_events.h"
 
 #include <string>
-#include <errno.h>
+#include <cerrno>
 #include <unistd.h>
 
 #ifdef HAVE_INOTIFY

--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -45,9 +45,9 @@
 #include "torrent/exceptions.h"
 #include "torrent/hash_string.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
 #include <zlib.h>
 
 #include <algorithm>
@@ -65,7 +65,7 @@ struct log_cache_entry {
   bool equal_outputs(const outputs_type& out) const { return out == outputs; }
 
   void allocate(unsigned int count) { cache_first = new log_slot[count]; cache_last = cache_first + count; }
-  void clear()                      { delete [] cache_first; cache_first = NULL; cache_last = NULL; }
+  void clear()                      { delete [] cache_first; cache_first = nullptr; cache_last = nullptr; }
 
   outputs_type outputs;
   log_slot*    cache_first;
@@ -74,7 +74,7 @@ struct log_cache_entry {
 
 struct log_gz_output {
   log_gz_output(const char* filename) { gz_file = gzopen(filename, "w"); }
-  ~log_gz_output() { if (gz_file != NULL) gzclose(gz_file); }
+  ~log_gz_output() { if (gz_file != nullptr) gzclose(gz_file); }
 
   bool is_valid() { return gz_file != Z_NULL; }
 
@@ -141,7 +141,7 @@ log_rebuild_cache() {
     const log_group::outputs_type& use_outputs = log_groups[idx].cached_outputs();
 
     if (use_outputs == 0) {
-      log_groups[idx].set_cached(NULL, NULL);
+      log_groups[idx].set_cached(nullptr, nullptr);
       continue;
     }
 
@@ -173,8 +173,8 @@ log_group::internal_print(const HashString* hash, const char* subsystem, const v
   char buffer[buffer_size];
   char* first = buffer;
 
-  if (subsystem != NULL) {
-    if (hash != NULL) {
+  if (subsystem != nullptr) {
+    if (hash != nullptr) {
       first = hash_string_to_hex(*hash, first);
       first += snprintf(first, 4096 - (first - buffer), "->%s: ", subsystem);
     } else {
@@ -197,7 +197,7 @@ log_group::internal_print(const HashString* hash, const char* subsystem, const v
                                            (const char*)buffer,
                                            std::distance(buffer, first),
                                            std::distance(log_groups.begin(), this)));
-  if (dump_data != NULL) {
+  if (dump_data != nullptr) {
     std::for_each(m_first, m_last, std::bind(&log_slot::operator(),
                                              std::placeholders::_1,
                                              (const char*)dump_data,

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -146,23 +146,23 @@ enum {
 
 #define lt_log_print(log_group, ...)                                    \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(NULL, NULL, NULL, 0, __VA_ARGS__);
+    torrent::log_groups[log_group].internal_print(nullptr, nullptr, nullptr, 0, __VA_ARGS__);
 
 #define lt_log_print_info(log_group, log_info, log_subsystem, ...)      \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(&log_info->hash(), log_subsystem, NULL, 0, __VA_ARGS__);
+    torrent::log_groups[log_group].internal_print(&log_info->hash(), log_subsystem, nullptr, 0, __VA_ARGS__);
 
 #define lt_log_print_data(log_group, log_data, log_subsystem, ...)      \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(&log_data->hash(), log_subsystem, NULL, 0, __VA_ARGS__);
+    torrent::log_groups[log_group].internal_print(&log_data->hash(), log_subsystem, nullptr, 0, __VA_ARGS__);
 
 #define lt_log_print_dump(log_group, log_dump_data, log_dump_size, ...) \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(NULL, NULL, log_dump_data, log_dump_size, __VA_ARGS__); \
+    torrent::log_groups[log_group].internal_print(nullptr, nullptr, log_dump_data, log_dump_size, __VA_ARGS__); \
 
 #define lt_log_print_hash(log_group, log_hash, log_subsystem, ...)      \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(&log_hash, log_subsystem, NULL, 0, __VA_ARGS__);
+    torrent::log_groups[log_group].internal_print(&log_hash, log_subsystem, nullptr, 0, __VA_ARGS__);
 
 #define lt_log_print_info_dump(log_group, log_dump_data, log_dump_size, log_info, log_subsystem, ...) \
   if (torrent::log_groups[log_group].valid())                           \
@@ -170,7 +170,7 @@ enum {
 
 #define lt_log_print_subsystem(log_group, log_subsystem, ...)           \
   if (torrent::log_groups[log_group].valid())                           \
-    torrent::log_groups[log_group].internal_print(NULL, log_subsystem, NULL, 0, __VA_ARGS__);
+    torrent::log_groups[log_group].internal_print(nullptr, log_subsystem, nullptr, 0, __VA_ARGS__);
 
 class log_buffer;
 
@@ -180,13 +180,13 @@ class LIBTORRENT_EXPORT log_group {
 public:
   typedef std::bitset<64> outputs_type;
 
-  log_group() : m_first(NULL), m_last(NULL) {
+  log_group() : m_first(nullptr), m_last(nullptr) {
     m_outputs.reset();
     m_cached_outputs.reset();
   }
 
-  bool                valid() const { return m_first != NULL; }
-  bool                empty() const { return m_first == NULL; }
+  bool                valid() const { return m_first != nullptr; }
+  bool                empty() const { return m_first == nullptr; }
 
   size_t              size_outputs() const { return std::distance(m_first, m_last); }
 

--- a/src/torrent/utils/log_buffer.h
+++ b/src/torrent/utils/log_buffer.h
@@ -77,7 +77,7 @@ public:
   using base_type::empty;
   using base_type::size;
 
-  log_buffer() : m_max_size(200) { pthread_mutex_init(&m_lock, NULL); }
+  log_buffer() : m_max_size(200) { pthread_mutex_init(&m_lock, nullptr); }
 
   unsigned int        max_size() const { return m_max_size; }
   

--- a/src/torrent/utils/net.cc
+++ b/src/torrent/utils/net.cc
@@ -50,8 +50,8 @@ address_info_lookup(const char* hostname, int family, int socktype) {
   hints.ai_family = family;
   hints.ai_socktype = socktype;
   
-  addrinfo* res = NULL;
-  int err = ::getaddrinfo(hostname, NULL, &hints, &res);
+  addrinfo* res = nullptr;
+  int err = ::getaddrinfo(hostname, nullptr, &hints, &res);
 
   if (err)
     throw address_info_error(err);
@@ -61,7 +61,7 @@ address_info_lookup(const char* hostname, int family, int socktype) {
 
 bool
 address_info_call(addrinfo* ai, int flags, slot_ai_success slot_success) {
-  while (ai != NULL) {
+  while (ai != nullptr) {
     slot_success(ai->ai_addr, ai->ai_addrlen);
     return true;
   }

--- a/src/torrent/utils/option_strings.cc
+++ b/src/torrent/utils/option_strings.cc
@@ -67,7 +67,7 @@ option_pair option_list_connection[] = {
   { "seed",         Download::CONNECTION_SEED },
   { "initial_seed", Download::CONNECTION_INITIAL_SEED },
   { "metadata",     Download::CONNECTION_METADATA },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_heuristics[] = {
@@ -76,19 +76,19 @@ option_pair option_list_heuristics[] = {
   { "upload_seed",               choke_queue::HEURISTICS_UPLOAD_SEED },
   { "download_leech",            choke_queue::HEURISTICS_DOWNLOAD_LEECH },
   { "invalid",                   choke_queue::HEURISTICS_MAX_SIZE },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_heuristics_download[] = {
   { "download_leech",            choke_queue::HEURISTICS_DOWNLOAD_LEECH },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_heuristics_upload[] = {
   { "upload_leech",              choke_queue::HEURISTICS_UPLOAD_LEECH },
   { "upload_leech_experimental", choke_queue::HEURISTICS_UPLOAD_LEECH_EXPERIMENTAL },
   { "upload_seed",               choke_queue::HEURISTICS_UPLOAD_SEED },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_encryption[] = {
@@ -100,13 +100,13 @@ option_pair option_list_encryption[] = {
   { "require_rc4",      torrent::ConnectionManager::encryption_require_RC4 },
   { "enable_retry",     torrent::ConnectionManager::encryption_enable_retry },
   { "prefer_plaintext", torrent::ConnectionManager::encryption_prefer_plaintext },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_ip_filter[] = {
   { "unwanted",  PeerInfo::flag_unwanted },
   { "preferred", PeerInfo::flag_preferred },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_ip_tos[] = {
@@ -115,13 +115,13 @@ option_pair option_list_ip_tos[] = {
   { "throughput",  torrent::ConnectionManager::iptos_throughput },
   { "reliability", torrent::ConnectionManager::iptos_reliability },
   { "mincost",     torrent::ConnectionManager::iptos_mincost },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 option_pair option_list_tracker_mode[] = {
   { "normal",     choke_group::TRACKER_MODE_NORMAL },
   { "aggressive", choke_group::TRACKER_MODE_AGGRESSIVE },
-  { NULL, 0 }
+  { nullptr, 0 }
 };
 
 const char* option_list_log_group[] = {
@@ -216,7 +216,7 @@ const char* option_list_log_group[] = {
 
   "ui_events",
 
-  NULL
+  nullptr
 };
 
 const char* option_list_tracker_event[] = {
@@ -226,7 +226,7 @@ const char* option_list_tracker_event[] = {
   "stopped",
   "scrape",
 
-  NULL
+  nullptr
 };
 
 option_pair* option_pair_lists[OPTION_START_COMPACT] = {
@@ -256,7 +256,7 @@ option_find_string(option_enum opt_enum, const char* name) {
     do {
       if (std::strcmp(itr->name, name) == 0)
         return itr->value;
-    } while ((++itr)->name != NULL);
+    } while ((++itr)->name != nullptr);
 
   } else if (opt_enum < OPTION_MAX_SIZE) {
     const char** itr = option_single_lists[opt_enum - OPTION_START_COMPACT].name;
@@ -264,7 +264,7 @@ option_find_string(option_enum opt_enum, const char* name) {
     do {
       if (std::strcmp(*itr, name) == 0)
         return std::distance(option_single_lists[opt_enum - OPTION_START_COMPACT].name, itr);
-    } while (*++itr != NULL);
+    } while (*++itr != nullptr);
   }
 
   throw input_error("Invalid option name.");  
@@ -278,7 +278,7 @@ option_as_string(option_enum opt_enum, unsigned int value) {
     do {
       if (itr->value == value)
         return itr->name;
-    } while ((++itr)->name != NULL);
+    } while ((++itr)->name != nullptr);
 
   } else if (opt_enum < OPTION_MAX_SIZE) {
     if (value < option_single_lists[opt_enum - OPTION_START_COMPACT].size)
@@ -295,13 +295,13 @@ option_list_strings(option_enum opt_enum) {
   if (opt_enum < OPTION_START_COMPACT) {
     option_pair* itr = option_pair_lists[opt_enum];
 
-    while (itr->name != NULL)
+    while (itr->name != nullptr)
       result.push_back(std::string(itr++->name));
 
   } else if (opt_enum < OPTION_MAX_SIZE) {
     const char** itr = option_single_lists[opt_enum - OPTION_START_COMPACT].name;
   
-    while (*itr != NULL) result.push_back(std::string(*itr++));
+    while (*itr != nullptr) result.push_back(std::string(*itr++));
   }
 
   return Object::from_list(result);

--- a/src/torrent/utils/resume.cc
+++ b/src/torrent/utils/resume.cc
@@ -495,7 +495,7 @@ resume_load_addresses(Download download, const Object& object) {
 
     PeerInfo* peerInfo = peerList->insert_address(socketAddress.c_sockaddr(), flags);
 
-    if (peerInfo == NULL)
+    if (peerInfo == nullptr)
       continue;
 
     peerInfo->set_failed_counter(itr->get_key_value("failed"));

--- a/src/torrent/utils/thread_base.cc
+++ b/src/torrent/utils/thread_base.cc
@@ -37,7 +37,7 @@
 #include "config.h"
 
 #include <cstring>
-#include <signal.h>
+#include <csignal>
 #include <unistd.h>
 
 #include "exceptions.h"

--- a/src/torrent/utils/thread_base.cc
+++ b/src/torrent/utils/thread_base.cc
@@ -56,9 +56,9 @@ thread_base::thread_base() :
   m_flags(0),
   m_instrumentation_index(INSTRUMENTATION_POLLING_DO_POLL_OTHERS - INSTRUMENTATION_POLLING_DO_POLL),
 
-  m_poll(NULL),
-  m_interrupt_sender(NULL),
-  m_interrupt_receiver(NULL)
+  m_poll(nullptr),
+  m_interrupt_sender(nullptr),
+  m_interrupt_receiver(nullptr)
 {
   std::memset(&m_thread, 0, sizeof(pthread_t));
 
@@ -77,10 +77,10 @@ thread_base::~thread_base() {
 
 void
 thread_base::start_thread() {
-  if (m_poll == NULL)
+  if (m_poll == nullptr)
     throw internal_error("No poll object for thread defined.");
 
-  if (!is_initialized() || pthread_create(&m_thread, NULL, (pthread_func)&thread_base::event_loop, this))
+  if (!is_initialized() || pthread_create(&m_thread, nullptr, (pthread_func)&thread_base::event_loop, this))
     throw internal_error("Failed to create thread.");
 }
 
@@ -188,7 +188,7 @@ thread_base::event_loop(thread_base* thread) {
   }
 
   __sync_lock_test_and_set(&thread->m_state, STATE_INACTIVE);
-  return NULL;
+  return nullptr;
 }
 
 }

--- a/src/tracker/tracker_dht.cc
+++ b/src/tracker/tracker_dht.cc
@@ -68,7 +68,7 @@ TrackerDht::TrackerDht(TrackerList* parent, const std::string& url, int flags) :
 
 TrackerDht::~TrackerDht() {
   if (is_busy())
-    manager->dht_manager()->router()->cancel_announce(NULL, this);
+    manager->dht_manager()->router()->cancel_announce(nullptr, this);
 }
 
 bool
@@ -83,7 +83,7 @@ TrackerDht::is_usable() const {
 
 void
 TrackerDht::send_state(int state) {
-  if (m_parent == NULL)
+  if (m_parent == nullptr)
     throw internal_error("TrackerDht::send_state(...) does not have a valid m_parent.");
 
   if (is_busy()) {

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -71,7 +71,7 @@ TrackerHttp::TrackerHttp(TrackerList* parent, const std::string& url, int flags)
   Tracker(parent, url, flags),
 
   m_get(Http::slot_factory()()),
-  m_data(NULL) {
+  m_data(nullptr) {
 
   m_get->signal_done().push_back(std::bind(&TrackerHttp::receive_done, this));
   m_get->signal_failed().push_back(std::bind(&TrackerHttp::receive_failed, this, std::placeholders::_1));
@@ -98,7 +98,7 @@ TrackerHttp::~TrackerHttp() {
 
 bool
 TrackerHttp::is_busy() const {
-  return m_data != NULL;
+  return m_data != nullptr;
 }
 
 void
@@ -116,7 +116,7 @@ void
 TrackerHttp::send_state(int state) {
   close_directly();
 
-  if (m_parent == NULL)
+  if (m_parent == nullptr)
     throw internal_error("TrackerHttp::send_state(...) does not have a valid m_parent.");
 
   m_latest_event = state;
@@ -206,7 +206,7 @@ TrackerHttp::send_state(int state) {
 
 void
 TrackerHttp::send_scrape() {
-  if (m_data != NULL)
+  if (m_data != nullptr)
     return;
 
   m_latest_event = EVENT_SCRAPE;
@@ -231,7 +231,7 @@ TrackerHttp::send_scrape() {
 
 void
 TrackerHttp::close() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     return;
 
   LT_LOG_TRACKER(DEBUG, "Tracker HTTP request cancelled: state:%s url:%s.",
@@ -242,7 +242,7 @@ TrackerHttp::close() {
 
 void
 TrackerHttp::disown() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     return;
 
   LT_LOG_TRACKER(DEBUG, "Tracker HTTP request disowned: state:%s url:%s.",
@@ -255,7 +255,7 @@ TrackerHttp::disown() {
 
   // Allocate this dynamically, so that we don't need to do this here.
   m_get = Http::slot_factory()();
-  m_data = NULL;
+  m_data = nullptr;
 }
 
 TrackerHttp::Type
@@ -265,19 +265,19 @@ TrackerHttp::type() const {
 
 void
 TrackerHttp::close_directly() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     return;
 
   m_get->close();
-  m_get->set_stream(NULL);
+  m_get->set_stream(nullptr);
 
   delete m_data;
-  m_data = NULL;
+  m_data = nullptr;
 }
 
 void
 TrackerHttp::receive_done() {
-  if (m_data == NULL)
+  if (m_data == nullptr)
     throw internal_error("TrackerHttp::receive_done() called on an invalid object");
 
   if (lt_log_is_valid(LOG_TRACKER_DEBUG)) {

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -70,17 +70,17 @@ TrackerUdp::TrackerUdp(TrackerList* parent, const std::string& url, int flags) :
 
   m_port(0),
 
-  m_slot_resolver(NULL),
-  m_readBuffer(NULL),
-  m_writeBuffer(NULL) {
+  m_slot_resolver(nullptr),
+  m_readBuffer(nullptr),
+  m_writeBuffer(nullptr) {
 
   m_taskTimeout.slot() = std::bind(&TrackerUdp::receive_timeout, this);
 }
 
 TrackerUdp::~TrackerUdp() {
-  if (m_slot_resolver != NULL) {
+  if (m_slot_resolver != nullptr) {
     *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
+    m_slot_resolver = nullptr;
   }
 
   close_directly();
@@ -107,9 +107,9 @@ TrackerUdp::send_state(int state) {
 
   // Because we can only remember one slot, set any pending resolves blocked
   // so that if this tracker is deleted, the member function won't be called.
-  if (m_slot_resolver != NULL) {
+  if (m_slot_resolver != nullptr) {
     *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
+    m_slot_resolver = nullptr;
   }
 
   m_slot_resolver = make_resolver_slot(hostname);
@@ -139,12 +139,12 @@ TrackerUdp::make_resolver_slot(const hostname_type& hostname) {
 
 void
 TrackerUdp::start_announce(const sockaddr* sa, int err) {
-  if (m_slot_resolver != NULL) {
+  if (m_slot_resolver != nullptr) {
     *m_slot_resolver = resolver_type();
-    m_slot_resolver = NULL;
+    m_slot_resolver = nullptr;
   }
 
-  if (sa == NULL)
+  if (sa == nullptr)
     return receive_failed("could not resolve hostname");
 
   m_connectAddress = *rak::socket_address::cast_from(sa);
@@ -208,8 +208,8 @@ TrackerUdp::close_directly() {
   delete m_readBuffer;
   delete m_writeBuffer;
 
-  m_readBuffer = NULL;
-  m_writeBuffer = NULL;
+  m_readBuffer = nullptr;
+  m_writeBuffer = nullptr;
 
   priority_queue_erase(&taskScheduler, &m_taskTimeout);
 

--- a/src/utils/sha_fast.cc
+++ b/src/utils/sha_fast.cc
@@ -40,7 +40,7 @@
  * GPL.
  */
 
-#include <string.h>
+#include <cstring>
 #include "sha_fast.h"
 
 namespace torrent {


### PR DESCRIPTION
nullptr is the C++11 replacement for NULL. Found with
-Wzero-as-null-pointer-constant .

Also changed a few C headers to use the C++ versions as the C headers
cause the same warning to be emitted.