### PR TITLE
Fix thread unit tests

### DIFF
--- a/src/torrent/utils/thread_interrupt.h
+++ b/src/torrent/utils/thread_interrupt.h
@@ -30,7 +30,7 @@ private:
   SocketFd&           get_fd() { return *reinterpret_cast<SocketFd*>(&m_fileDesc); }
 
   thread_interrupt*   m_other;
-  std::atomic_flag    m_poking;
+  std::atomic_bool    m_poking;
 };
 
 }

--- a/test/helpers/test_thread.h
+++ b/test/helpers/test_thread.h
@@ -33,7 +33,7 @@ public:
 
   void    init_thread();
 
-  void    set_pre_stop() { m_test_state |= test_flag_pre_stop; }
+  void    set_pre_stop() { m_test_flags |= test_flag_pre_stop; }
   void    set_acquire_global() { m_test_flags |= test_flag_acquire_global; }
   void    set_test_flag(int flags) { m_test_flags |= flags; }
 


### PR DESCRIPTION
Convert m_poking back to a bool due to test_and_set having different return values than compare_exchange. Without this test_thread_base fails:
```
test_thread_base.cc:61:Assertion
Test name: test_thread_base::test_lifecycle
assertion failed
- Expression: wait_for_true(std::bind(&test_thread::is_test_state, thread, test
_thread::TEST_PRE_STOP))

test_thread_base.cc:130:Assertion
Test name: test_thread_base::test_interrupt
assertion failed
- Expression: wait_for_true(std::bind(&test_thread::is_not_test_flags, thread, 
test_thread::test_flag_do_work))

Failures !!!
Run: 27   Failure total: 2   Failures: 2   Errors: 0
FAIL: LibTorrent_Test_Torrent_Utils
```
The first failure is fixed by the test_thread.h change, the second by the m_poking change.