### PR TITLE
Remove unused code and convert some functions to lamdas/std::fun

### DIFF
--- a/rak/functional.h
+++ b/rak/functional.h
@@ -52,21 +52,6 @@ struct reference_fix<Type&> {
   typedef Type type;
 };
 
-template <typename Type>
-struct value_t {
-  value_t(Type v) : m_v(v) {}
-
-  Type operator () () const { return m_v; }
-
-  Type m_v;
-};
-
-template <typename Type>
-inline value_t<Type>
-value(Type v) {
-  return value_t<Type>(v);
-}
-
 template <typename Type, typename Ftor>
 struct accumulate_t {
   accumulate_t(Type t, Ftor f) : result(t), m_f(f) {}
@@ -105,27 +90,6 @@ template <typename Type, typename Ftor>
 inline equal_t<Type, Ftor>
 equal(Type t, Ftor f) {
   return equal_t<Type, Ftor>(t, f);
-}
-
-template <typename Type, typename Ftor>
-struct equal_ptr_t {
-  typedef bool result_type;
-
-  equal_ptr_t(Type* t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (const Arg& a) {
-    return *m_t == *m_f(a);
-  }
-
-  Type* m_t;
-  Ftor  m_f;
-};
-
-template <typename Type, typename Ftor>
-inline equal_ptr_t<Type, Ftor>
-equal_ptr(Type* t, Ftor f) {
-  return equal_ptr_t<Type, Ftor>(t, f);
 }
 
 template <typename Type, typename Ftor>
@@ -186,45 +150,6 @@ template <typename FtorA, typename FtorB>
 inline less2_t<FtorA, FtorB>
 less2(FtorA f_a, FtorB f_b) {
   return less2_t<FtorA,FtorB>(f_a,f_b);
-}
-
-template <typename Type, typename Ftor>
-struct _greater {
-  typedef bool result_type;
-
-  _greater(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t > m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline _greater<Type, Ftor>
-greater(Type t, Ftor f) {
-  return _greater<Type, Ftor>(t, f);
-}
-
-template <typename FtorA, typename FtorB>
-struct greater2_t : public std::binary_function<typename FtorA::argument_type, typename FtorB::argument_type, bool> {
-  greater2_t(FtorA f_a, FtorB f_b) : m_f_a(f_a), m_f_b(f_b) {}
-
-  bool operator () (typename FtorA::argument_type a, typename FtorB::argument_type b) {
-    return m_f_a(a) > m_f_b(b);
-  }
-
-  FtorA m_f_a;
-  FtorB m_f_b;
-};
-
-template <typename FtorA, typename FtorB>
-inline greater2_t<FtorA, FtorB>
-greater2(FtorA f_a, FtorB f_b) {
-  return greater2_t<FtorA,FtorB>(f_a,f_b);
 }
 
 template <typename Type, typename Ftor>
@@ -295,48 +220,6 @@ on(Src s, Dest d) {
   return on_t<Src, Dest>(s, d);
 }  
 
-template <typename Src, typename Dest>
-struct on2_t : public std::binary_function<typename Src::argument_type, typename Dest::second_argument_type, typename Dest::result_type> {
-  typedef typename Dest::result_type result_type;
-
-  on2_t(Src s, Dest d) : m_dest(d), m_src(s) {}
-
-  result_type operator () (typename reference_fix<typename Src::argument_type>::type first, typename reference_fix<typename Dest::second_argument_type>::type second) {
-    return m_dest(m_src(first), second);
-  }
-
-  Dest m_dest;
-  Src m_src;
-};
-    
-template <typename Src, typename Dest>
-inline on2_t<Src, Dest>
-on2(Src s, Dest d) {
-  return on2_t<Src, Dest>(s, d);
-}  
-
-// Creates a functor for accessing a member.
-template <typename Class, typename Member>
-struct mem_ptr_t : public std::unary_function<Class*, Member&> {
-  mem_ptr_t(Member Class::*m) : m_member(m) {}
-
-  Member& operator () (Class* c) {
-    return c->*m_member;
-  }
-
-  const Member& operator () (const Class* c) {
-    return c->*m_member;
-  }
-
-  Member Class::*m_member;
-};
-
-template <typename Class, typename Member>
-inline mem_ptr_t<Class, Member>
-mem_ptr(Member Class::*m) {
-  return mem_ptr_t<Class, Member>(m);
-}
-
 template <typename Class, typename Member>
 struct mem_ref_t : public std::unary_function<Class&, Member&> {
   mem_ref_t(Member Class::*m) : m_member(m) {}
@@ -371,26 +254,6 @@ const_mem_ref(const Member Class::*m) {
   return const_mem_ref_t<Class, Member>(m);
 }
 
-template <typename Cond, typename Then>
-struct if_then_t {
-  if_then_t(Cond c, Then t) : m_cond(c), m_then(t) {}
-
-  template <typename Arg>
-  void operator () (Arg& a) {
-    if (m_cond(a))
-      m_then(a);
-  }
-
-  Cond m_cond;
-  Then m_then;
-};
-
-template <typename Cond, typename Then>
-inline if_then_t<Cond, Then>
-if_then(Cond c, Then t) {
-  return if_then_t<Cond, Then>(c, t);
-}
-
 template <typename T>
 struct call_delete : public std::unary_function<T*, void> {
   void operator () (T* t) {
@@ -402,31 +265,6 @@ template <typename T>
 inline void
 call_delete_func(T* t) {
   delete t;
-}
-
-template <typename Operation>
-class bind1st_t : public std::unary_function<typename Operation::second_argument_type, typename Operation::result_type> {
-public:
-  typedef typename reference_fix<typename Operation::first_argument_type>::type  value_type;
-  typedef typename reference_fix<typename Operation::second_argument_type>::type argument_type;
-
-  bind1st_t(const Operation& op, const value_type v) :
-    m_op(op), m_value(v) {}
-
-  typename Operation::result_type
-  operator () (const argument_type arg) {
-    return m_op(m_value, arg);
-  }
-
-protected:
-  Operation  m_op;
-  value_type m_value;
-};
-
-template <typename Operation, typename Type>
-inline bind1st_t<Operation>
-bind1st(const Operation& op, const Type& val) {
-  return bind1st_t<Operation>(op, val);
 }
 
 template <typename Operation>
@@ -458,59 +296,6 @@ bind2nd(const Operation& op, const Type& val) {
 // be replaced by TR1 stuff later. Requires an object to bind, instead
 // of using a seperate functor for that.
 
-template <typename Ret>
-class ptr_fun0 {
-public:
-  typedef Ret result_type;
-  typedef Ret (*Function)();
-
-  ptr_fun0() {}
-  ptr_fun0(Function f) : m_function(f) {}
-
-  bool is_valid() const { return m_function; }
-
-  Ret operator () () { return m_function(); }
-  
-private:
-  Function m_function;
-};
-
-template <typename Object, typename Ret>
-class mem_fun0 {
-public:
-  typedef Ret result_type;
-  typedef Ret (Object::*Function)();
-
-  mem_fun0() : m_object(NULL) {}
-  mem_fun0(Object* o, Function f) : m_object(o), m_function(f) {}
-
-  bool is_valid() const { return m_object; }
-
-  Ret operator () () { return (m_object->*m_function)(); }
-  
-private:
-  Object* m_object;
-  Function m_function;
-};
-
-template <typename Object, typename Ret>
-class const_mem_fun0 {
-public:
-  typedef Ret result_type;
-  typedef Ret (Object::*Function)() const;
-
-  const_mem_fun0() : m_object(NULL) {}
-  const_mem_fun0(const Object* o, Function f) : m_object(o), m_function(f) {}
-
-  bool is_valid() const { return m_object; }
-
-  Ret operator () () const { return (m_object->*m_function)(); }
-  
-private:
-  const Object* m_object;
-  Function      m_function;
-};
-
 template <typename Object, typename Ret, typename Arg1>
 class mem_fun1 {
 public:
@@ -530,101 +315,9 @@ private:
 };
 
 template <typename Object, typename Ret, typename Arg1>
-class const_mem_fun1 {
-public:
-  typedef Ret result_type;
-  typedef Ret (Object::*Function)(Arg1) const;
-
-  const_mem_fun1() : m_object(NULL) {}
-  const_mem_fun1(const Object* o, Function f) : m_object(o), m_function(f) {}
-
-  bool is_valid() const { return m_object; }
-
-  Ret operator () (Arg1 a1) const { return (m_object->*m_function)(a1); }
-  
-private:
-  const Object* m_object;
-  Function      m_function;
-};
-
-template <typename Object, typename Ret, typename Arg1, typename Arg2>
-class mem_fun2 : public std::binary_function<Arg1, Arg2, Ret> {
-public:
-  typedef Ret result_type;
-  typedef Ret (Object::*Function)(Arg1, Arg2);
-  typedef Object object_type;
-
-  mem_fun2() : m_object(NULL) {}
-  mem_fun2(Object* o, Function f) : m_object(o), m_function(f) {}
-
-  bool         is_valid() const { return m_object; }
-
-  object_type*       object() { return m_object; }
-  const object_type* object() const { return m_object; }
-
-  Ret          operator () (Arg1 a1, Arg2 a2) { return (m_object->*m_function)(a1, a2); }
-  
-private:
-  Object* m_object;
-  Function m_function;
-};
-
-template <typename Object, typename Ret, typename Arg1, typename Arg2, typename Arg3>
-class mem_fun3 {
-public:
-  typedef Ret result_type;
-  typedef Ret (Object::*Function)(Arg1, Arg2, Arg3);
-
-  mem_fun3() : m_object(NULL) {}
-  mem_fun3(Object* o, Function f) : m_object(o), m_function(f) {}
-
-  bool is_valid() const { return m_object; }
-
-  Ret operator () (Arg1 a1, Arg2 a2, Arg3 a3) { return (m_object->*m_function)(a1, a2, a3); }
-  
-private:
-  Object* m_object;
-  Function m_function;
-};
-
-template <typename Ret>
-inline ptr_fun0<Ret>
-ptr_fun(Ret (*f)()) { return ptr_fun0<Ret>(f); }
-
-template <typename Object, typename Ret>
-inline mem_fun0<Object, Ret>
-make_mem_fun(Object* o, Ret (Object::*f)()) {
- return mem_fun0<Object, Ret>(o, f);
-}
-
-template <typename Object, typename Ret>
-inline const_mem_fun0<Object, Ret>
-make_mem_fun(const Object* o, Ret (Object::*f)() const) {
- return const_mem_fun0<Object, Ret>(o, f);
-}
-
-template <typename Object, typename Ret, typename Arg1>
 inline mem_fun1<Object, Ret, Arg1>
 make_mem_fun(Object* o, Ret (Object::*f)(Arg1)) {
  return mem_fun1<Object, Ret, Arg1>(o, f);
-}
-
-template <typename Object, typename Ret, typename Arg1>
-inline const_mem_fun1<Object, Ret, Arg1>
-make_mem_fun(const Object* o, Ret (Object::*f)(Arg1) const) {
- return const_mem_fun1<Object, Ret, Arg1>(o, f);
-}
-
-template <typename Object, typename Ret, typename Arg1, typename Arg2>
-inline mem_fun2<Object, Ret, Arg1, Arg2>
-make_mem_fun(Object* o, Ret (Object::*f)(Arg1, Arg2)) {
- return mem_fun2<Object, Ret, Arg1, Arg2>(o, f);
-}
-
-template <typename Object, typename Ret, typename Arg1, typename Arg2, typename Arg3>
-inline mem_fun3<Object, Ret, Arg1, Arg2, Arg3>
-make_mem_fun(Object* o, Ret (Object::*f)(Arg1, Arg2, Arg3)) {
- return mem_fun3<Object, Ret, Arg1, Arg2, Arg3>(o, f);
 }
 
 template <typename Container>
@@ -659,23 +352,6 @@ slot_list_call(const Container& slot_list, Arg1 arg1) {
   }
 
   (*first)(arg1);
-}
-
-template <typename Container, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-inline void
-slot_list_call(const Container& slot_list, Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4) {
-  if (slot_list.empty())
-    return;
-
-  typename Container::const_iterator first = slot_list.begin();
-  typename Container::const_iterator next = slot_list.begin();
-
-  while (++next != slot_list.end()) {
-    (*first)(arg1, arg2, arg3, arg4);
-    first = next;
-  }
-
-  (*first)(arg1, arg2, arg3, arg4);
 }
 
 }

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -217,9 +217,9 @@ DownloadConstructor::add_tracker_group(const Object& b) {
   if (!b.is_list())
     throw bencode_error("Tracker group list not a list");
 
-  std::for_each(b.as_list().begin(), b.as_list().end(),
-		rak::bind2nd(rak::make_mem_fun(this, &DownloadConstructor::add_tracker_single),
-			     m_download->main()->tracker_list()->size_group()));
+  for (const auto& tracker : b.as_list()) {
+    add_tracker_single(tracker, m_download->main()->tracker_list()->size_group());
+  }
 }
 
 void

--- a/src/download/download_main.h
+++ b/src/download/download_main.h
@@ -93,16 +93,16 @@ public:
   void                setup_delegator();
   void                setup_tracker();
 
-  typedef rak::const_mem_fun1<HandshakeManager, uint32_t, DownloadMain*>                   SlotCountHandshakes;
-  typedef rak::mem_fun1<DownloadWrapper, void, ChunkHandle>                                SlotHashCheckAdd;
+  typedef std::function<uint32_t(DownloadMain*)>                         slot_count_handshakes_type;
+  typedef std::function<void(ChunkHandle)>                               slot_hash_check_add_type;
 
-  typedef rak::mem_fun2<HandshakeManager, void, const rak::socket_address&, DownloadMain*> slot_start_handshake_type;
-  typedef rak::mem_fun1<HandshakeManager, void, DownloadMain*>                             slot_stop_handshakes_type;
+  typedef std::function<void(const rak::socket_address&, DownloadMain*)> slot_start_handshake_type;
+  typedef std::function<void(DownloadMain*)>                             slot_stop_handshakes_type;
 
   void                slot_start_handshake(slot_start_handshake_type s) { m_slotStartHandshake = s; }
   void                slot_stop_handshakes(slot_stop_handshakes_type s) { m_slotStopHandshakes = s; }
-  void                slot_count_handshakes(SlotCountHandshakes s) { m_slotCountHandshakes = s; }
-  void                slot_hash_check_add(SlotHashCheckAdd s)      { m_slotHashCheckAdd = s; }
+  void                slot_count_handshakes(slot_count_handshakes_type s) { m_slotCountHandshakes = s; }
+  void                slot_hash_check_add(slot_hash_check_add_type s)     { m_slotHashCheckAdd = s; }
 
   void                add_peer(const rak::socket_address& sa);
 
@@ -165,8 +165,8 @@ private:
   slot_start_handshake_type m_slotStartHandshake;
   slot_stop_handshakes_type m_slotStopHandshakes;
 
-  SlotCountHandshakes m_slotCountHandshakes;
-  SlotHashCheckAdd    m_slotHashCheckAdd;
+  slot_count_handshakes_type m_slotCountHandshakes;
+  slot_hash_check_add_type   m_slotHashCheckAdd;
 
   rak::priority_item  m_delay_download_done;
   rak::priority_item  m_delay_partially_done;

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -93,8 +93,12 @@ Manager::~Manager() {
 
 void
 Manager::initialize_download(DownloadWrapper* d) {
-  d->main()->slot_count_handshakes(rak::make_mem_fun(m_handshakeManager, &HandshakeManager::size_info));
-  d->main()->slot_start_handshake(rak::make_mem_fun(m_handshakeManager, &HandshakeManager::add_outgoing));
+  d->main()->slot_count_handshakes([this](DownloadMain* download) {
+    return m_handshakeManager->size_info(download);
+  });
+  d->main()->slot_start_handshake([this](const rak::socket_address& sa, DownloadMain* download) {
+    return m_handshakeManager->add_outgoing(sa, download);
+  });
   d->main()->slot_stop_handshakes(rak::make_mem_fun(m_handshakeManager, &HandshakeManager::erase_download));
 
   // TODO: The resource manager doesn't need to know about this

--- a/src/protocol/peer_connection_leech.cc
+++ b/src/protocol/peer_connection_leech.cc
@@ -543,8 +543,10 @@ PeerConnection<type>::fill_write_buffer() {
       !haveQueue->empty() &&
       m_peerChunks.have_timer() <= haveQueue->front().first &&
       m_up->can_write_have()) {
-    DownloadMain::have_queue_type::iterator last = std::find_if(haveQueue->begin(), haveQueue->end(),
-                                                                rak::greater(m_peerChunks.have_timer(), rak::mem_ref(&DownloadMain::have_queue_type::value_type::first)));
+
+    auto last = std::find_if(haveQueue->begin(), haveQueue->end(), [this](auto v) {
+      return m_peerChunks.have_timer() > v.first;
+    });
 
     do {
       m_up->write_have((--last)->second);

--- a/src/torrent/peer/connection_list.cc
+++ b/src/torrent/peer/connection_list.cc
@@ -219,9 +219,9 @@ ConnectionList::find(const char* id) {
 
 ConnectionList::iterator
 ConnectionList::find(const sockaddr* sa) {
-  return std::find_if(begin(), end(), rak::equal_ptr(rak::socket_address::cast_from(sa),
-                                                     rak::on(std::mem_fun(&Peer::m_ptr), rak::on(std::mem_fun(&PeerConnectionBase::peer_info),
-                                                                                                 std::mem_fun(&PeerInfo::socket_address)))));
+  return std::find_if(begin(), end(), [sa](Peer* p) {
+    return *rak::socket_address::cast_from(sa) == *p->m_ptr()->peer_info()->socket_address();
+  });
 }
 
 void


### PR DESCRIPTION
All the code in functional.h should be able to be replaced by the C++11 constructs. This first PR is more just demonstration, removing unused functions and replacing a couple of the lesser-used ones to ensure a) these patterns are something you're good with and b) before the changes need to happen across a ton of different files. If you're good with the changes, I'd be happy to put all them in this PR, or create multiple medium-sized ones, etc, whatever you'd prefer.