### PR TITLE
Convert bitfield tests to use pointers for atomic values

### DIFF
--- a/test/torrent/utils/test_signal_bitfield.cc
+++ b/test/torrent/utils/test_signal_bitfield.cc
@@ -1,5 +1,8 @@
 #include "config.h"
 
+#include <functional>
+#include <atomic>
+
 #include "test_signal_bitfield.h"
 
 #include "helpers/test_thread.h"
@@ -12,13 +15,13 @@
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_signal_bitfield, "torrent/utils");
 
 static void
-mark_index(std::atomic_uint32_t& bitfield, unsigned int index) {
-  bitfield |= 1 << index;
+mark_index(std::atomic_uint32_t* bitfield, unsigned int index) {
+  bitfield->fetch_or(1 << index);
 }
 
 static bool
-check_index(std::atomic_uint32_t& bitfield, unsigned int index) {
-  return bitfield & (1 << index);
+check_index(std::atomic_uint32_t* bitfield, unsigned int index) {
+  return *bitfield & (1 << index);
 }
 
 void
@@ -42,7 +45,7 @@ verify_did_internal_error(std::function<unsigned int ()> func, bool should_throw
 }
 
 #define SETUP_SIGNAL_BITFIELD()                 \
-  std::atomic_uint32_t marked_bitfield = 0;     \
+  std::atomic_uint32_t marked_bitfield{0};      \
   torrent::signal_bitfield signal_bitfield;
 
 
@@ -61,16 +64,16 @@ test_signal_bitfield::test_basic() {
   SIGNAL_BITFIELD_DID_INTERNAL_ERROR(torrent::signal_bitfield::slot_type(), true);
 
   for (unsigned int i = 0; i < torrent::signal_bitfield::max_size; i++)
-    CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, marked_bitfield, i)) == i);
+    CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, &marked_bitfield, i)) == i);
 
-  SIGNAL_BITFIELD_DID_INTERNAL_ERROR(std::bind(&mark_index, marked_bitfield, torrent::signal_bitfield::max_size), true);
+  SIGNAL_BITFIELD_DID_INTERNAL_ERROR(std::bind(&mark_index, &marked_bitfield, torrent::signal_bitfield::max_size), true);
 }
 
 void
 test_signal_bitfield::test_single() {
   SETUP_SIGNAL_BITFIELD();
 
-  CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, marked_bitfield, 0)) == 0);
+  CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, &marked_bitfield, 0)) == 0);
 
   signal_bitfield.signal(0);
   CPPUNIT_ASSERT(marked_bitfield == 0x0);
@@ -89,7 +92,7 @@ test_signal_bitfield::test_multiple() {
   SETUP_SIGNAL_BITFIELD();
 
   for (unsigned int i = 0; i < torrent::signal_bitfield::max_size; i++)
-    CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, marked_bitfield, i)) == i);
+    CPPUNIT_ASSERT(signal_bitfield.add_signal(std::bind(&mark_index, &marked_bitfield, i)) == i);
 
   signal_bitfield.signal(2);
   signal_bitfield.signal(31);
@@ -106,12 +109,12 @@ test_signal_bitfield::test_multiple() {
 
 void
 test_signal_bitfield::test_threaded() {
-  uint32_t marked_bitfield = 0;
+  std::atomic_uint32_t marked_bitfield{0};
   test_thread* thread = new test_thread;
   // thread->set_test_flag(test_thread::test_flag_long_timeout);
 
   for (unsigned int i = 0; i < torrent::signal_bitfield::max_size; i++)
-    CPPUNIT_ASSERT(thread->signal_bitfield()->add_signal(std::bind(&mark_index, marked_bitfield, i)) == i);
+    CPPUNIT_ASSERT(thread->signal_bitfield()->add_signal(std::bind(&mark_index, &marked_bitfield, i)) == i);
 
   thread->init_thread();
   thread->start_thread();
@@ -125,7 +128,7 @@ test_signal_bitfield::test_threaded() {
     thread->signal_bitfield()->signal(i % 20);
     // thread->interrupt();
 
-    CPPUNIT_ASSERT(wait_for_true(std::bind(&check_index, marked_bitfield, i % 20)));
+    CPPUNIT_ASSERT(wait_for_true(std::bind(&check_index, &marked_bitfield, i % 20)));
     marked_bitfield &= ~uint32_t();
   }
 


### PR DESCRIPTION
This fixes compilation of the tests, which otherwise fails with:
```
torrent/utils/test_signal_bitfield.cc:128:43: error: could not convert ‘std::bind(_Func&&, _BoundArgs&& ...) [with _Func = bool (*)(atomic<unsigned int>&, unsigned int); _BoundArgs = {unsigned int&, int}; typename _Bind_helper<__is_socketlike<_Func>::value, _Func, _BoundArgs ...>::type = _Bind_helper<false, bool (*)(atomic<unsigned int>&, unsigned int), unsigned int&, int>::type; __is_socketlike<_Func> = __is_socketlike<bool (*)(atomic<unsigned int>&, unsigned int), bool (*)(atomic<unsigned int>&, unsigned int)>; typename decay<_Tp>::type = bool (*)(atomic<unsigned int>&, unsigned int)](marked_bitfield, (i % 20))’ from ‘std::_Bind_helper<false, bool (*)(std::atomic<unsigned int>&, unsigned int), unsigned int&, int>::type’ to ‘std::function<bool()>’
  128 |     CPPUNIT_ASSERT(wait_for_true(std::bind(&check_index, marked_bitfield, i % 20)));
      |                                  ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                           |
      |                                           std::_Bind_helper<false, bool (*)(std::atomic<unsigned int>&, unsigned int), unsigned int&, int>::type
```