### PR TITLE
fix(poll_epoll.cc): add exception handling for m_table array allocation

### DIFF
--- a/src/torrent/poll_epoll.cc
+++ b/src/torrent/poll_epoll.cc
@@ -131,7 +131,13 @@ PollEPoll::PollEPoll(int fd, int maxEvents, int maxOpenSockets) :
   m_waitingEvents(0),
   m_events(new epoll_event[m_maxEvents]) {
 
-  m_table.resize(maxOpenSockets);
+  try {
+    m_table.resize(maxOpenSockets);
+  } catch (std::bad_alloc) {
+    std::stringstream s;
+    s << "Error allocating m_table array: too much space requested:" << maxOpenSockets;
+    throw internal_error(s.str());
+  }
 }
 
 PollEPoll::~PollEPoll() {


### PR DESCRIPTION
The try-catch block has been added to handle the std::bad_alloc exception that may occur when allocating memory for the m_table array. If the exception is thrown, an internal_error is raised with a message indicating that too much space was requested.

This pull-request is more a "report an issue" than a real fix.
I recently encountered an issue that prevented me to use rtorrent inside a docker container. The issue is caused by a huge value of the system variable _SC_OPEN_MAX, that is directly used to allocate an array. 
More informations [here](https://forums.docker.com/t/weird-sc-open-max-value/135297) and [here](https://stackoverflow.com/questions/75536471/rtorrent-docker-container-failing-to-start-saying-stdbad-alloc/75908017#75908017).
As I had a hard time finding the issue, I think it would be interesting to report the issue with a more accurate message.
I am not sure at all this is the right fix. Please let me know if I can do anything other.

Thanks for your read and your time.