### PR TITLE
Increase peice preloading rate from 5KB/s to 30KB/s

### DIFF
--- a/src/torrent/chunk_manager.cc
+++ b/src/torrent/chunk_manager.cc
@@ -59,7 +59,7 @@ ChunkManager::ChunkManager() :
 
   m_preloadType(0),
   m_preloadMinSize(256 << 10),
-  m_preloadRequiredRate(5 << 10),
+  m_preloadRequiredRate(30 << 10),
 
   m_statsPreloaded(0),
   m_statsNotPreloaded(0),


### PR DESCRIPTION
Many users are complaining about I/O thrashing when enabling piece preloading. We need to increase the default rate value to make it work reasonably as intended. There is no real world situation, where we'd want to set the default rate any lower. https://github.com/rakshasa/rtorrent/issues/443