### PR TITLE
libtorrent.pc.in: add Libs.Private

### DIFF
--- a/libtorrent.pc.in
+++ b/libtorrent.pc.in
@@ -7,4 +7,5 @@ Name: libtorrent
 Description: A BitTorrent library
 Version: @VERSION@
 Libs: -L${libdir} -ltorrent
+Libs.Private: -lz
 Cflags: -I${includedir}


### PR DESCRIPTION
Add Libs.Private: -lz so applications that want to link statically with
libtorrent (such as rtorrent) will know that they must link with -lz

Fixes:
 - http://autobuild.buildroot.org/results/075598e1699c2ac20a4dfbcb5695bbb7343f9a86

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>