### PR TITLE
Replace usleep with C++11's sleep_for

### DIFF
--- a/src/data/hash_queue.cc
+++ b/src/data/hash_queue.cc
@@ -36,8 +36,9 @@
 
 #include "config.h"
 
+#include <chrono>
 #include <functional>
-#include <unistd.h>
+#include <thread>
 
 #include "torrent/exceptions.h"
 #include "torrent/data/download_data.h"
@@ -135,7 +136,7 @@ HashQueue::remove(HashQueueNode::id_type id) {
 
       while ((done_itr = m_done_chunks.find(hash_chunk)) == m_done_chunks.end()) {
         pthread_mutex_unlock(&m_done_chunks_lock);
-        usleep(100);
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
         pthread_mutex_lock(&m_done_chunks_lock);
       }
 

--- a/src/torrent/utils/thread_base.cc
+++ b/src/torrent/utils/thread_base.cc
@@ -1,8 +1,9 @@
 #include "config.h"
 
+#include <chrono>
 #include <cstring>
 #include <signal.h>
-#include <unistd.h>
+#include <thread>
 
 #include "torrent/exceptions.h"
 #include "torrent/poll.h"
@@ -60,7 +61,7 @@ thread_base::stop_thread_wait() {
   release_global_lock();
 
   while (!is_inactive()) {
-    usleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
   acquire_global_lock();
@@ -132,7 +133,7 @@ thread_base::event_loop(thread_base* thread) {
       }
 
       // Add the sleep call when testing interrupts, etc.
-      // usleep(50);
+      // std::this_thread::sleep_for(std::chrono::microseconds(50));
 
       int poll_flags = 0;
 


### PR DESCRIPTION
usleep is deprecated and replaced by nanosleep in POSIX 2008.

sleep_for is standard C++11 and internally uses nanosleep.