### PR TITLE
Increase max throttle speed to 33 gigabits

### DIFF
--- a/src/torrent/throttle.cc
+++ b/src/torrent/throttle.cc
@@ -36,6 +36,8 @@
 
 #include "config.h"
 
+#include <climits>
+
 #include <rak/timer.h> 
 
 #include "net/throttle_internal.h"
@@ -77,18 +79,18 @@ Throttle::create_slave() {
 
 bool
 Throttle::is_throttled() {
-  return m_maxRate != 0 && m_maxRate != std::numeric_limits<uint32_t>::max();
+  return m_maxRate != 0 && m_maxRate < UINT_MAX;
 }
 
 void
-Throttle::set_max_rate(uint32_t v) {
+Throttle::set_max_rate(uint64_t v) {
   if (v == m_maxRate)
     return;
 
-  if (v > (1 << 30))
-    throw input_error("Throttle rate must be between 0 and 2^30.");
+  if (v > (UINT_MAX - 1))
+    throw input_error("Throttle rate must be between 0 and 4294967295.");
 
-  uint32_t oldRate = m_maxRate;
+  uint64_t oldRate = m_maxRate;
   m_maxRate = v;
 
   m_throttleList->set_min_chunk_size(calculate_min_chunk_size());

--- a/src/torrent/throttle.h
+++ b/src/torrent/throttle.h
@@ -54,8 +54,8 @@ public:
   bool                is_throttled();
 
   // 0 == UNLIMITED.
-  uint32_t            max_rate() const { return m_maxRate; }
-  void                set_max_rate(uint32_t v);
+  uint64_t            max_rate() const { return m_maxRate; }
+  void                set_max_rate(uint64_t v);
 
   const Rate*         rate() const;
 
@@ -72,7 +72,7 @@ protected:
   uint32_t            calculate_max_chunk_size() const LIBTORRENT_NO_EXPORT;
   uint32_t            calculate_interval() const LIBTORRENT_NO_EXPORT;
 
-  uint32_t            m_maxRate;
+  uint64_t            m_maxRate;
 
   ThrottleList*       m_throttleList;
 };


### PR DESCRIPTION
This commit increases the max throttle speed from 1.6 gigabits to 33 gigabits.

It's no longer possible to use a bit shift operator and we must use some 64 bit unsigned integers.

This is critically useful for ruTorrent to restore throttle functionality, since many connections now exceed 1.6 gigabits.