### PR TITLE
configure: Define _GNU_SOURCE when checking for pthread_setname_np

### DIFF
--- a/scripts/checks.m4
+++ b/scripts/checks.m4
@@ -451,6 +451,7 @@ AC_DEFUN([TORRENT_CHECK_PTHREAD_SETNAME_NP], [
   AC_MSG_CHECKING(for pthread_setname_np type)
 
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #define _GNU_SOURCE
     #include <pthread.h>
     #include <sys/types.h>
   ]], [[


### PR DESCRIPTION
Previously, the test would always fail with compilers that do not support implicit function declarations because the pthread_setname_np function was not declared.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
