### PR TITLE
Respect min interval returned by the tracker for failed announces

### DIFF
--- a/src/torrent/tracker.cc
+++ b/src/torrent/tracker.cc
@@ -51,8 +51,8 @@ Tracker::Tracker(TrackerList* parent, const std::string& url, int flags) :
   m_group(0),
   m_url(url),
 
-  m_normal_interval(1800),
-  m_min_interval(600),
+  m_normal_interval(0),
+  m_min_interval(0),
 
   m_latest_event(EVENT_NONE),
   m_latest_new_peers(0),
@@ -104,13 +104,16 @@ Tracker::success_time_next() const {
   if (m_success_counter == 0)
     return 0;
 
-  return m_success_time_last + m_normal_interval;
+  return m_success_time_last + std::max(m_normal_interval, (uint32_t)default_min_interval);
 }
 
 uint32_t
 Tracker::failed_time_next() const {
   if (m_failed_counter == 0)
     return 0;
+
+  if (m_min_interval > 0)
+    return m_failed_time_last + m_min_interval;
 
   return m_failed_time_last + (5 << std::min(m_failed_counter - 1, (uint32_t)6));
 }

--- a/src/torrent/tracker.cc
+++ b/src/torrent/tracker.cc
@@ -104,7 +104,7 @@ Tracker::success_time_next() const {
   if (m_success_counter == 0)
     return 0;
 
-  return m_success_time_last + std::max(m_normal_interval, (uint32_t)default_min_interval);
+  return m_success_time_last + std::max(m_normal_interval, (uint32_t)min_normal_interval);
 }
 
 uint32_t
@@ -112,10 +112,10 @@ Tracker::failed_time_next() const {
   if (m_failed_counter == 0)
     return 0;
 
-  if (m_min_interval > 0)
+  if (m_min_interval > min_min_interval)
     return m_failed_time_last + m_min_interval;
 
-  return m_failed_time_last + (5 << std::min(m_failed_counter - 1, (uint32_t)6));
+  return m_failed_time_last + std::min(5 << std::min(m_failed_counter - 1, (uint32_t)6), min_min_interval-1);
 }
 
 std::string

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -36,8 +36,13 @@ public:
   static const int max_flag_size   = 0x10;
   static const int mask_base_flags = 0x10 - 1;
 
+  static const int min_min_interval = 300;
   static const int default_min_interval = 600;
+  static const int max_min_interval = 4 * 3600;
+
+  static const int min_normal_interval = 600;
   static const int default_normal_interval = 1800;
+  static const int max_normal_interval = 8 * 3600;
 
   virtual ~Tracker() {}
 
@@ -115,8 +120,8 @@ protected:
 
   void                set_group(uint32_t v)                 { m_group = v; }
 
-  void                set_normal_interval(int v)            { m_normal_interval = std::min(std::max(600, v), 8 * 3600); }
-  void                set_min_interval(int v)               { m_min_interval = std::min(std::max(300, v), 4 * 3600); }
+  void                set_normal_interval(int v)            { m_normal_interval = std::min(std::max(min_normal_interval, v), max_normal_interval); }
+  void                set_min_interval(int v)               { m_min_interval = std::min(std::max(min_min_interval, v), max_min_interval); }
 
   int                 m_flags;
 

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -29,20 +29,20 @@ public:
     EVENT_SCRAPE
   };
 
-  static const int flag_enabled = 0x1;
+  static const int flag_enabled       = 0x1;
   static const int flag_extra_tracker = 0x2;
-  static const int flag_can_scrape = 0x4;
+  static const int flag_can_scrape    = 0x4;
 
   static const int max_flag_size   = 0x10;
   static const int mask_base_flags = 0x10 - 1;
 
-  static const int min_min_interval = 300;
-  static const int default_min_interval = 600;
-  static const int max_min_interval = 4 * 3600;
+  static constexpr int min_min_interval     = 300;
+  static constexpr int default_min_interval = 600;
+  static constexpr int max_min_interval     = 4 * 3600;
 
-  static const int min_normal_interval = 600;
-  static const int default_normal_interval = 1800;
-  static const int max_normal_interval = 8 * 3600;
+  static constexpr int min_normal_interval     = 600;
+  static constexpr int default_normal_interval = 1800;
+  static constexpr int max_normal_interval     = 8 * 3600;
 
   virtual ~Tracker() {}
 

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -36,6 +36,9 @@ public:
   static const int max_flag_size   = 0x10;
   static const int mask_base_flags = 0x10 - 1;
 
+  static const int default_min_interval = 600;
+  static const int default_normal_interval = 1800;
+
   virtual ~Tracker() {}
 
   int                 flags() const { return m_flags; }

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -392,9 +392,7 @@ tracker_next_timeout_promiscuous(Tracker* tracker) {
   int32_t interval;
 
   if (tracker->failed_counter()) {
-    interval = 5 << std::min<int>(tracker->failed_counter() - 1, 6);
-    if (tracker->min_interval() > 0)
-      interval = std::max(interval, (int32_t)tracker->min_interval());
+    interval = tracker->failed_time_next() - tracker->failed_time_last();
   } else {
     interval = tracker->normal_interval();
   }

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -391,10 +391,13 @@ tracker_next_timeout_promiscuous(Tracker* tracker) {
 
   int32_t interval;
 
-  if (tracker->failed_counter())
+  if (tracker->failed_counter()) {
     interval = 5 << std::min<int>(tracker->failed_counter() - 1, 6);
-  else
+    if (tracker->min_interval() > 0)
+      interval = std::max(interval, (int32_t)tracker->min_interval());
+  } else {
     interval = tracker->normal_interval();
+  }
 
   int32_t min_interval = std::max(tracker->min_interval(), (uint32_t)300);
   int32_t use_interval = std::min(interval, min_interval);

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -39,7 +39,7 @@ TrackerHttp::TrackerHttp(TrackerList* parent, const std::string& url, int flags)
   m_data(NULL) {
 
   m_get->signal_done().push_back(std::bind(&TrackerHttp::receive_done, this));
-  m_get->signal_failed().push_back(std::bind(&TrackerHttp::receive_failed, this, std::placeholders::_1));
+  m_get->signal_failed().push_back(std::bind(&TrackerHttp::receive_signal_failed, this, std::placeholders::_1));
 
   // Haven't considered if this needs any stronger error detection,
   // can dropping the '?' be used for malicious purposes?
@@ -277,6 +277,13 @@ TrackerHttp::receive_done() {
     process_scrape(b);
   else
     process_success(b);
+}
+
+void
+TrackerHttp::receive_signal_failed(std::string msg) {
+  m_normal_interval = 0;
+  m_min_interval = 0;
+  return receive_failed(msg);
 }
 
 void

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -282,7 +282,7 @@ TrackerHttp::receive_done() {
 void
 TrackerHttp::receive_signal_failed(std::string msg) {
   m_normal_interval = 0;
-  m_min_interval = 0;
+  m_min_interval    = 0;
   return receive_failed(msg);
 }
 
@@ -331,9 +331,9 @@ TrackerHttp::process_success(const Object& object) {
     set_normal_interval(default_normal_interval);
 
   if (object.has_key_value("min interval"))
-    set_normal_interval(object.get_key_value("min interval"));
+    set_min_interval(object.get_key_value("min interval"));
   else
-    set_normal_interval(default_min_interval);
+    set_min_interval(default_min_interval);
 
   if (object.has_key_string("tracker id"))
     m_tracker_id = object.get_key_string("tracker id");

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -269,8 +269,6 @@ TrackerHttp::receive_done() {
   }
 
   // If no failures, set intervals to defaults prior to processing
-  set_normal_interval(default_normal_interval);
-  set_min_interval(default_min_interval);
 
   if (m_latest_event == EVENT_SCRAPE)
     process_scrape(b);
@@ -321,6 +319,10 @@ TrackerHttp::process_success(const Object& object) {
 
   AddressList l;
 
+  if (!object.has_key_value("interval"))
+    set_normal_interval(default_normal_interval);
+  if (!object.has_key_value("min interval"))
+    set_min_interval(default_min_interval);
   if (!object.has_key("peers") && !object.has_key("peers6"))
     return receive_failed("No peers returned");
 

--- a/src/tracker/tracker_http.h
+++ b/src/tracker/tracker_http.h
@@ -68,7 +68,7 @@ private:
   void                receive_done();
   void                receive_failed(std::string msg);
 
-  void                process_bencode_response(const Object& object);
+  void                process_failure(const Object& object);
   void                process_success(const Object& object);
   void                process_scrape(const Object& object);
 

--- a/src/tracker/tracker_http.h
+++ b/src/tracker/tracker_http.h
@@ -66,6 +66,7 @@ private:
   void                request_prefix(std::stringstream* stream, const std::string& url);
 
   void                receive_done();
+  void                receive_signal_failed(std::string msg);
   void                receive_failed(std::string msg);
 
   void                process_failure(const Object& object);

--- a/src/tracker/tracker_http.h
+++ b/src/tracker/tracker_http.h
@@ -68,6 +68,7 @@ private:
   void                receive_done();
   void                receive_failed(std::string msg);
 
+  void                process_bencode_response(const Object& object);
   void                process_success(const Object& object);
   void                process_scrape(const Object& object);
 

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -383,6 +383,7 @@ TrackerUdp::process_announce_output() {
     return false;
 
   set_normal_interval(m_readBuffer->read_32());
+  set_min_interval(default_min_interval);
 
   m_scrape_incomplete = m_readBuffer->read_32(); // leechers
   m_scrape_complete   = m_readBuffer->read_32(); // seeders

--- a/test/torrent/tracker_controller_features.cc
+++ b/test/torrent/tracker_controller_features.cc
@@ -70,7 +70,7 @@ tracker_controller_features::test_requesting_timeout() {
   TEST_MULTI3_IS_BUSY("10111", "10111");
 
   CPPUNIT_ASSERT(tracker_0_0->trigger_failure());
-  CPPUNIT_ASSERT(tracker_controller.seconds_to_next_timeout() == 5);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)5, tracker_controller.seconds_to_next_timeout());
   // CPPUNIT_ASSERT(tracker_0_1->trigger_failure());
   CPPUNIT_ASSERT(tracker_1_0->trigger_failure());
   CPPUNIT_ASSERT(tracker_2_0->trigger_failure());

--- a/test/torrent/tracker_controller_requesting.cc
+++ b/test/torrent/tracker_controller_requesting.cc
@@ -30,6 +30,8 @@ do_test_hammering_basic(bool success1, bool success2, bool success3, uint32_t mi
 
   if (min_interval != 0)
     tracker_0_0->set_new_min_interval(min_interval);
+  else
+    tracker_0_0->set_new_min_interval(600);
 
   CPPUNIT_ASSERT(tracker_0_0->is_busy());
   CPPUNIT_ASSERT(success1 ? tracker_0_0->trigger_success() : tracker_0_0->trigger_failure());
@@ -107,6 +109,8 @@ do_test_hammering_multi3(bool success1, bool success2, bool success3, uint32_t m
 
   if (min_interval != 0)
     tracker_0_0->set_new_min_interval(min_interval);
+  else
+    tracker_0_0->set_new_min_interval(600);
 
   TEST_MULTI3_IS_BUSY("10000", "10000");
   CPPUNIT_ASSERT(success1 ? tracker_0_0->trigger_success() : tracker_0_0->trigger_failure());

--- a/test/torrent/tracker_controller_test.cc
+++ b/test/torrent/tracker_controller_test.cc
@@ -146,8 +146,8 @@ tracker_controller_test::test_single_failure() {
   TEST_SINGLE_FAILURE_TIMEOUT(40);
   TEST_SINGLE_FAILURE_TIMEOUT(80);
   TEST_SINGLE_FAILURE_TIMEOUT(160);
-  TEST_SINGLE_FAILURE_TIMEOUT(320);
-  TEST_SINGLE_FAILURE_TIMEOUT(320);
+  TEST_SINGLE_FAILURE_TIMEOUT(299);
+  TEST_SINGLE_FAILURE_TIMEOUT(299);
 
   // TODO: Test with cachedTime not rounded to second.
 
@@ -334,7 +334,7 @@ tracker_controller_test::test_multiple_failure() {
   TEST_MULTI3_IS_BUSY("00100", "00100");
   CPPUNIT_ASSERT(tracker_1_0->trigger_success());
 
-  CPPUNIT_ASSERT(test_goto_next_timeout(&tracker_controller, tracker_0_0->normal_interval()));
+  CPPUNIT_ASSERT(test_goto_next_timeout(&tracker_controller, tracker_1_0->normal_interval()));
   TEST_MULTI3_IS_BUSY("10000", "10000");
   CPPUNIT_ASSERT(tracker_0_0->trigger_failure());
   TEST_MULTI3_IS_BUSY("01000", "01000");

--- a/test/torrent/tracker_list_test.cc
+++ b/test/torrent/tracker_list_test.cc
@@ -43,10 +43,13 @@ TrackerTest::trigger_success(torrent::TrackerList::address_list* address_list, u
   m_open = !(m_flags & flag_close_on_done);
   return_new_peers = new_peers;
 
-  if (m_latest_event == EVENT_SCRAPE)
+  if (m_latest_event == EVENT_SCRAPE) {
     parent()->receive_scrape_success(this);
-  else
+  } else {
+    set_normal_interval(default_normal_interval);
+    set_min_interval(default_min_interval);
     parent()->receive_success(this, address_list);
+  }
 
   m_requesting_state = -1;
   return true;
@@ -61,10 +64,13 @@ TrackerTest::trigger_failure() {
   m_open = !(m_flags & flag_close_on_done);
   return_new_peers = 0;
 
-  if (m_latest_event == EVENT_SCRAPE)
+  if (m_latest_event == EVENT_SCRAPE) {
     parent()->receive_scrape_failed(this, "failed");
-  else
+  } else {
+    set_normal_interval(0);
+    set_min_interval(0);
     parent()->receive_failed(this, "failed");
+  }
 
   m_requesting_state = -1;
   return true;

--- a/test/torrent/tracker_list_test.h
+++ b/test/torrent/tracker_list_test.h
@@ -77,8 +77,8 @@ public:
   void                set_scrape_on_success(bool state) { if (state) m_flags |= flag_scrape_on_success; else m_flags &= ~flag_scrape_on_success; }
   void                set_can_scrape()              { m_flags |= flag_can_scrape; }
 
-  void                set_success(uint32_t counter, uint32_t time_last) { m_success_counter = counter; m_success_time_last = time_last; }
-  void                set_failed(uint32_t counter, uint32_t time_last)  { m_failed_counter = counter; m_failed_time_last = time_last; }
+  void                set_success(uint32_t counter, uint32_t time_last) { m_success_counter = counter; m_success_time_last = time_last; set_normal_interval(default_normal_interval); set_min_interval(default_min_interval);}
+  void                set_failed(uint32_t counter, uint32_t time_last)  { m_failed_counter = counter; m_failed_time_last = time_last; m_normal_interval = 0; m_min_interval = 0; }
   void                set_latest_new_peers(uint32_t peers)              { m_latest_new_peers = peers; }
   void                set_latest_sum_peers(uint32_t peers)              { m_latest_sum_peers = peers; }
 

--- a/test/torrent/tracker_timeout_test.cc
+++ b/test/torrent/tracker_timeout_test.cc
@@ -25,7 +25,7 @@ void
 tracker_timeout_test::test_set_timeout() {
   TrackerTest tracker(NULL, "");
 
-  CPPUNIT_ASSERT(tracker.normal_interval() == 1800);
+  CPPUNIT_ASSERT(tracker.normal_interval() == 0);
 
   tracker.set_new_normal_interval(100);
   CPPUNIT_ASSERT(tracker.normal_interval() == 600);
@@ -33,7 +33,7 @@ tracker_timeout_test::test_set_timeout() {
   CPPUNIT_ASSERT(tracker.normal_interval() == 8 * 3600);
 
   tracker.set_new_min_interval(100);
-  CPPUNIT_ASSERT(tracker.min_interval() == 300);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)300, tracker.min_interval());
   tracker.set_new_min_interval(4 * 4000);
   CPPUNIT_ASSERT(tracker.min_interval() == 4 * 3600);
 }
@@ -60,18 +60,18 @@ tracker_timeout_test::test_timeout_tracker() {
 
   // Check also failed...
 
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 1800);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)1800, torrent::tracker_next_timeout(&tracker, flags));
   tracker.send_state(torrent::Tracker::EVENT_NONE);
   CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == ~uint32_t());
   tracker.send_state(torrent::Tracker::EVENT_SCRAPE);
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 1800);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)1800, torrent::tracker_next_timeout(&tracker, flags));
 
   tracker.close();
 
   tracker.set_success(1, torrent::cachedTime.seconds() - 3);
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 1800 - 3);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)(1800 - 3), torrent::tracker_next_timeout(&tracker, flags));
   tracker.set_success(1, torrent::cachedTime.seconds() + 3);
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 1800 + 3);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)(1800 + 3), torrent::tracker_next_timeout(&tracker, flags));
 
   tracker.close();
   flags = torrent::TrackerController::flag_active | torrent::TrackerController::flag_promiscuous_mode;
@@ -126,9 +126,10 @@ tracker_timeout_test::test_timeout_requesting() {
   tracker.set_failed(2, torrent::cachedTime.seconds());
   CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 10);
   tracker.set_failed(6 + 1, torrent::cachedTime.seconds());
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 320);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)299, torrent::tracker_next_timeout(&tracker, flags));
   tracker.set_failed(7 + 1, torrent::cachedTime.seconds());
-  CPPUNIT_ASSERT(torrent::tracker_next_timeout(&tracker, flags) == 320);
+  CPPUNIT_ASSERT_EQUAL((uint32_t)299, torrent::tracker_next_timeout(&tracker, flags));
+
   
   //std::cout << "timeout:" << torrent::tracker_next_timeout(&tracker, flags) << std::endl;
 


### PR DESCRIPTION
This changes the default values for the base class to `0`, and relies on the successful parsing of an announce to set them to something sane. If the interval can't be parsed during a failure (from an unrelated failure or just the keys missing), it fails back to the original backoff behavior. However, in order to accommodate the previous logic without modifying the ABI, the backoff timeout is capped at 299 seconds instead of 320.

Fixes [#1215](https://github.com/rakshasa/rtorrent/issues/1215)