### PR TITLE
Fix bug:src/net/socket_fd.cc:disable the usage of IPV6_TCLASS if it i…

### DIFF
--- a/src/net/socket_fd.cc
+++ b/src/net/socket_fd.cc
@@ -71,7 +71,11 @@ SocketFd::set_priority(priority_type p) {
   int opt = p;
 
   if (m_ipv6_socket)
+#ifdef IPV6_TCLASS
     return setsockopt(m_fd, IPPROTO_IPV6, IPV6_TCLASS, &opt, sizeof(opt)) == 0;
+#else
+    return false;
+#endif
   else
     return setsockopt(m_fd, IPPROTO_IP, IP_TOS, &opt, sizeof(opt)) == 0;
 }


### PR DESCRIPTION
I have already report this bug to the debian bug tracking system, debian-hurd and bug-hurd.
With their advises, I decide to block the use of `IPV6_TCLASS` under the GNU Hurd.

https://github.com/rakshasa/libtorrent/issues/219