### PR TITLE
Convert more of functional.h to standard library constructs

### DIFF
--- a/rak/functional.h
+++ b/rak/functional.h
@@ -52,23 +52,6 @@ struct reference_fix<Type&> {
   typedef Type type;
 };
 
-template <typename Type, typename Ftor>
-struct accumulate_t {
-  accumulate_t(Type t, Ftor f) : result(t), m_f(f) {}
-
-  template <typename Arg>
-  void operator () (const Arg& a) { result += m_f(a); }
-
-  Type result;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline accumulate_t<Type, Ftor>
-accumulate(Type t, Ftor f) {
-  return accumulate_t<Type, Ftor>(t, f);
-}
-
 // Operators:
 
 template <typename Type, typename Ftor>
@@ -93,27 +76,6 @@ equal(Type t, Ftor f) {
 }
 
 template <typename Type, typename Ftor>
-struct not_equal_t {
-  typedef bool result_type;
-
-  not_equal_t(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t != m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline not_equal_t<Type, Ftor>
-not_equal(Type t, Ftor f) {
-  return not_equal_t<Type, Ftor>(t, f);
-}
-
-template <typename Type, typename Ftor>
 struct less_t {
   typedef bool result_type;
 
@@ -132,24 +94,6 @@ template <typename Type, typename Ftor>
 inline less_t<Type, Ftor>
 less(Type t, Ftor f) {
   return less_t<Type, Ftor>(t, f);
-}
-
-template <typename FtorA, typename FtorB>
-struct less2_t : public std::binary_function<typename FtorA::argument_type, typename FtorB::argument_type, bool> {
-  less2_t(FtorA f_a, FtorB f_b) : m_f_a(f_a), m_f_b(f_b) {}
-
-  bool operator () (typename FtorA::argument_type a, typename FtorB::argument_type b) {
-    return m_f_a(a) < m_f_b(b);
-  }
-
-  FtorA m_f_a;
-  FtorB m_f_b;
-};
-
-template <typename FtorA, typename FtorB>
-inline less2_t<FtorA, FtorB>
-less2(FtorA f_a, FtorB f_b) {
-  return less2_t<FtorA,FtorB>(f_a,f_b);
 }
 
 template <typename Type, typename Ftor>
@@ -172,33 +116,6 @@ inline less_equal_t<Type, Ftor>
 less_equal(Type t, Ftor f) {
   return less_equal_t<Type, Ftor>(t, f);
 }
-
-template <typename Type, typename Ftor>
-struct greater_equal_t {
-  typedef bool result_type;
-
-  greater_equal_t(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t >= m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline greater_equal_t<Type, Ftor>
-greater_equal(Type t, Ftor f) {
-  return greater_equal_t<Type, Ftor>(t, f);
-}
-
-template<typename Tp>
-struct invert : public std::unary_function<Tp, Tp> {
-  Tp
-  operator () (const Tp& x) const { return ~x; }
-};
 
 template <typename Src, typename Dest>
 struct on_t : public std::unary_function<typename Src::argument_type, typename Dest::result_type> {
@@ -260,37 +177,6 @@ struct call_delete : public std::unary_function<T*, void> {
     delete t;
   }
 };
-
-template <typename T>
-inline void
-call_delete_func(T* t) {
-  delete t;
-}
-
-template <typename Operation>
-class bind2nd_t : public std::unary_function<typename Operation::first_argument_type, typename Operation::result_type> {
-public:
-  typedef typename reference_fix<typename Operation::first_argument_type>::type argument_type;
-  typedef typename reference_fix<typename Operation::second_argument_type>::type value_type;
-
-  bind2nd_t(const Operation& op, const value_type v) :
-    m_op(op), m_value(v) {}
-
-  typename Operation::result_type
-  operator () (argument_type arg) {
-    return m_op(arg, m_value);
-  }
-
-protected:
-  Operation  m_op;
-  value_type m_value;
-};
-
-template <typename Operation, typename Type>
-inline bind2nd_t<Operation>
-bind2nd(const Operation& op, const Type& val) {
-  return bind2nd_t<Operation>(op, val);
-}
 
 // Lightweight callback function including pointer to object. Should
 // be replaced by TR1 stuff later. Requires an object to bind, instead

--- a/src/data/chunk_list.cc
+++ b/src/data/chunk_list.cc
@@ -291,7 +291,9 @@ ChunkList::sync_chunks(int flags) {
   if (flags & sync_all)
     split = m_queue.begin();
   else
-    split = std::stable_partition(m_queue.begin(), m_queue.end(), rak::not_equal(1, std::mem_fun(&ChunkListNode::writable)));
+    split = std::stable_partition(m_queue.begin(), m_queue.end(), [](ChunkListNode* n) {
+      return 1 != n->writable();
+    });
 
   // Allow a flag that does more culling, so that we only get large
   // continous sections.

--- a/src/download/chunk_selector.cc
+++ b/src/download/chunk_selector.cc
@@ -59,7 +59,7 @@ ChunkSelector::initialize(ChunkStatistics* cs) {
 
   untouched->set_size_bits(completed->size_bits());
   untouched->allocate();
-  std::transform(completed->begin(), completed->end(), untouched->begin(), rak::invert<Bitfield::value_type>());
+  std::transform(completed->begin(), completed->end(), untouched->begin(), [](const Bitfield::value_type& v) { return ~v; });
   untouched->update();
 
   m_sharedQueue.enable(32);

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -359,7 +359,9 @@ DownloadConstructor::choose_path(std::list<Path>* pathList) {
   EncodingList::const_iterator encodingLast  = m_encodingList->end();
   
   for ( ; encodingFirst != encodingLast; ++encodingFirst) {
-    std::list<Path>::iterator itr = std::find_if(pathFirst, pathLast, rak::bind2nd(download_constructor_encoding_match(), encodingFirst->c_str()));
+    auto itr = std::find_if(pathFirst, pathLast, [encodingFirst](const Path& p) {
+      return download_constructor_encoding_match()(p, encodingFirst->c_str());
+    });
     
     if (itr != pathLast)
       pathList->splice(pathFirst, *pathList, itr);

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -73,8 +73,9 @@ HandshakeManager::find(const rak::socket_address& sa) {
 
 void
 HandshakeManager::erase_download(DownloadMain* info) {
-  iterator split = std::partition(base_type::begin(), base_type::end(),
-                                  rak::not_equal(info, std::mem_fun(&Handshake::download)));
+  auto split = std::partition(base_type::begin(), base_type::end(), [info](Handshake* h) {
+    return info != h->download();
+  });
 
   std::for_each(split, base_type::end(), std::ptr_fun(&handshake_manager_delete_handshake));
   base_type::erase(split, base_type::end());

--- a/src/torrent/data/block.cc
+++ b/src/torrent/data/block.cc
@@ -141,10 +141,12 @@ Block::erase(BlockTransfer* transfer) {
       transfer_list_type::iterator first = std::find_if(m_transfers.begin(), m_transfers.end(), std::not1(std::mem_fun(&BlockTransfer::is_leader)));
       transfer_list_type::iterator last = std::stable_partition(first, m_transfers.end(), std::mem_fun(&BlockTransfer::is_not_leader));
 
-      transfer_list_type::iterator newLeader = std::max_element(first, last, rak::less2(std::mem_fun(&BlockTransfer::position), std::mem_fun(&BlockTransfer::position)));
+      transfer_list_type::iterator new_leader = std::max_element(first, last, [](BlockTransfer* t1, BlockTransfer* t2) {
+        return t1->position() < t2->position();
+      });
 
-      if (newLeader != last) {
-        m_leader = *newLeader;
+      if (new_leader != last) {
+        m_leader = *new_leader;
         m_leader->set_state(BlockTransfer::STATE_LEADER);
       } else {
         m_leader = NULL;

--- a/src/torrent/download/choke_group.cc
+++ b/src/torrent/download/choke_group.cc
@@ -1,72 +1,26 @@
-// libTorrent - BitTorrent library
-// Copyright (C) 2005-2011, Jari Sundell
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-// 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-// 
-// You should have received a copy of the GNU General Public License
-// along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-//
-// In addition, as a special exception, the copyright holders give
-// permission to link the code of portions of this program with the
-// OpenSSL library under certain conditions as described in each
-// individual source file, and distribute linked combinations
-// including the two.
-//
-// You must obey the GNU General Public License in all respects for
-// all of the code used other than OpenSSL.  If you modify file(s)
-// with this exception, you may extend this exception to your version
-// of the file(s), but you are not obligated to do so.  If you do not
-// wish to do so, delete this exception statement from your version.
-// If you delete this exception statement from all source files in the
-// program, then also delete it here.
-//
-// Contact:  Jari Sundell <jaris@ifi.uio.no>
-//
-//           Skomakerveien 33
-//           3185 Skoppum, NORWAY
-
 #include "config.h"
 
-#include <algorithm>
-#include <functional>
-
 #include "choke_group.h"
-#include "choke_queue.h"
 
-// TODO: Put resource_manager_entry in a separate file.
-#include "resource_manager.h"
+#include <numeric>
 
-#include "torrent/exceptions.h"
 #include "download/download_main.h"
 
 namespace torrent {
 
 choke_group::choke_group() :
-  m_tracker_mode(TRACKER_MODE_NORMAL),
-  m_down_queue(choke_queue::flag_unchoke_all_new),
-  m_first(NULL), m_last(NULL) { }
+    m_tracker_mode(TRACKER_MODE_NORMAL),
+    m_down_queue(choke_queue::flag_unchoke_all_new),
+    m_first(nullptr), m_last(nullptr) {}
 
 uint64_t
 choke_group::up_rate() const {
-  return
-    std::for_each(m_first, m_last, 
-                  rak::accumulate((uint64_t)0, std::bind(&Rate::rate, std::bind(&resource_manager_entry::up_rate, std::placeholders::_1)))).result;
+  return std::accumulate(m_first, m_last, (uint64_t)0, [](uint64_t i, auto r) { return i + r.up_rate()->rate(); });
 }
 
 uint64_t
 choke_group::down_rate() const {
-  return
-    std::for_each(m_first, m_last, 
-                  rak::accumulate((uint64_t)0, std::bind(&Rate::rate, std::bind(&resource_manager_entry::down_rate, std::placeholders::_1)))).result;
+  return std::accumulate(m_first, m_last, (uint64_t)0, [](uint64_t i, auto r) { return i + r.down_rate()->rate(); });
 }
 
-}
+} // namespace torrent

--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -313,7 +313,7 @@ ResourceManager::receive_tick() {
 unsigned int
 ResourceManager::total_weight() const {
   // TODO: This doesn't take into account inactive downloads.
-  return std::for_each(begin(), end(), rak::accumulate((unsigned int)0, std::mem_fun_ref(&value_type::priority))).result;
+  return std::accumulate(begin(), end(), (unsigned int)0, [](unsigned int i, auto r){ return i + r.priority(); });
 }
 
 int

--- a/src/torrent/peer/peer_list.cc
+++ b/src/torrent/peer/peer_list.cc
@@ -164,7 +164,9 @@ PeerList::insert_available(const void* al) {
       continue;
     }
 
-    availItr = std::find_if(availItr, availLast, rak::bind2nd(std::ptr_fun(&socket_address_less_rak), *itr));
+    availItr = std::find_if(availItr, availLast, [&itr](const rak::socket_address& sa) {
+      return socket_address_less_rak(sa, *itr);
+    });
 
     if (availItr != availLast && !socket_address_less(availItr->c_sockaddr(), itr->c_sockaddr())) {
       // The address is already in m_available_list, so don't bother


### PR DESCRIPTION
I also snuck in a couple other fixes into choke_group.cc since it was so small. These are the last of the low-hanging fruit, the other functions are much more widespread.