### PR TITLE
Add is_initialized() API

### DIFF
--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -90,6 +90,11 @@ cleanup() {
 }
 
 bool
+is_initialized() {
+  return manager != NULL;
+}
+
+bool
 is_inactive() {
   return manager == NULL ||
     std::find_if(manager->download_manager()->begin(), manager->download_manager()->end(), std::not1(std::mem_fun(&DownloadWrapper::is_stopped)))

--- a/src/torrent/torrent.h
+++ b/src/torrent/torrent.h
@@ -57,6 +57,7 @@ void                initialize() LIBTORRENT_EXPORT;
 void                cleanup() LIBTORRENT_EXPORT;
 
 bool                is_inactive() LIBTORRENT_EXPORT;
+bool                is_initialized() LIBTORRENT_EXPORT;
 
 thread_base*        main_thread() LIBTORRENT_EXPORT;
 


### PR DESCRIPTION
Backports is_initialized() API from [jesec/libtorrent](https://github.com/jesec/libtorrent) . This is required to fix a memory leak with SCGI on rTorrent. A pull request will be created later on rTorrent linking this. It will require a new release version of libtorrent.