### PR TITLE
log: Fix format so GCC can check it

### DIFF
--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -16,6 +16,8 @@
 #include <functional>
 #include <memory>
 
+#define GROUPFMT (group >= LOG_NON_CASCADING) ? ("%" PRIi32 " ") : ("%" PRIi32 " %c ")
+
 namespace torrent {
 
 struct log_cache_entry {
@@ -356,9 +358,7 @@ log_gz_file_write(std::shared_ptr<log_gz_output>& outfile, const char* data, siz
 
   // Normal groups are nul-terminated strings.
   if (group >= 0) {
-    const char* fmt = (group >= LOG_NON_CASCADING) ? ("%" PRIi32 " ") : ("%" PRIi32 " %c ");
-
-    int buffer_length = snprintf(buffer, 64, fmt,
+    int buffer_length = snprintf(buffer, 64, GROUPFMT,
                                  cachedTime.seconds(),
                                  log_level_char[group % 6]);
     


### PR DESCRIPTION
const char *fmt is a variable, not a constant expression (it's not even constant).

Change to a define so GCC can check it properly.

I tried doing cute things with constexpr to avoid having a define, but everything I tried failed.

edit: This fixes -Werror=format=2