### PR TITLE
Fix file truncation on resume with fallocate enabled

### DIFF
--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -107,14 +107,14 @@ SocketFile::set_size(uint64_t size, int flags) const {
     throw internal_error("SocketFile::set_size() called on a closed file");
 
 #ifdef HAVE_FALLOCATE
-  if (flags & flag_fallocate && fallocate(m_fd, 0, 0, size) == 0)
+  if (flags & flag_fallocate && fallocate(m_fd, 0, 0, size) == 0 && ftruncate(m_fd, size) == 0)
     return true;
 #endif
 
 #ifdef USE_POSIX_FALLOCATE
   if (flags & flag_fallocate &&
       flags & flag_fallocate_blocking &&
-      posix_fallocate(m_fd, 0, size) == 0)
+      posix_fallocate(m_fd, 0, size) == 0 && ftruncate(m_fd, size) == 0)
     return true;
 #endif
 


### PR DESCRIPTION
- Call ftruncate() after fallocate() to ensure the file gets shrunk
  if needed.

- Open the files queued for resizing in writable mode to allow
  fixing the files with a wrong size later.