### PR TITLE
Add basic padding file support

### DIFF
--- a/src/data/memory_chunk.h
+++ b/src/data/memory_chunk.h
@@ -54,6 +54,7 @@ class MemoryChunk {
   static const int prot_write             = PROT_WRITE;
   static const int prot_none              = PROT_NONE;
   static const int map_shared             = MAP_SHARED;
+  static const int map_anon               = MAP_ANON;
 
 #ifdef USE_MADVISE
   static const int advice_normal          = MADV_NORMAL;

--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -153,6 +153,18 @@ SocketFile::set_size(uint64_t size, int flags) const {
 }
 
 MemoryChunk
+SocketFile::create_padding_chunk(uint32_t length, int prot, int flags) const {
+  flags |= MemoryChunk::map_anon;
+
+  char* ptr = (char*)mmap(NULL, length, prot, flags, -1, 0);
+
+  if (ptr == MAP_FAILED)
+    return MemoryChunk();
+
+  return MemoryChunk(ptr, ptr, ptr + length, prot, flags);
+}
+
+MemoryChunk
 SocketFile::create_chunk(uint64_t offset, uint32_t length, int prot, int flags) const {
   if (!is_open())
     throw internal_error("SocketFile::get_chunk() called on a closed file");

--- a/src/data/socket_file.h
+++ b/src/data/socket_file.h
@@ -72,6 +72,7 @@ public:
   uint64_t            size() const;
   bool                set_size(uint64_t s, int flags = 0) const;
 
+  MemoryChunk         create_padding_chunk(uint32_t length, int prot, int flags) const;
   MemoryChunk         create_chunk(uint64_t offset, uint32_t length, int prot, int flags) const;
   
   fd_type             fd() const                                        { return m_fd; }

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -323,7 +323,15 @@ DownloadConstructor::parse_multi_files(const Object& b, uint32_t chunkSize) {
       throw input_error("Bad torrent file, invalid length for file.");
 
     torrentSize += length;
-    *splitItr = FileList::split_type(length, choose_path(&pathList));
+
+    int flags = 0;
+    if (listItr->has_key_string("attr")) {
+      std::string attr = listItr->get_key_string("attr");
+      if (attr.find('p') != std::string::npos)
+        flags |= File::flag_attr_padding;
+    }
+
+    *splitItr = FileList::split_type(length, choose_path(&pathList), flags);
   }
 
   FileList* fileList = m_download->main()->file_list();

--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -59,6 +59,8 @@ const int File::flag_previously_created;
 const int File::flag_prioritize_first;
 const int File::flag_prioritize_last;
 
+const int File::flag_attr_padding;
+
 File::File() :
   m_fd(-1),
   m_protection(0),
@@ -76,12 +78,17 @@ File::File() :
 }
 
 File::~File() {
+  if (is_padding());
+    return;
   if (is_open())
     throw internal_error("File::~File() called on an open file.");
 }
 
 bool
 File::is_created() const {
+  if (is_padding())
+    return true;
+
   rak::file_stat fs;
 
   // If we can't even get permission to do fstat, we might as well
@@ -98,6 +105,9 @@ File::is_created() const {
 
 bool
 File::is_correct_size() const {
+  if (is_padding())
+    return true;
+
   rak::file_stat fs;
 
   if (!fs.update(frozen_path()))
@@ -111,6 +121,9 @@ File::is_correct_size() const {
 
 bool
 File::prepare(int prot, int flags) {
+  if (is_padding())
+    return true;
+
   m_lastTouched = cachedTime.usec();
 
   // Check if we got write protection and flag_resize_queued is
@@ -170,6 +183,9 @@ File::set_match_depth(File* left, File* right) {
 
 bool
 File::resize_file() {
+  if (is_padding())
+    return true;
+
   if (!is_open())
     return false;
 

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -57,6 +57,7 @@ public:
   static const int flag_prioritize_first   = (1 << 5);
   static const int flag_prioritize_last    = (1 << 6);
 
+  static const int flag_attr_padding       = (1 << 7);
   File();
   ~File();
 
@@ -69,6 +70,7 @@ public:
   bool                is_create_queued() const                 { return m_flags & flag_create_queued; }
   bool                is_resize_queued() const                 { return m_flags & flag_resize_queued; }
   bool                is_previously_created() const            { return m_flags & flag_previously_created; }
+  bool                is_padding() const                       { return m_flags & flag_attr_padding; }
 
   bool                has_flags(int flags)                     { return m_flags & flags; }
 
@@ -166,12 +168,12 @@ File::is_valid_position(uint64_t p) const {
 
 inline void
 File::set_flags(int flags) {
-  set_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last));
+  set_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last | flag_attr_padding));
 }
 
 inline void
 File::unset_flags(int flags) {
-  unset_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last));
+  unset_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last| flag_attr_padding));
 }
 
 inline void

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -63,9 +63,9 @@ public:
   friend class DownloadWrapper;
   friend class Handshake;
 
-  typedef std::vector<File*>            base_type;
-  typedef std::vector<std::string>      path_list;
-  typedef std::pair<uint64_t, Path>     split_type;
+  typedef std::vector<File*>              base_type;
+  typedef std::vector<std::string>        path_list;
+  typedef std::tuple<uint64_t, Path, int> split_type;
 
   // The below are using-directives that make visible functions and
   // typedefs in the parent std::vector, only those listed below are

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -71,6 +71,9 @@ FileManager::set_max_open_files(size_type s) {
 
 bool
 FileManager::open(value_type file, int prot, int flags) {
+  if (file->is_padding())
+    return true;
+
   if (file->is_open())
     close(file);
 
@@ -100,6 +103,9 @@ FileManager::open(value_type file, int prot, int flags) {
 void
 FileManager::close(value_type file) {
   if (!file->is_open())
+    return;
+
+  if (file->is_padding())
     return;
 
   SocketFile(file->file_descriptor()).close();

--- a/src/torrent/data/file_utils.cc
+++ b/src/torrent/data/file_utils.cc
@@ -37,6 +37,7 @@
 #include "config.h"
 
 #include <cstring>
+#include <set>
 
 #include "exceptions.h"
 #include "file.h"
@@ -67,17 +68,17 @@ file_split(FileList* fileList, FileList::iterator position, uint64_t maxSize, co
 
   for (unsigned int i = 0; i != splitSize; ++i, ++splitItr) {
     if (i == splitSize - 1 && (*position)->size_bytes() % maxSize != 0)
-      splitItr->first = (*position)->size_bytes() % maxSize;
+      std::get<0>(*splitItr) = (*position)->size_bytes() % maxSize;
     else
-      splitItr->first = maxSize;
+      std::get<0>(*splitItr) = maxSize;
 
     name[nameSize + 0] = '0' + (i / 100) % 10;
     name[nameSize + 1] = '0' + (i / 10) % 10;
     name[nameSize + 2] = '0' + (i / 1) % 10;
     name[nameSize + 3] = '\0';
     
-    splitItr->second = *srcPath;
-    splitItr->second.back() = name;
+    std::get<1>(*splitItr) = *srcPath;
+    std::get<1>(*splitItr).back() = name;
   }
 
   return fileList->split(position, splitList, splitItr).second;

--- a/src/torrent/utils/resume.cc
+++ b/src/torrent/utils/resume.cc
@@ -97,6 +97,9 @@ resume_load_progress(Download download, const Object& object) {
   FileList* fileList = download.file_list();
 
   for (FileList::iterator listItr = fileList->begin(), listLast = fileList->end(); listItr != listLast; ++listItr, ++filesItr) {
+    if ( (*listItr)->is_padding())
+      continue;
+
     std::string file_path = (*listItr)->path()->as_string();
     unsigned int file_index = std::distance(fileList->begin(), listItr);
 


### PR DESCRIPTION
This is a very simple partial implementation of [BEP 47](https://www.bittorrent.org/beps/bep_0047.html), adding simple padding file support (`p` in the `attr` key). It's not feature complete in that rTorrent may still unnecessarily request data from peers, but the padding files are:
* not stored on disk (instead represented by an anonymous mmap when reading/writing)
* allowed to exist as duplicate "files" (addresses https://github.com/rakshasa/rtorrent/issues/1156)