### PR TITLE
Speed up delegating by returning multiple request assignments at once

### DIFF
--- a/src/download/delegator.cc
+++ b/src/download/delegator.cc
@@ -130,7 +130,7 @@ Delegator::delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPiece
         if (!bl_itr->is_finished()) {
           BlockTransfer* inserted_info = bl_itr->insert(peerInfo);
           if (inserted_info != NULL) {
-            new_transfers.push_back(bl_itr->insert(peerInfo));
+            new_transfers.push_back(inserted_info);
             overlapped = bl_itr->size_not_stalled();
           }
         }

--- a/src/download/delegator.cc
+++ b/src/download/delegator.cc
@@ -1,3 +1,4 @@
+
 // libTorrent - BitTorrent library
 // Copyright (C) 2005-2011, Jari Sundell
 //
@@ -52,192 +53,133 @@
 
 namespace torrent {
 
-struct DelegatorCheckAffinity {
-  DelegatorCheckAffinity(Delegator* delegator, Block** target, unsigned int index, const PeerInfo* peerInfo) :
-    m_delegator(delegator), m_target(target), m_index(index), m_peerInfo(peerInfo) {}
-
-  bool operator () (BlockList* d) {
-    return m_index == d->index() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != NULL;
-  }
-
-  Delegator*          m_delegator;
-  Block**             m_target;
-  unsigned int        m_index;
-  const PeerInfo*     m_peerInfo;
-};
-
-struct DelegatorCheckSeeder {
-  DelegatorCheckSeeder(Delegator* delegator, Block** target, const PeerInfo* peerInfo) :
-    m_delegator(delegator), m_target(target), m_peerInfo(peerInfo) {}
-
-  bool operator () (BlockList* d) {
-    return d->by_seeder() && (*m_target = m_delegator->delegate_piece(d, m_peerInfo)) != NULL;
-  }
-
-  Delegator*          m_delegator;
-  Block**             m_target;
-  const PeerInfo*     m_peerInfo;
-};
-
-struct DelegatorCheckPriority {
-  DelegatorCheckPriority(Delegator* delegator, Block** target, priority_t p, const PeerChunks* peerChunks) :
-    m_delegator(delegator), m_target(target), m_priority(p), m_peerChunks(peerChunks) {}
-
-  bool operator () (BlockList* d) {
-    return
-      m_priority == d->priority() &&
-      m_peerChunks->bitfield()->get(d->index()) &&
-      (*m_target = m_delegator->delegate_piece(d, m_peerChunks->peer_info())) != NULL;
-  }
-
-  Delegator*          m_delegator;
-  Block**             m_target;
-  priority_t          m_priority;
-  const PeerChunks*   m_peerChunks;
-};
-
-// TODO: Should this ensure we don't download pieces that are priority off?
-struct DelegatorCheckAggressive {
-  DelegatorCheckAggressive(Delegator* delegator, Block** target, uint16_t* o, const PeerChunks* peerChunks) :
-    m_delegator(delegator), m_target(target), m_overlapp(o), m_peerChunks(peerChunks) {}
-
-  bool operator () (BlockList* d) {
-    Block* tmp;
-
-    if (!m_peerChunks->bitfield()->get(d->index()) ||
-        d->priority() == PRIORITY_OFF ||
-        (tmp = m_delegator->delegate_aggressive(d, m_overlapp, m_peerChunks->peer_info())) == NULL)
-      return false;
-
-    *m_target = tmp;
-    return m_overlapp == 0;
-  }
-
-  Delegator*          m_delegator;
-  Block**             m_target;
-  uint16_t*           m_overlapp;
-  const PeerChunks*   m_peerChunks;
-};
-
-BlockTransfer*
-Delegator::delegate(PeerChunks* peerChunks, int affinity) {
+std::vector<BlockTransfer*>
+Delegator::delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPieces) {
   // TODO: Make sure we don't queue the same piece several time on the same peer when
   // it timeout cancels them.
-  Block* target = NULL;
+  std::vector<BlockTransfer*> new_transfers;
+  PeerInfo* peerInfo = peerChunks->peer_info();
 
   // Find piece with same index as affinity. This affinity should ensure that we
   // never start another piece while the chunk this peer used to download is still
   // in progress.
-  //
+
   // TODO: What if the hash failed? Don't want data from that peer again.
-  if (affinity >= 0 && 
-      std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckAffinity(this, &target, affinity, peerChunks->peer_info()))
-      != m_transfers.end())
-    return target->insert(peerChunks->peer_info());
+  if (affinity >= 0) {
+    for (BlockList* itr : m_transfers) {
+      if (new_transfers.size() >= maxPieces)
+        return new_transfers;
+      if (affinity == itr->index())
+        delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
+    }
+  }
 
-  if (peerChunks->is_seeder() && (target = delegate_seeder(peerChunks)) != NULL)
-    return target->insert(peerChunks->peer_info());
+  // Prioritize full seeders
+  if (peerChunks->is_seeder()) {
+    for (BlockList* itr : m_transfers) {
+      if (new_transfers.size() >= maxPieces)
+        return new_transfers;
+      if (itr->by_seeder())
+        delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
+    }
+    // Create new high priority pieces.
+    delegate_new_chunks(new_transfers, maxPieces, peerChunks, true);
+    // Create new normal priority pieces.
+    delegate_new_chunks(new_transfers, maxPieces, peerChunks, false);
+  }
+  if (new_transfers.size() >= maxPieces)
+    return new_transfers;
 
-  // High priority pieces.
-  if (std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckPriority(this, &target, PRIORITY_HIGH, peerChunks))
-      != m_transfers.end())
-    return target->insert(peerChunks->peer_info());
+  // Find existing high priority pieces.
+  for (BlockList* itr : m_transfers) {
+    if (new_transfers.size() >= maxPieces)
+      return new_transfers;
+    if (itr->priority() == PRIORITY_HIGH && peerChunks->bitfield()->get(itr->index()))
+      delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
+  }
 
-  // Find normal priority pieces.
-  if ((target = new_chunk(peerChunks, true)))
-    return target->insert(peerChunks->peer_info());
+  // Create new high priority pieces.
+  delegate_new_chunks(new_transfers, maxPieces, peerChunks, true);
 
-  // Normal priority pieces.
-  if (std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckPriority(this, &target, PRIORITY_NORMAL, peerChunks))
-      != m_transfers.end())
-    return target->insert(peerChunks->peer_info());
+  // Find existing normal priority pieces.
+  for (BlockList* itr : m_transfers) {
+    if (new_transfers.size() >= maxPieces)
+      return new_transfers;
+    if (itr->priority() == PRIORITY_NORMAL && peerChunks->bitfield()->get(itr->index()))
+      delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
+  }
 
-  if ((target = new_chunk(peerChunks, false)))
-    return target->insert(peerChunks->peer_info());
+  // Create new normal priority pieces.
+  delegate_new_chunks(new_transfers, maxPieces, peerChunks, false);
 
   if (!m_aggressive)
-    return NULL;
+    return new_transfers;
 
-  // Aggressive mode, look for possible downloads that already have
-  // one or more queued.
+  // In aggressive mode, look for possible downloads that already have
+  // one or more transfers queued.
 
   // No more than 4 per piece.
   uint16_t overlapped = 5;
-
-  std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckAggressive(this, &target, &overlapped, peerChunks));
-
-  return target ? target->insert(peerChunks->peer_info()) : NULL;
-}
-  
-Block*
-Delegator::delegate_seeder(PeerChunks* peerChunks) {
-  Block* target = NULL;
-
-  if (std::find_if(m_transfers.begin(), m_transfers.end(), DelegatorCheckSeeder(this, &target, peerChunks->peer_info()))
-      != m_transfers.end())
-    return target;
-
-  if ((target = new_chunk(peerChunks, true)))
-    return target;
-  
-  if ((target = new_chunk(peerChunks, false)))
-    return target;
-
-  return NULL;
-}
-
-Block*
-Delegator::new_chunk(PeerChunks* pc, bool highPriority) {
-  uint32_t index = m_slot_chunk_find(pc, highPriority);
-
-  if (index == ~(uint32_t)0)
-    return NULL;
-
-  TransferList::iterator itr = m_transfers.insert(Piece(index, 0, m_slot_chunk_size(index)), block_size);
-
-  (*itr)->set_by_seeder(pc->is_seeder());
-
-  if (highPriority)
-    (*itr)->set_priority(PRIORITY_HIGH);
-  else
-    (*itr)->set_priority(PRIORITY_NORMAL);
-
-  return &*(*itr)->begin();
-}
-
-Block*
-Delegator::delegate_piece(BlockList* c, const PeerInfo* peerInfo) {
-  Block* p = NULL;
-
-  for (BlockList::iterator i = c->begin(); i != c->end(); ++i) {
-    if (i->is_finished() || !i->is_stalled())
-      continue;
-
-    if (i->size_all() == 0) {
-      // No one is downloading this, assign.
-      return &*i;
-
-    } else if (p == NULL && i->find(peerInfo) == NULL) {
-      // Stalled but we really want to finish this piece. Check 'p' so
-      // that we don't end up queuing the pieces in reverse.
-      p = &*i;
+  for (BlockList* itr : m_transfers) {
+    if (new_transfers.size() >= maxPieces)
+      return new_transfers;
+    if (peerChunks->bitfield()->get(itr->index()) && itr->priority() != PRIORITY_OFF) {
+      for (auto bl_itr = itr->begin(); bl_itr != itr->end() && overlapped != 0; bl_itr++) {
+        if (new_transfers.size() >= maxPieces || bl_itr->size_not_stalled() >= overlapped)
+          break;
+        if (!bl_itr->is_finished()) {
+          BlockTransfer* inserted_info = bl_itr->insert(peerInfo);
+          if (inserted_info != NULL) {
+            new_transfers.push_back(bl_itr->insert(peerInfo));
+            overlapped = bl_itr->size_not_stalled();
+          }
+        }
+      }
     }
   }
-      
-  return p;
+
+  return new_transfers;
 }
 
-Block*
-Delegator::delegate_aggressive(BlockList* c, uint16_t* overlapped, const PeerInfo* peerInfo) {
-  Block* p = NULL;
+void
+Delegator::delegate_new_chunks(std::vector<BlockTransfer*> &transfers, uint32_t maxPieces, PeerChunks* pc, bool highPriority) {
+  // Find new chunks and if successful, add all possible pieces into `transfers`
+  while (transfers.size() < maxPieces) {
+    uint32_t index = m_slot_chunk_find(pc, highPriority);
 
-  for (BlockList::iterator i = c->begin(); i != c->end() && *overlapped != 0; ++i)
-    if (!i->is_finished() && i->size_not_stalled() < *overlapped && i->find(peerInfo) == NULL) {
-      p = &*i;
-      *overlapped = i->size_not_stalled();
+    if (index == ~(uint32_t)0)
+      return;
+
+    TransferList::iterator itr = m_transfers.insert(Piece(index, 0, m_slot_chunk_size(index)), block_size);
+
+    (*itr)->set_by_seeder(pc->is_seeder());
+
+    if (highPriority)
+      (*itr)->set_priority(PRIORITY_HIGH);
+    else
+      (*itr)->set_priority(PRIORITY_NORMAL);
+    delegate_from_blocklist(transfers, maxPieces, *itr, pc->peer_info());
+  }
+}
+
+void
+Delegator::delegate_from_blocklist(std::vector<BlockTransfer*> &transfers, uint32_t maxPieces, BlockList* c, PeerInfo* peerInfo) {
+  for (auto i = c->begin(); i != c->end() && transfers.size() < maxPieces; ++i) {
+    // If not finished and stalled, and no one is downloading this, then assign
+    if (!i->is_finished() && i->is_stalled() && i->size_all() == 0)
+      transfers.push_back(i->insert(peerInfo));
+  }
+  if (transfers.size() >= maxPieces)
+    return;
+
+  // Fill any remaining slots with potentially stalled pieces.
+  for (auto i = c->begin(); i != c->end() && transfers.size() < maxPieces; ++i) {
+    if (!i->is_finished() && i->is_stalled()) {
+      BlockTransfer* inserted_info = i->insert(peerInfo);
+      if (inserted_info != NULL)
+        transfers.push_back(inserted_info);
     }
-      
-  return p;
+  }
 }
 
 } // namespace torrent

--- a/src/download/delegator.h
+++ b/src/download/delegator.h
@@ -64,7 +64,7 @@ public:
   TransferList*       transfer_list()                     { return &m_transfers; }
   const TransferList* transfer_list() const               { return &m_transfers; }
 
-  BlockTransfer*     delegate(PeerChunks* peerChunks, int affinity);
+  std::vector<BlockTransfer*> delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPieces);
 
   bool               get_aggressive()                     { return m_aggressive; }
   void               set_aggressive(bool a)               { m_aggressive = a; }
@@ -72,15 +72,9 @@ public:
   slot_peer_chunk&   slot_chunk_find()                    { return m_slot_chunk_find; }
   slot_size&         slot_chunk_size()                    { return m_slot_chunk_size; }
 
-  // Don't call this from the outside.
-  Block*             delegate_piece(BlockList* c, const PeerInfo* peerInfo);
-  Block*             delegate_aggressive(BlockList* c, uint16_t* overlapped, const PeerInfo* peerInfo);
-
 private:
-  // Start on a new chunk, returns .end() if none possible. bf is
-  // remote peer's bitfield.
-  Block*             new_chunk(PeerChunks* pc, bool highPriority);
-
+  void               delegate_from_blocklist(std::vector<BlockTransfer*> &transfers, uint32_t maxPieces, BlockList* c, PeerInfo* peerInfo);
+  void               delegate_new_chunks(std::vector<BlockTransfer*> &transfers, uint32_t maxPieces, PeerChunks* pc, bool highPriority);
   Block*             delegate_seeder(PeerChunks* peerChunks);
 
   TransferList       m_transfers;

--- a/src/protocol/peer_connection_metadata.cc
+++ b/src/protocol/peer_connection_metadata.cc
@@ -436,10 +436,12 @@ PeerConnectionMetadata::try_request_metadata_pieces() {
   if (!m_up->can_write_extension() || m_extensions->has_pending_message())
     return false;
 
-  const Piece* p = request_list()->delegate();
+  std::vector<const Piece*> pieces = request_list()->delegate(1);
 
-  if (p == NULL)
+  if (pieces.empty())
     return false;
+
+  const Piece* p = pieces.front();
 
   if (!m_download->file_list()->is_valid_piece(*p) || !m_peerChunks.bitfield()->get(p->index()))
     throw internal_error("PeerConnectionMetadata::try_request_metadata_pieces() tried to use an invalid piece.");

--- a/src/protocol/protocol_base.h
+++ b/src/protocol/protocol_base.h
@@ -144,12 +144,15 @@ public:
   bool                can_write_port() const                  { return m_buffer.reserved_left() >= sizeof_port; }
   bool                can_write_extension() const             { return m_buffer.reserved_left() >= sizeof_extension; }
 
+  size_type           max_write_request() const               { return m_buffer.reserved_left() / sizeof_request; }
+
   bool                can_read_have_body() const              { return m_buffer.remaining() >= sizeof_have_body; }
   bool                can_read_request_body() const           { return m_buffer.remaining() >= sizeof_request_body; }
   bool                can_read_cancel_body() const            { return m_buffer.remaining() >= sizeof_request_body; }
   bool                can_read_piece_body() const             { return m_buffer.remaining() >= sizeof_piece_body; }
   bool                can_read_port_body() const              { return m_buffer.remaining() >= sizeof_port_body; }
   bool                can_read_extension_body() const         { return m_buffer.remaining() >= sizeof_extension_body; }
+
 
 protected:
   State               m_state;

--- a/src/protocol/request_list.h
+++ b/src/protocol/request_list.h
@@ -38,6 +38,7 @@
 #define LIBTORRENT_REQUEST_LIST_H
 
 #include <deque>
+#include <vector>
 
 #include "torrent/data/block_transfer.h"
 #include "utils/instrumentation.h"
@@ -80,8 +81,7 @@ public:
 
   // Some parameters here, like how fast we are downloading and stuff
   // when we start considering those.
-  const Piece*         delegate();
-
+  std::vector<const Piece*>  delegate(uint32_t maxPieces);
   void                 stall_initial();
   void                 stall_prolonged();
 

--- a/src/torrent/data/block.cc
+++ b/src/torrent/data/block.cc
@@ -80,7 +80,7 @@ Block::~Block() {
 BlockTransfer*
 Block::insert(PeerInfo* peerInfo) {
   if (find_queued(peerInfo) || find_transfer(peerInfo))
-    throw internal_error("Block::insert(...) find_queued(peerInfo) || find_transfer(peerInfo).");
+    return NULL;
 
   m_notStalled++;
 

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -126,9 +126,12 @@ public:
   // block == NULL.
   static void               release(BlockTransfer* transfer);
 
+  // Only allow move constructions
+  Block(const Block&) = delete;
+  void operator = (const Block&) = delete;
+  Block(Block&&) = default;
+
 private:
-  Block(const Block&);
-  void operator = (const Block&);
 
   void                      invalidate_transfer(BlockTransfer* transfer) LIBTORRENT_NO_EXPORT;
 

--- a/src/torrent/data/block_list.h
+++ b/src/torrent/data/block_list.h
@@ -1,3 +1,4 @@
+
 // libTorrent - BitTorrent library
 // Copyright (C) 2005-2011, Jari Sundell
 //
@@ -44,70 +45,27 @@
 
 namespace torrent {
 
-// Temporary workaround until we can use C++11's std::vector::emblace_back.
-template <typename Type>
-class no_copy_vector {
+class LIBTORRENT_EXPORT BlockList : private std::vector<Block> {
 public:
-  typedef Type        value_type;
-  typedef size_t      size_type;
-  typedef value_type& reference;
-  typedef ptrdiff_t   difference_type;
-
-  typedef value_type*       iterator;
-  typedef const value_type* const_iterator;
-
-  no_copy_vector() : m_size(0), m_values(NULL) {}
-  ~no_copy_vector() { clear(); }
-
-  size_type size() const { return m_size; }
-  bool      empty() const { return m_size == 0; }
-
-  void resize(size_type s) { clear(); m_size = s; m_values = new value_type[s]; }
-
-  void clear() { delete [] m_values; m_values = NULL; m_size = 0; }
-
-  iterator       begin() { return m_values; }
-  const_iterator begin() const { return m_values; }
-
-  iterator       end() { return m_values + m_size; }
-  const_iterator end() const { return m_values + m_size; }
-
-  value_type&    back() { return *(m_values + m_size - 1); }
-
-  value_type&    operator[](size_type idx) { return m_values[idx]; }
-
-private:
-  no_copy_vector(const no_copy_vector&);
-  void operator = (const no_copy_vector&);
-
-  size_type m_size;
-  Block*    m_values;
-};
-
-class LIBTORRENT_EXPORT BlockList : public no_copy_vector<Block> {
-public:
-  typedef no_copy_vector<Block> base_type;
-  typedef uint32_t              size_type;
+  typedef uint32_t           size_type;
+  typedef std::vector<Block> base_type;
 
   using base_type::value_type;
   using base_type::reference;
   using base_type::difference_type;
 
   using base_type::iterator;
-  // using base_type::reverse_iterator;
+  using base_type::const_iterator;
   using base_type::size;
   using base_type::empty;
 
   using base_type::begin;
   using base_type::end;
-  // using base_type::rbegin;
-  // using base_type::rend;
 
   using base_type::operator[];
 
   BlockList(const Piece& piece, uint32_t blockLength);
   ~BlockList();
-
   bool                is_all_finished() const       { return m_finished == size(); }
 
   const Piece&        piece() const                 { return m_piece; }


### PR DESCRIPTION
This should follow the same logic as before, which I double-checked by graphing the piece progress from the `LT_LOG_PIECE_EVENTS` log and confirming the same patterns showed up.

In addition to the main change, this also makes some other performance improvements:
 * Modifies `Block::insert` to return a NULL if the peer already exists, to avoid needing to scanning for the peer info twice.
 * `BlockList` uses a regular `std::vector` with the copy assignment/constructor disabled