### PR TITLE
Simplify updating queue entries

### DIFF
--- a/rak/priority_queue.h
+++ b/rak/priority_queue.h
@@ -74,6 +74,10 @@ public:
     base_type::pop_back();
   }
 
+  void update() {
+    std::make_heap(begin(), end(), m_compare);
+  }
+
   void push(const value_type& value) {
     base_type::push_back(value);
     std::push_heap(begin(), end(), m_compare);
@@ -95,12 +99,8 @@ public:
     return true;
   }
 
-  // Removes 'itr' from the queue. This assumes 'itr' has been
-  // modified such that it has a higher priority than any other
-  // element in the queue.
+  // Removes 'itr' from the queue.
   void erase(iterator itr) {
-//     std::push_heap(begin(), ++itr, m_compare);
-//     pop();
     base_type::erase(itr);
     std::make_heap(begin(), end(), m_compare);
   }

--- a/rak/priority_queue_default.h
+++ b/rak/priority_queue_default.h
@@ -127,14 +127,32 @@ priority_queue_erase(priority_queue_default* queue, priority_item* item) {
   if (!item->is_valid())
     throw torrent::internal_error("priority_queue_erase(...) called on an invalid item.");
 
-  // Clear time before erasing to force it to the top.
+  // Unqueue it before erasing.
   item->clear_time();
   
   if (!queue->erase(item))
     throw torrent::internal_error("priority_queue_erase(...) could not find item in queue.");
+}
 
-  if (queue->find(item) != queue->end())
-    throw torrent::internal_error("priority_queue_erase(...) item still in queue.");
+inline void
+priority_queue_upsert(priority_queue_default* queue, priority_item* item, timer t) {
+  if (t == timer())
+
+    throw torrent::internal_error("priority_queue_insert(...) received a bad timer.");
+
+  if (!item->is_valid())
+    throw torrent::internal_error("priority_queue_insert(...) called on an invalid item.");
+
+  if (queue->find(item) == queue->end()) {
+    if (item->is_queued())
+      throw torrent::internal_error(
+       "priority_queue_upsert(...) cannot insert an already queued item.");
+    item->set_time(t);
+    queue->push(item);
+  } else {
+    item->set_time(t);
+    queue->update();
+  }
 }
 
 }

--- a/src/data/hash_torrent.cc
+++ b/src/data/hash_torrent.cc
@@ -212,8 +212,7 @@ HashTorrent::queue(bool quick) {
 
       LT_LOG_THIS(INFO, "Completed (error): position:%u try_quick:%u errno:%i msg:'%s'.",
                   m_position, quick, m_errno, handle.error_number().c_str());
-      rak::priority_queue_erase(&taskScheduler, &m_delayChecked);
-      rak::priority_queue_insert(&taskScheduler, &m_delayChecked, cachedTime);
+      rak::priority_queue_upsert(&taskScheduler, &m_delayChecked, cachedTime);
       return;
     }
 
@@ -235,11 +234,10 @@ HashTorrent::queue(bool quick) {
   if (m_outstanding == 0) {
     LT_LOG_THIS(INFO, "Completed (normal): position:%u try_quick:%u.", m_position, quick);
 
-    // Erase the scheduled item just to make sure that if hashing is
+    // Update the scheduled item just to make sure that if hashing is
     // started again during the delay it won't cause an exception.
-    rak::priority_queue_erase(&taskScheduler, &m_delayChecked);
-    rak::priority_queue_insert(&taskScheduler, &m_delayChecked, cachedTime);
-   }
+    rak::priority_queue_upsert(&taskScheduler, &m_delayChecked, cachedTime);
+  }
 }
 
 }

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -313,8 +313,7 @@ DownloadMain::receive_tracker_success() {
   if (!info()->is_active())
     return;
 
-  priority_queue_erase(&taskScheduler, &m_taskTrackerRequest);
-  priority_queue_insert(&taskScheduler, &m_taskTrackerRequest, (cachedTime + rak::timer::from_seconds(10)).round_seconds());
+  priority_queue_upsert(&taskScheduler, &m_taskTrackerRequest, (cachedTime + rak::timer::from_seconds(10)).round_seconds());
 }
 
 void

--- a/src/download/download_wrapper.cc
+++ b/src/download/download_wrapper.cc
@@ -191,9 +191,8 @@ DownloadWrapper::receive_hash_done(ChunkHandle handle, const char* hash) {
         finished_download();
 
       } else if (was_partial && data()->wanted_chunks() == 0) {
-        priority_queue_erase(&taskScheduler, &m_main->delay_partially_done());
         priority_queue_erase(&taskScheduler, &m_main->delay_partially_restarted());
-        priority_queue_insert(&taskScheduler, &m_main->delay_partially_done(), cachedTime);
+        priority_queue_upsert(&taskScheduler, &m_main->delay_partially_done(), cachedTime);
       }
     
       if (!m_main->have_queue()->empty() && m_main->have_queue()->front().first >= cachedTime)

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -524,8 +524,7 @@ Handshake::read_peer() {
   manager->poll()->insert_write(this);
 
   // Give some extra time for reading/writing the bitfield.
-  priority_queue_erase(&taskScheduler, &m_taskTimeout);
-  priority_queue_insert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(120)).round_seconds());
+  priority_queue_upsert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(120)).round_seconds());
 
   return true;
 }

--- a/src/protocol/request_list.cc
+++ b/src/protocol/request_list.cc
@@ -147,7 +147,6 @@ void
 RequestList::unchoked() {
   m_last_unchoke = cachedTime;
 
-  priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
 
   // Clear choked queue if the peer doesn't start sending previously
   // requested pieces.
@@ -155,8 +154,10 @@ RequestList::unchoked() {
   // This handles the case where a peer does a choke immediately
   // followed unchoke before starting to send pieces.
   if (!m_queues.queue_empty(bucket_choked)) {
-    priority_queue_insert(&taskScheduler, &m_delay_remove_choked,
+    priority_queue_upsert(&taskScheduler, &m_delay_remove_choked,
                           (cachedTime + rak::timer::from_seconds(timeout_remove_choked)).round_seconds());
+  } else {
+    priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
   }
 }
 
@@ -244,8 +245,7 @@ RequestList::downloading(const Piece& piece) {
 
     // We make sure that the choked queue eventually gets cleared if
     // the peer has skipped sending some pieces from the choked queue.
-    priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
-    priority_queue_insert(&taskScheduler, &m_delay_remove_choked,
+    priority_queue_upsert(&taskScheduler, &m_delay_remove_choked,
                           (cachedTime + rak::timer::from_seconds(timeout_choked_received)).round_seconds());
     break;
   default:

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -69,8 +69,7 @@ TrackerController::update_timeout(uint32_t seconds_to_next) {
   if (seconds_to_next != 0)
     next_timeout = (cachedTime + rak::timer::from_seconds(seconds_to_next)).round_seconds();
 
-  priority_queue_erase(&taskScheduler, &m_private->task_timeout);
-  priority_queue_insert(&taskScheduler, &m_private->task_timeout, next_timeout);
+  priority_queue_upsert(&taskScheduler, &m_private->task_timeout, next_timeout);
 }
 
 inline int
@@ -145,8 +144,7 @@ TrackerController::scrape_request(uint32_t seconds_to_request) {
   if (seconds_to_request != 0)
     next_timeout = (cachedTime + rak::timer::from_seconds(seconds_to_request)).round_seconds();
 
-  priority_queue_erase(&taskScheduler, &m_private->task_scrape);
-  priority_queue_insert(&taskScheduler, &m_private->task_scrape, next_timeout);
+  priority_queue_upsert(&taskScheduler, &m_private->task_scrape, next_timeout);
 }
 
 // The send_*_event() functions tries to ensure the relevant trackers

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -274,8 +274,7 @@ TrackerUdp::event_read() {
 
     prepare_announce_input();
 
-    priority_queue_erase(&taskScheduler, &m_taskTimeout);
-    priority_queue_insert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(m_parent->info()->udp_timeout())).round_seconds());
+    priority_queue_upsert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(m_parent->info()->udp_timeout())).round_seconds());
 
     m_tries = m_parent->info()->udp_tries();
     manager->poll()->insert_write(this);


### PR DESCRIPTION
The erase/insert pattern can be replaced by a single method that updates an existing entry's timer, or inserting if it doesn't exist.

This primary goal was to reduce CPU usage when handling incoming connections on large instances, but since the optimization was pretty generic it's been applied to many places.