### PR TITLE
Fix for inotify missing quickly renamed files (rakshasa/rtorrent #936)

### DIFF
--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -154,8 +154,11 @@ directory_events::event_read() {
     wd_list::const_iterator itr = std::find_if(m_wd_list.begin(), m_wd_list.end(),
                                                std::bind(&watch_descriptor::compare_desc, std::placeholders::_1, event->wd));
 
-    if (itr != m_wd_list.end())
-      itr->slot(itr->path + event->name);
+    if (itr != m_wd_list.end()) {
+      std::string sname(event->name);
+      if((sname.substr(sname.find_last_of(".") ) == ".torrent"))
+        itr->slot(itr->path + event->name);
+    }
 
     event = (struct inotify_event*)(next_event);
   }


### PR DESCRIPTION
If a browser uses temporary files in the same folder as destination a inotify event occurs for the temporary file and is added by libtorrent before the rename happens. In this case when removing the torrent the file associated with it did not exist anymore. Sometimes the rename happened just before libtorrent wanted to add the temporary file. In that case the torrent was not added to downloads. This fix tells libtorrent to just add files ending in .torrent. Maybe a better fix would be to add a rename handler.