### PR TITLE
Allow log files to be appended

### DIFF
--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -429,6 +429,19 @@ log_open_file_output(const char* name, const char* filename) {
 }
 
 void
+log_open_file_output_append(const char* name, const char* filename) {
+  std::shared_ptr<std::ofstream> outfile(new std::ofstream(filename, std::ofstream::out | std::ofstream::app));
+
+  if (!outfile->good())
+    throw input_error("Could not open log file '" + std::string(filename) + "'.");
+
+  log_open_output(name, std::bind(&log_file_write, outfile,
+                                  std::placeholders::_1,
+                                  std::placeholders::_2,
+                                  std::placeholders::_3));
+}
+
+void
 log_open_gz_file_output(const char* name, const char* filename) {
   std::shared_ptr<log_gz_output> outfile(new log_gz_output(filename));
 

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -237,9 +237,8 @@ void log_remove_group_output(int group, const char* name) LIBTORRENT_EXPORT;
 void log_add_child(int group, int child) LIBTORRENT_EXPORT;
 void log_remove_child(int group, int child) LIBTORRENT_EXPORT;
 
-void        log_open_file_output(const char* name, const char* filename) LIBTORRENT_EXPORT;
-void        log_open_file_output_append(const char* name, const char* filename) LIBTORRENT_EXPORT;
-void        log_open_gz_file_output(const char* name, const char* filename) LIBTORRENT_EXPORT;
+void        log_open_file_output(const char* name, const char* filename, bool append = false) LIBTORRENT_EXPORT;
+void        log_open_gz_file_output(const char* name, const char* filename, bool append = false) LIBTORRENT_EXPORT;
 log_buffer* log_open_log_buffer(const char* name) LIBTORRENT_EXPORT;
 
 //

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -238,6 +238,7 @@ void log_add_child(int group, int child) LIBTORRENT_EXPORT;
 void log_remove_child(int group, int child) LIBTORRENT_EXPORT;
 
 void        log_open_file_output(const char* name, const char* filename) LIBTORRENT_EXPORT;
+void        log_open_file_output_append(const char* name, const char* filename) LIBTORRENT_EXPORT;
 void        log_open_gz_file_output(const char* name, const char* filename) LIBTORRENT_EXPORT;
 log_buffer* log_open_log_buffer(const char* name) LIBTORRENT_EXPORT;
 

--- a/test/torrent/utils/log_test.cc
+++ b/test/torrent/utils/log_test.cc
@@ -155,3 +155,38 @@ utils_log_test::test_file_output() {
 
   CPPUNIT_ASSERT_MESSAGE(buffer, std::string(buffer).find("test_file") != std::string::npos);
 }
+
+void
+utils_log_test::test_file_output_append() {
+  std::string filename = "utils_log_test.XXXXXX";
+
+  mktemp(&*filename.begin());
+
+  torrent::log_open_file_output_append("test_file", filename.c_str());
+  torrent::log_add_group_output(GROUP_PARENT_1, "test_file");
+
+  lt_log_print(GROUP_PARENT_1, "test_line_1");
+
+  torrent::log_cleanup(); // To ensure we flush the buffers.
+
+  // re-open and write 2nd line
+  torrent::log_open_file_output_append("test_file", filename.c_str());
+  torrent::log_add_group_output(GROUP_PARENT_1, "test_file");
+
+  lt_log_print(GROUP_PARENT_1, "test_line_2");
+
+  torrent::log_cleanup(); // To ensure we flush the buffers.
+
+  std::ifstream temp_file(filename.c_str());
+
+  CPPUNIT_ASSERT(temp_file.good());
+
+  char buffer_line1[256];
+  temp_file.getline(buffer_line1, 256);
+
+  char buffer_line2[256];
+  temp_file.getline(buffer_line2, 256);
+
+  CPPUNIT_ASSERT_MESSAGE(buffer_line1, std::string(buffer_line1).find("test_line_1") != std::string::npos);
+  CPPUNIT_ASSERT_MESSAGE(buffer_line2, std::string(buffer_line2).find("test_line_2") != std::string::npos);
+}

--- a/test/torrent/utils/log_test.cc
+++ b/test/torrent/utils/log_test.cc
@@ -162,7 +162,7 @@ utils_log_test::test_file_output_append() {
 
   mktemp(&*filename.begin());
 
-  torrent::log_open_file_output_append("test_file", filename.c_str());
+  torrent::log_open_file_output("test_file", filename.c_str(), false);
   torrent::log_add_group_output(GROUP_PARENT_1, "test_file");
 
   lt_log_print(GROUP_PARENT_1, "test_line_1");
@@ -170,7 +170,7 @@ utils_log_test::test_file_output_append() {
   torrent::log_cleanup(); // To ensure we flush the buffers.
 
   // re-open and write 2nd line
-  torrent::log_open_file_output_append("test_file", filename.c_str());
+  torrent::log_open_file_output("test_file", filename.c_str(), true);
   torrent::log_add_group_output(GROUP_PARENT_1, "test_file");
 
   lt_log_print(GROUP_PARENT_1, "test_line_2");

--- a/test/torrent/utils/log_test.h
+++ b/test/torrent/utils/log_test.h
@@ -10,6 +10,7 @@ class utils_log_test : public CppUnit::TestFixture {
   CPPUNIT_TEST(test_print);
   CPPUNIT_TEST(test_children);
   CPPUNIT_TEST(test_file_output);
+  CPPUNIT_TEST(test_file_output_append);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -22,4 +23,5 @@ public:
   void test_print();
   void test_children();
   void test_file_output();
+  void test_file_output_append();
 };


### PR DESCRIPTION
Rather than current implentation of truncate/overwrite by default.

The only real difference from standard open_file is in the ofstream constructor. Added tests as well.

Makes using simple file names great again, and prevent rtorrent from overwriting all files on a restart. I also ran into a small issue when using logrotate.d and the copytruncate directive. After a log rotation had been performed, and when rtorrent began writing to file again, it wouuld be filled with null 0's up to the last position it had been written to. This would potentially solve that.