### PR TITLE
fix buffer position tracking in read_port

### DIFF
--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -630,7 +630,7 @@ Handshake::read_port() {
   m_readBuffer.read_8();
 
   if (length == 2)
-    manager->dht_manager()->add_node(m_address.get(), m_readBuffer.read_16());
+    manager->dht_manager()->add_node(m_address.get(), m_readBuffer.peek_16());
 
   m_readBuffer.consume(length);
   return true;


### PR DESCRIPTION
#254 / 11c38cc540bc1ca7c193cdc28be6e9890df4c84b included this change:

```diff
@@ -627,7 +628,7 @@ Handshake::read_port() {
   m_readBuffer.read_8();
 
   if (length == 2)
-    manager->dht_manager()->add_node(m_address.c_sockaddr(), m_readBuffer.peek_16());
+    manager->dht_manager()->add_node(m_address.get(), m_readBuffer.read_16());
 
   m_readBuffer.consume(length);
   return true;
```

This is probably the cause of #256. Debug logging shows the value of `ProtocolBuffer::remaining()` going to `65534`, i.e., `-2`, since `m_position` advances an additional 2 beyond `m_end`.