### PR TITLE
Fix all compiler warnings

### DIFF
--- a/rak/allocators.h
+++ b/rak/allocators.h
@@ -73,7 +73,7 @@ public:
 
   size_type max_size () const throw() { return std::numeric_limits<size_t>::max() / sizeof(T); }
 
-  pointer allocate(size_type num, const_void_pointer hint = 0) { return alloc_size(num*sizeof(T)); }
+  pointer allocate(size_type num, const_void_pointer = 0) { return alloc_size(num*sizeof(T)); }
 
   static pointer alloc_size(size_type size) {
     pointer ptr = NULL;
@@ -84,7 +84,7 @@ public:
 
   void construct (pointer p, const T& value) { new((void*)p)T(value); }
   void destroy (pointer p) { p->~T(); }
-  void deallocate (pointer p, size_type num) { free((void*)p); }
+  void deallocate (pointer p, size_type) { free((void*)p); }
 };
 
 

--- a/rak/priority_queue.h
+++ b/rak/priority_queue.h
@@ -126,8 +126,8 @@ public:
 
   typename container_type::const_reference operator * () { return m_queue->top(); }
 
-  bool operator != (const queue_pop_iterator& itr)       { return !m_queue->empty() && !m_compare(m_queue->top()); }
-  bool operator == (const queue_pop_iterator& itr)       { return m_queue->empty() || m_compare(m_queue->top()); }
+  bool operator != (const queue_pop_iterator&)       { return !m_queue->empty() && !m_compare(m_queue->top()); }
+  bool operator == (const queue_pop_iterator&)       { return m_queue->empty() || m_compare(m_queue->top()); }
 
 private:
   Queue*  m_queue;

--- a/rak/priority_queue_default.h
+++ b/rak/priority_queue_default.h
@@ -51,7 +51,7 @@ public:
   typedef std::function<void (void)> slot_void;
 
   priority_item() {}
-  ~priority_item() {
+  ~priority_item() noexcept(false) {
     if (is_queued())
       throw torrent::internal_error("priority_item::~priority_item() called on a queued item.");
 

--- a/rak/unordered_vector.h
+++ b/rak/unordered_vector.h
@@ -87,7 +87,7 @@ private:
 
 template <typename _Tp>
 typename unordered_vector<_Tp>::iterator
-unordered_vector<_Tp>::insert(iterator position, const value_type& x) {
+unordered_vector<_Tp>::insert(iterator, const value_type& x) {
   Base::push_back(x);
 
   return --end();

--- a/src/data/chunk.cc
+++ b/src/data/chunk.cc
@@ -50,7 +50,7 @@
 jmp_buf jmp_disk_full;
 
 void
-bus_handler(int sig, siginfo_t *si, void *vuctx)
+bus_handler(int, siginfo_t *si, void *)
 {
     if (si->si_code == BUS_ADRERR)
         longjmp(jmp_disk_full, 1);

--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -48,7 +48,9 @@
 #include <sys/types.h>
 
 #ifdef HAVE_FALLOCATE
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <linux/falloc.h>
 #endif
 

--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -610,7 +610,7 @@ DhtRouter::delete_node(const DhtNodeList::accessor& itr) {
 struct contact_node_t {
   contact_node_t(DhtRouter* router, int port) : m_router(router), m_port(port) { }
 
-  void operator() (const sockaddr* sa, int err)
+  void operator() (const sockaddr* sa, int)
     { if (sa != NULL) m_router->contact(rak::socket_address::cast_from(sa), m_port); }
 
   DhtRouter* m_router;

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -350,7 +350,7 @@ DhtServer::create_get_peers_response(const DhtMessage& req, const rak::socket_ad
 }
 
 void
-DhtServer::create_announce_peer_response(const DhtMessage& req, const rak::socket_address* sa, DhtMessage& reply) {
+DhtServer::create_announce_peer_response(const DhtMessage& req, const rak::socket_address* sa, DhtMessage&) {
   raw_string info_hash = req[key_a_infoHash].as_raw_string();
 
   if (info_hash.size() < HashString::size_data)
@@ -542,7 +542,7 @@ DhtServer::drop_packet(DhtTransactionPacket* packet) {
 }
 
 void
-DhtServer::create_query(transaction_itr itr, int tID, const rak::socket_address* sa, int priority) {
+DhtServer::create_query(transaction_itr itr, int tID, const rak::socket_address*, int priority) {
   if (itr->second->id() == m_router->id())
     throw internal_error("DhtServer::create_query trying to send to itself.");
 

--- a/src/dht/dht_transaction.cc
+++ b/src/dht/dht_transaction.cc
@@ -59,7 +59,7 @@ DhtSearch::DhtSearch(const HashString& target, const DhtBucket& contacts)
   add_contacts(contacts);
 }
 
-DhtSearch::~DhtSearch() {
+DhtSearch::~DhtSearch() noexcept(false) {
   // Make sure transactions were destructed first. Since it is the destruction
   // of a transaction that triggers this destructor, that should always be the 
   // case.
@@ -207,7 +207,7 @@ DhtSearch::node_status(const_accessor& n, bool success) {
   set_node_active(n, false);
 }
 
-DhtAnnounce::~DhtAnnounce() {
+DhtAnnounce::~DhtAnnounce() noexcept(false) {
   if (!complete())
     throw internal_error("DhtAnnounce::~DhtAnnounce called while announce not complete.");
 

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -99,7 +99,7 @@ public:
   static const unsigned int max_announce = 3;
 
   DhtSearch(const HashString& target, const DhtBucket& contacts);
-  virtual ~DhtSearch();
+  virtual ~DhtSearch() noexcept(false);
 
   // Wrapper for iterators, allowing more convenient access to the key
   // and element values, which also makes it easier to change the container
@@ -173,7 +173,7 @@ public:
   DhtAnnounce(const HashString& infoHash, TrackerDht* tracker, const DhtBucket& contacts)
     : DhtSearch(infoHash, contacts),
       m_tracker(tracker) { }
-  ~DhtAnnounce();
+  ~DhtAnnounce() noexcept(false);
 
   virtual bool         is_announce() const               { return true; }
 

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -234,6 +234,10 @@ public:
   char* data_end;
 };
 
+// See dht/dht_server.cc
+template <>
+const DhtMessage::key_list_type DhtMessage::base_type::keys;
+
 // Class holding transaction data to be transmitted.
 class DhtTransactionPacket {
 public:

--- a/src/download/chunk_statistics.cc
+++ b/src/download/chunk_statistics.cc
@@ -45,7 +45,7 @@
 namespace torrent {
 
 inline bool
-ChunkStatistics::should_add(PeerChunks* pc) {
+ChunkStatistics::should_add(PeerChunks*) {
   return m_accounted < max_accounted;
 }
 

--- a/src/net/local_addr.cc
+++ b/src/net/local_addr.cc
@@ -196,7 +196,7 @@ bool get_local_address(sa_family_t family, rak::socket_address *address) {
     }
 
     for (const nlmsghdr *nlmsg = (const nlmsghdr *)buf;
-         NLMSG_OK(nlmsg, ret);
+         NLMSG_OK(nlmsg, (unsigned int)ret);
          nlmsg = NLMSG_NEXT(nlmsg, ret)) {
       if (nlmsg->nlmsg_seq != seq_no)
         continue;

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -1038,7 +1038,7 @@ PeerConnectionBase::send_ext_message() {
 }
 
 void
-PeerConnectionBase::receive_metadata_piece(uint32_t piece, const char* data, uint32_t length) {
+PeerConnectionBase::receive_metadata_piece(uint32_t, const char*, uint32_t) {
 }
 
 }

--- a/src/protocol/peer_factory.cc
+++ b/src/protocol/peer_factory.cc
@@ -43,28 +43,28 @@
 namespace torrent {
 
 PeerConnectionBase*
-createPeerConnectionDefault(bool encrypted) {
+createPeerConnectionDefault(bool) {
   PeerConnectionBase* pc = new PeerConnection<Download::CONNECTION_LEECH>;
 
   return pc;
 }
 
 PeerConnectionBase*
-createPeerConnectionSeed(bool encrypted) {
+createPeerConnectionSeed(bool) {
   PeerConnectionBase* pc = new PeerConnection<Download::CONNECTION_SEED>;
 
   return pc;
 }
 
 PeerConnectionBase*
-createPeerConnectionInitialSeed(bool encrypted) {
+createPeerConnectionInitialSeed(bool) {
   PeerConnectionBase* pc = new PeerConnection<Download::CONNECTION_INITIAL_SEED>;
 
   return pc;
 }
 
 PeerConnectionBase*
-createPeerConnectionMetadata(bool encrypted) {
+createPeerConnectionMetadata(bool) {
   PeerConnectionBase* pc = new PeerConnectionMetadata;
 
   return pc;

--- a/src/protocol/request_list.cc
+++ b/src/protocol/request_list.cc
@@ -229,7 +229,7 @@ RequestList::downloading(const Piece& piece) {
     //
     // Alternatively, move back some elements to bucket_queued.
 
-    if (std::distance(m_queues.begin(itr.first), itr.second) < m_last_unordered_position)
+    if ((size_t)std::abs(std::distance(m_queues.begin(itr.first), itr.second)) < m_last_unordered_position)
       m_last_unordered_position--;
 
     m_transfer = m_queues.take(itr.first, itr.second);

--- a/src/torrent/bitfield.cc
+++ b/src/torrent/bitfield.cc
@@ -47,7 +47,7 @@
 namespace torrent {
 
 void
-Bitfield::set_size_bits(size_type s) {
+Bitfield::set_size_bits(size_type s) noexcept(false) {
   if (m_data != NULL)
     throw internal_error("Bitfield::set_size_bits(size_type s) m_data != NULL.");
 
@@ -55,7 +55,7 @@ Bitfield::set_size_bits(size_type s) {
 }
 
 void
-Bitfield::set_size_set(size_type s) {
+Bitfield::set_size_set(size_type s) noexcept(false) {
   if (s > m_size || m_data != NULL)
     throw internal_error("Bitfield::set_size_set(size_type s) s > m_size.");
 

--- a/src/torrent/chunk_manager.cc
+++ b/src/torrent/chunk_manager.cc
@@ -73,7 +73,7 @@ ChunkManager::ChunkManager() :
   m_maxMemoryUsage = (estimate_max_memory_usage() * 4) / 5;
 }
 
-ChunkManager::~ChunkManager() {
+ChunkManager::~ChunkManager() noexcept(false) {
   if (m_memoryUsage != 0 || m_memoryBlockCount != 0)
     throw internal_error("ChunkManager::~ChunkManager() m_memoryUsage != 0 || m_memoryBlockCount != 0.");
 }

--- a/src/torrent/chunk_manager.h
+++ b/src/torrent/chunk_manager.h
@@ -62,7 +62,7 @@ public:
   using base_type::empty;
 
   ChunkManager();
-  ~ChunkManager();
+  ~ChunkManager() noexcept(false);
   
   uint64_t            memory_usage() const                      { return m_memoryUsage; }
   uint64_t            sync_queue_memory_usage() const;

--- a/src/torrent/data/block.cc
+++ b/src/torrent/data/block.cc
@@ -51,7 +51,7 @@
 
 namespace torrent {
 
-Block::~Block() {
+Block::~Block() noexcept(false) {
   if (m_state != STATE_INCOMPLETE && m_state != STATE_COMPLETED)
     throw internal_error("Block dtor with 'm_state != STATE_INCOMPLETE && m_state != STATE_COMPLETED'");
 

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -62,7 +62,7 @@ public:
   } state_type;
 
   Block();
-  ~Block();
+  ~Block() noexcept(false);
 
   bool                      is_stalled() const                           { return m_notStalled == 0; }
   bool                      is_finished() const                          { return m_leader != NULL && m_leader->is_finished(); }

--- a/src/torrent/data/block_list.cc
+++ b/src/torrent/data/block_list.cc
@@ -45,7 +45,7 @@
 
 namespace torrent {
 
-BlockList::BlockList(const Piece& piece, uint32_t blockLength) :
+BlockList::BlockList(const Piece& piece, uint32_t blockLength) noexcept(false) :
   m_piece(piece),
   m_priority(PRIORITY_OFF),
   m_finished(0),

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -59,7 +59,7 @@ public:
   } state_type;
 
   BlockTransfer();
-  ~BlockTransfer();
+  ~BlockTransfer() noexcept(false);
 
   // TODO: Do we need to also check for peer_info?...
   bool                is_valid() const              { return m_block != NULL; }
@@ -124,7 +124,7 @@ BlockTransfer::BlockTransfer() :
 }
 
 inline
-BlockTransfer::~BlockTransfer() {
+BlockTransfer::~BlockTransfer() noexcept(false) {
   if (m_block != NULL)
     throw internal_error("BlockTransfer::~BlockTransfer() block not NULL");
 

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -72,7 +72,7 @@ public:
   bool                is_finished() const           { return m_position == m_piece.length(); }
 
   key_type            peer_info()                   { return m_peer_info; }
-  const key_type      const_peer_info() const       { return m_peer_info; }
+  key_type            const_peer_info() const       { return m_peer_info; }
 
   Block*              block()                       { return m_block; }
   const Block*        const_block() const           { return m_block; }

--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -75,7 +75,7 @@ File::File() :
   m_matchDepthNext(0) {
 }
 
-File::~File() {
+File::~File() noexcept(false) {
   if (is_open())
     throw internal_error("File::~File() called on an open file.");
 }

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -58,7 +58,7 @@ public:
   static const int flag_prioritize_last    = (1 << 6);
 
   File();
-  ~File();
+  ~File() noexcept(false);
 
   bool                is_created() const;
   bool                is_open() const                          { return m_fd != -1; }

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -602,7 +602,7 @@ FileList::create_chunk(uint64_t offset, uint32_t length, int prot) {
   if (offset + length > m_torrentSize)
     throw internal_error("Tried to access chunk out of range in FileList", data()->hash());
 
-  std::auto_ptr<Chunk> chunk(new Chunk);
+  std::unique_ptr<Chunk> chunk(new Chunk);
 
   for (iterator itr = std::find_if(begin(), end(), std::bind2nd(std::mem_fun(&File::is_valid_position), offset)); length != 0; ++itr) {
 

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -53,7 +53,7 @@ FileManager::FileManager() :
   m_filesClosedCounter(0),
   m_filesFailedCounter(0) {}
 
-FileManager::~FileManager() {
+FileManager::~FileManager() noexcept(false) {
   if (!empty())
     throw internal_error("FileManager::~FileManager() called but empty() != true.");
 }

--- a/src/torrent/data/file_manager.h
+++ b/src/torrent/data/file_manager.h
@@ -59,7 +59,7 @@ public:
   using base_type::rend;
 
   FileManager();
-  ~FileManager();
+  ~FileManager() noexcept(false);
 
   size_type           open_files() const              { return base_type::size(); }
 

--- a/src/torrent/data/transfer_list.cc
+++ b/src/torrent/data/transfer_list.cc
@@ -61,7 +61,7 @@ TransferList::TransferList() :
 
 // TODO: Derp if transfer list isn't cleared...
 
-TransferList::~TransferList() {
+TransferList::~TransferList() noexcept(false) {
   if (!base_type::empty())
     throw internal_error("TransferList::~TransferList() called on an non-empty object");
 }

--- a/src/torrent/data/transfer_list.h
+++ b/src/torrent/data/transfer_list.h
@@ -66,7 +66,7 @@ public:
   using base_type::rend;
 
   TransferList();
-  ~TransferList();
+  ~TransferList() noexcept(false);
 
   iterator            find(uint32_t index);
   const_iterator      find(uint32_t index) const;

--- a/src/torrent/download/choke_queue.cc
+++ b/src/torrent/download/choke_queue.cc
@@ -70,7 +70,7 @@ log_choke_changes_func_new(void* address, const char* title, int quota, int adju
                title, quota, adjust);
 }
 
-choke_queue::~choke_queue() {
+choke_queue::~choke_queue() noexcept(false) {
   if (m_currently_unchoked != 0)
     throw internal_error("choke_queue::~choke_queue() called but m_currentlyUnchoked != 0.");
 
@@ -265,7 +265,7 @@ choke_queue::balance_entry(group_entry* entry) {
 }
 
 int
-choke_queue::cycle(uint32_t quota) {
+choke_queue::cycle(uint32_t quota) noexcept(false) {
   // TODO: This should not use the old values, but rather the number
   // of unchoked this round.
   // HACKKKKKK
@@ -423,7 +423,7 @@ choke_queue::disconnected(PeerConnectionBase* pc, choke_status* base) {
 // No need to do any choking as the next choke balancing will take
 // care of things.
 void
-choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain*, group_entry* base) {
+choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain*, group_entry* base) noexcept(false) {
   if (src != NULL) {
     group_container_type::iterator itr = std::find(src->m_group_container.begin(), src->m_group_container.end(), base);
 
@@ -540,7 +540,7 @@ bool range_is_contained(Itr first, Itr last, Itr lower_bound, Itr upper_bound) {
 uint32_t
 choke_queue::adjust_choke_range(iterator first, iterator last,
                                 container_type* src_container, container_type* dest_container,
-                                uint32_t max, bool is_choke) {
+                                uint32_t max, bool is_choke) noexcept(false) {
   target_type target[order_max_size + 1];
 
   if (is_choke) {

--- a/src/torrent/download/choke_queue.cc
+++ b/src/torrent/download/choke_queue.cc
@@ -423,7 +423,7 @@ choke_queue::disconnected(PeerConnectionBase* pc, choke_status* base) {
 // No need to do any choking as the next choke balancing will take
 // care of things.
 void
-choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain* download, group_entry* base) {
+choke_queue::move_connections(choke_queue* src, choke_queue* dest, DownloadMain*, group_entry* base) {
   if (src != NULL) {
     group_container_type::iterator itr = std::find(src->m_group_container.begin(), src->m_group_container.end(), base);
 

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -111,7 +111,7 @@ public:
     m_maxUnchoked(unlimited),
     m_currently_queued(0),
     m_currently_unchoked(0) {}
-  ~choke_queue();
+  ~choke_queue() noexcept(false);
   
   bool                is_full() const                         { return !is_unlimited() && size_unchoked() >= m_maxUnchoked; }
   bool                is_unlimited() const                    { return m_maxUnchoked == unlimited; }

--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -64,7 +64,7 @@ ResourceManager::ResourceManager() :
 {
 }
 
-ResourceManager::~ResourceManager() {
+ResourceManager::~ResourceManager() noexcept(false) {
   if (m_currentlyUploadUnchoked != 0)
     throw internal_error("ResourceManager::~ResourceManager() called but m_currentlyUploadUnchoked != 0.");
 
@@ -115,7 +115,7 @@ ResourceManager::update_group_iterators() {
 }
 
 void
-ResourceManager::validate_group_iterators() {
+ResourceManager::validate_group_iterators() noexcept(false) {
   base_type::iterator       entry_itr = base_type::begin();
   choke_base_type::iterator group_itr = choke_base_type::begin();
 
@@ -133,7 +133,7 @@ ResourceManager::validate_group_iterators() {
 }
 
 void
-ResourceManager::erase(DownloadMain* d) {
+ResourceManager::erase(DownloadMain* d) noexcept(false) {
   iterator itr = std::find_if(begin(), end(), rak::equal(d, std::mem_fun_ref(&value_type::download)));
 
   if (itr == end())
@@ -282,7 +282,7 @@ ResourceManager::set_max_download_unchoked(unsigned int m) {
 // The choking choke manager won't updated it's count until after
 // possibly multiple calls of this function.
 void
-ResourceManager::receive_upload_unchoke(int num) {
+ResourceManager::receive_upload_unchoke(int num) noexcept(false) {
   lt_log_print(LOG_PEER_INFO, "Upload unchoked slots adjust; currently:%u adjust:%i", m_currentlyUploadUnchoked, num);
 
   if ((int)m_currentlyUploadUnchoked + num < 0)
@@ -292,7 +292,7 @@ ResourceManager::receive_upload_unchoke(int num) {
 }
 
 void
-ResourceManager::receive_download_unchoke(int num) {
+ResourceManager::receive_download_unchoke(int num) noexcept(false) {
   lt_log_print(LOG_PEER_INFO, "Download unchoked slots adjust; currently:%u adjust:%i", m_currentlyDownloadUnchoked, num);
 
   if ((int)m_currentlyDownloadUnchoked + num < 0)
@@ -346,7 +346,7 @@ ResourceManager::total_weight() const {
 }
 
 int
-ResourceManager::balance_unchoked(unsigned int weight, unsigned int max_unchoked, bool is_up) {
+ResourceManager::balance_unchoked(unsigned int weight, unsigned int max_unchoked, bool is_up) noexcept(false) {
   int change = 0;
 
   if (max_unchoked == 0) {

--- a/src/torrent/download/resource_manager.h
+++ b/src/torrent/download/resource_manager.h
@@ -103,7 +103,7 @@ public:
   using base_type::capacity;
 
   ResourceManager();
-  ~ResourceManager();
+  ~ResourceManager() noexcept(false);
 
   void                insert(DownloadMain* d, uint16_t priority) { insert(value_type(d, priority)); }
   void                erase(DownloadMain* d);

--- a/src/torrent/event.h
+++ b/src/torrent/event.h
@@ -8,7 +8,7 @@ namespace torrent {
 class LIBTORRENT_EXPORT Event {
 public:
   Event();
-  virtual ~Event();
+  virtual ~Event() noexcept(false);
 
   // TODO: Disable override.
   bool is_open() const;
@@ -33,7 +33,7 @@ protected:
 };
 
 inline Event::Event() : m_fileDesc(-1), m_ipv6_socket(false) {}
-inline Event::~Event() {}
+inline Event::~Event() noexcept(false) {}
 inline bool Event::is_open() const { return file_descriptor() != -1; }
 inline int  Event::file_descriptor() const { return m_fileDesc; }
 inline void Event::set_file_descriptor(int fd) { m_fileDesc = fd; }

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -608,7 +608,7 @@ object_write_bencode_c(object_write_t writeFunc,
 }
 
 object_buffer_t
-object_write_to_buffer(void* data, object_buffer_t buffer) {
+object_write_to_buffer(void*, object_buffer_t buffer) {
   if (buffer.first == buffer.second)
     throw internal_error("object_write_to_buffer(...) buffer overflow.");
 

--- a/src/torrent/peer/connection_list.cc
+++ b/src/torrent/peer/connection_list.cc
@@ -78,7 +78,7 @@ ConnectionList::clear() {
 }
 
 bool
-ConnectionList::want_connection(PeerInfo* p, Bitfield* bitfield) {
+ConnectionList::want_connection(PeerInfo*, Bitfield* bitfield) {
   if (m_download->file_list()->is_done() || m_download->initial_seeding() != NULL)
     return !bitfield->is_all_set();
 

--- a/src/torrent/peer/peer.h
+++ b/src/torrent/peer/peer.h
@@ -105,7 +105,7 @@ public:
 
 protected:
   Peer() {}
-  virtual ~Peer() {}
+  virtual ~Peer() noexcept(false) {}
 
   Peer(const Peer&);
   void operator = (const Peer&);

--- a/src/torrent/peer/peer_info.cc
+++ b/src/torrent/peer/peer_info.cc
@@ -68,7 +68,7 @@ PeerInfo::PeerInfo(const sockaddr* address) :
   m_address = sa->c_sockaddr();
 }
 
-PeerInfo::~PeerInfo() {
+PeerInfo::~PeerInfo() noexcept(false) {
   // if (m_transferCounter != 0)
   //   throw internal_error("PeerInfo::~PeerInfo() m_transferCounter != 0.");
 

--- a/src/torrent/peer/peer_info.h
+++ b/src/torrent/peer/peer_info.h
@@ -63,7 +63,7 @@ public:
   static const int mask_ip_table = flag_unwanted | flag_preferred;
 
   PeerInfo(const sockaddr* address);
-  ~PeerInfo();
+  ~PeerInfo() noexcept(false);
 
   bool                is_connected() const                  { return m_flags & flag_connected; }
   bool                is_incoming() const                   { return m_flags & flag_incoming; }

--- a/src/torrent/poll.h
+++ b/src/torrent/poll.h
@@ -52,7 +52,7 @@ public:
   static const uint32_t flag_waive_global_lock = 0x1;
 
   Poll() : m_flags(0) {}
-  virtual ~Poll() {}
+  virtual ~Poll() noexcept(false) {}
 
   uint32_t            flags() const { return m_flags; }
   void                set_flags(uint32_t flags) { m_flags = flags; }

--- a/src/torrent/poll_kqueue.cc
+++ b/src/torrent/poll_kqueue.cc
@@ -451,7 +451,7 @@ PollKQueue::perform() {
 }
 
 unsigned int
-PollKQueue::do_poll(int64_t timeout_usec, int flags) {
+PollKQueue::do_poll(int64_t, int) {
   throw internal_error("An PollKQueue function was called, but it is disabled.");
 }
 

--- a/src/torrent/poll_select.cc
+++ b/src/torrent/poll_select.cc
@@ -153,7 +153,7 @@ PollSelect::create(int maxOpenSockets) {
   return p;
 }
 
-PollSelect::~PollSelect() {
+PollSelect::~PollSelect() noexcept(false) {
   m_readSet->prepare();
   m_writeSet->prepare();
   m_exceptSet->prepare();

--- a/src/torrent/poll_select.h
+++ b/src/torrent/poll_select.h
@@ -52,7 +52,7 @@ namespace torrent {
 class LIBTORRENT_EXPORT PollSelect : public Poll {
 public:
   static PollSelect*  create(int maxOpenSockets);
-  virtual ~PollSelect();
+  virtual ~PollSelect() noexcept(false);
 
   virtual uint32_t    open_max() const;
 

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -129,7 +129,7 @@ encoding_list() {
 
 Download
 download_add(Object* object) {
-  std::auto_ptr<DownloadWrapper> download(new DownloadWrapper);
+  std::unique_ptr<DownloadWrapper> download(new DownloadWrapper);
 
   DownloadConstructor ctor;
   ctor.set_download(download.get());

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -36,7 +36,7 @@ public:
   static const int max_flag_size   = 0x10;
   static const int mask_base_flags = 0x10 - 1;
 
-  virtual ~Tracker() {}
+  virtual ~Tracker() noexcept(false) {}
 
   int                 flags() const { return m_flags; }
 

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -91,7 +91,7 @@ public:
   uint32_t            scrape_incomplete() const             { return m_scrape_incomplete; }
   uint32_t            scrape_downloaded() const             { return m_scrape_downloaded; }
 
-  virtual void        get_status(char* buffer, int length)  { buffer[0] = 0; } 
+  virtual void        get_status(char* buffer, int)         { buffer[0] = 0; } 
 
   static std::string  scrape_url_from(std::string url);
 

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -130,7 +130,7 @@ TrackerController::seconds_to_next_scrape() const {
 }
 
 void
-TrackerController::manual_request(bool request_now) {
+TrackerController::manual_request(bool) {
   if (!m_private->task_timeout.is_queued())
     return;
 
@@ -566,7 +566,7 @@ TrackerController::receive_failure(Tracker* tb, const std::string& msg) {
 }
 
 void
-TrackerController::receive_scrape(Tracker* tb) {
+TrackerController::receive_scrape(Tracker*) {
   if (!(m_flags & flag_active)) {
     return;
   }

--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -138,9 +138,12 @@ void
 directory_events::event_read() {
 #ifdef HAVE_INOTIFY
   char buffer[2048];
-  int result = ::read(m_fileDesc, buffer, 2048);
+  ssize_t result = ::read(m_fileDesc, buffer, 2048);
 
-  if (result < sizeof(struct inotify_event))
+  if (result < 0)
+    return;
+
+  if ((size_t)result < sizeof(struct inotify_event))
     return;
 
   struct inotify_event* event = (struct inotify_event*)buffer;

--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -310,7 +310,7 @@ log_add_group_output(int group, const char* name) {
 }
 
 void
-log_remove_group_output(int group, const char* name) {
+log_remove_group_output(int, const char*) {
 }
 
 // The log_children list is <child, group> since we build the output
@@ -329,7 +329,7 @@ log_add_child(int group, int child) {
 }
 
 void
-log_remove_child(int group, int child) {
+log_remove_child(int, int) {
   // Remove from all groups, then modify all outputs.
 }
 

--- a/src/torrent/utils/resume.cc
+++ b/src/torrent/utils/resume.cc
@@ -278,7 +278,7 @@ resume_save_progress(Download download, Object& object) {
 }
 
 void
-resume_clear_progress(Download download, Object& object) {
+resume_clear_progress(Download, Object& object) {
   object.erase_key("bitfield");
 }
 

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -116,7 +116,7 @@ TrackerUdp::send_state(int state) {
 }
 
 bool
-TrackerUdp::parse_udp_url(const std::string& url, hostname_type& hostname, int& port) const {
+TrackerUdp::parse_udp_url(const std::string&, hostname_type& hostname, int& port) const {
   if (std::sscanf(m_url.c_str(), "udp://%1023[^:]:%i", hostname.data(), &port) == 2 && hostname[0] != '\0' &&
       port > 0 && port < (1 << 16))
     return true;
@@ -138,7 +138,7 @@ TrackerUdp::make_resolver_slot(const hostname_type& hostname) {
 }
 
 void
-TrackerUdp::start_announce(const sockaddr* sa, int err) {
+TrackerUdp::start_announce(const sockaddr* sa, int) {
   if (m_slot_resolver != NULL) {
     *m_slot_resolver = resolver_type();
     m_slot_resolver = NULL;

--- a/test/data/test_chunk_list.cc
+++ b/test/data/test_chunk_list.cc
@@ -8,7 +8,7 @@
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_chunk_list, "data");
 
 torrent::Chunk*
-func_create_chunk(uint32_t index, int prot_flags) {
+func_create_chunk(uint32_t index, int) {
   // Do proper handling of prot_flags...
   char* memory_part1 = (char*)mmap(NULL, 10, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
 
@@ -27,12 +27,12 @@ func_create_chunk(uint32_t index, int prot_flags) {
 }
 
 uint64_t
-func_free_diskspace(torrent::ChunkList* chunk_list) {
+func_free_diskspace(torrent::ChunkList*) {
   return 0;
 }
 
 void
-func_storage_error(torrent::ChunkList* chunk_list, const std::string& message) {
+func_storage_error(torrent::ChunkList*, const std::string&) {
 }
 
 void

--- a/test/helpers/progress_listener.cc
+++ b/test/helpers/progress_listener.cc
@@ -43,7 +43,7 @@ progress_listener::addFailure(const CppUnit::TestFailure &failure) {
 }
 
 void
-progress_listener::endTest(CppUnit::Test *test) {
+progress_listener::endTest(CppUnit::Test *) {
   std::cout << (m_last_test_failed ? "" : " : OK") << std::endl;
 
   m_current_log_buffer.reset();
@@ -59,6 +59,6 @@ progress_listener::startSuite(CppUnit::Test *suite) {
 }
 
 void
-progress_listener::endSuite(CppUnit::Test *suite) {
+progress_listener::endSuite(CppUnit::Test *) {
   m_test_path.pop_back();
 }

--- a/test/main.cc
+++ b/test/main.cc
@@ -63,7 +63,7 @@ register_signal_handlers() {
   }
 }
 
-int main(int argc, char* argv[]) {
+int main(int, char**) {
   register_signal_handlers();
 
   CppUnit::TestResult controller;

--- a/test/protocol/test_request_list.cc
+++ b/test/protocol/test_request_list.cc
@@ -12,7 +12,7 @@
 CPPUNIT_TEST_SUITE_REGISTRATION(TestRequestList);
 
 static uint32_t
-chunk_index_size(uint32_t index) {
+chunk_index_size(uint32_t) {
   return 1 << 10;
 }
 
@@ -110,7 +110,7 @@ transfer_list_completed(torrent::TransferList* transfer_list, uint32_t index) {
 //
 
 static uint32_t
-basic_find_peer_chunk(torrent::PeerChunks* peerChunk, bool highPriority) {
+basic_find_peer_chunk(torrent::PeerChunks*, bool) {
   static int next_index = 0;
 
   return next_index++;

--- a/test/torrent/net/test_address_info.cc
+++ b/test/torrent/net/test_address_info.cc
@@ -51,12 +51,12 @@ test_address_info::test_helpers() {
   CPPUNIT_ASSERT(sin6_zero != nullptr);
   CPPUNIT_ASSERT(sin6_zero->sin6_family == AF_INET6);
   CPPUNIT_ASSERT(sin6_zero->sin6_port == 0);
-  CPPUNIT_ASSERT(compare_sin6_addr(sin6_zero->sin6_addr, in6_addr{0}));
+  CPPUNIT_ASSERT(compare_sin6_addr(sin6_zero->sin6_addr, in6_addr{{{0}}}));
 
   torrent::sin6_unique_ptr sin6_1 = torrent::sin6_from_sa(wrap_ai_get_first_sa("ff01::1"));
   CPPUNIT_ASSERT(sin6_1 != nullptr);
   CPPUNIT_ASSERT(sin6_1->sin6_family == AF_INET6);
   CPPUNIT_ASSERT(sin6_1->sin6_port == 0);
-  CPPUNIT_ASSERT(compare_sin6_addr(sin6_1->sin6_addr, in6_addr{0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
-  CPPUNIT_ASSERT(!compare_sin6_addr(sin6_1->sin6_addr, in6_addr{0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}));
+  CPPUNIT_ASSERT(compare_sin6_addr(sin6_1->sin6_addr, in6_addr{{{0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}}}));
+  CPPUNIT_ASSERT(!compare_sin6_addr(sin6_1->sin6_addr, in6_addr{{{0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}}}));
 }

--- a/test/torrent/net/test_socket_address.cc
+++ b/test/torrent/net/test_socket_address.cc
@@ -83,7 +83,7 @@ test_socket_address::test_make() {
   CPPUNIT_ASSERT(sin6_inet6->sin6_family == AF_INET6);
   CPPUNIT_ASSERT(sin6_inet6->sin6_port == 0);
   CPPUNIT_ASSERT(sin6_inet6->sin6_flowinfo == 0);
-  CPPUNIT_ASSERT(compare_sin6_addr(sin6_inet6->sin6_addr, in6_addr{0}));
+  CPPUNIT_ASSERT(compare_sin6_addr(sin6_inet6->sin6_addr, in6_addr{{{0}}}));
   CPPUNIT_ASSERT(sin6_inet6->sin6_scope_id == 0);
 
   torrent::sa_unique_ptr sa_unix = torrent::sa_make_unix("");

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -50,7 +50,7 @@ ObjectStreamTest::testOutputMask() {
 // Dummy function that invalidates the buffer once called.
 
 torrent::object_buffer_t
-object_write_to_invalidate(void* data, torrent::object_buffer_t buffer) {
+object_write_to_invalidate(void*, torrent::object_buffer_t buffer) {
   return torrent::object_buffer_t(buffer.second, buffer.second);
 }
 


### PR DESCRIPTION
`Explicitly handle signed comparison with unsigned` is implemented according to existing implicit conversion rules of C++ standard. 

No functional change expected. 

All tests passed.
```
OK (10)
PASS: LibTorrent_Test
==================
All 7 tests passed
==================
```


```
 Θ clang --version
Ubuntu clang version 11.0.1-++20201103062930+ef4ffcafbb2-1~exp1~20201103053545.129

 Θ CC=clang CXX=clang++ CFLAGS="-Wextra -Werror -Ofast" CXXFLAGS="-Wextra -Werror -Ofast" ./configure
```