### PR TITLE
Clean up rak::functional's last methods

### DIFF
--- a/rak/functional.h
+++ b/rak/functional.h
@@ -5,11 +5,35 @@
 
 namespace rak {
 
-template <typename Container, typename... Args>
+template <typename Container>
 inline void
-slot_list_call(const Container& slot_list, Args&&... args) {
-  for (const auto& slot : slot_list) {
-    slot(std::forward<Args>(args)...);
+slot_list_call(const Container& slot_list) {
+  if (slot_list.empty())
+    return;
+
+  typename Container::const_iterator first = slot_list.begin();
+  typename Container::const_iterator next  = slot_list.begin();
+
+  while (++next != slot_list.end()) {
+    (*first)();
+    first = next;
+  }
+
+  (*first)();
+}
+
+template <typename Container, typename Arg1>
+inline void
+slot_list_call(const Container& slot_list, Arg1 arg1) {
+  if (slot_list.empty())
+    return;
+
+  typename Container::const_iterator first = slot_list.begin();
+  typename Container::const_iterator next  = slot_list.begin();
+
+  while (++next != slot_list.end()) {
+    (*first)(arg1);
+    first = next;
   }
 }
 

--- a/rak/functional.h
+++ b/rak/functional.h
@@ -1,183 +1,18 @@
-// rak - Rakshasa's toolbox
-// Copyright (C) 2005-2007, Jari Sundell
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-// 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-// 
-// You should have received a copy of the GNU General Public License
-// along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-//
-// In addition, as a special exception, the copyright holders give
-// permission to link the code of portions of this program with the
-// OpenSSL library under certain conditions as described in each
-// individual source file, and distribute linked combinations
-// including the two.
-//
-// You must obey the GNU General Public License in all respects for
-// all of the code used other than OpenSSL.  If you modify file(s)
-// with this exception, you may extend this exception to your version
-// of the file(s), but you are not obligated to do so.  If you do not
-// wish to do so, delete this exception statement from your version.
-// If you delete this exception statement from all source files in the
-// program, then also delete it here.
-//
-// Contact:  Jari Sundell <jaris@ifi.uio.no>
-//
-//           Skomakerveien 33
-//           3185 Skoppum, NORWAY
-
 #ifndef RAK_FUNCTIONAL_H
 #define RAK_FUNCTIONAL_H
 
-#include <cstddef>
-#include <functional>
+#include <utility>
 
 namespace rak {
 
-template <typename Type>
-struct reference_fix {
-  typedef Type type;
-};
-
-template <typename Type>
-struct reference_fix<Type&> {
-  typedef Type type;
-};
-
-// Operators:
-
-template <typename Type, typename Ftor>
-struct equal_t {
-  typedef bool result_type;
-
-  equal_t(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t == m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline equal_t<Type, Ftor>
-equal(Type t, Ftor f) {
-  return equal_t<Type, Ftor>(t, f);
-}
-
-template <typename Type, typename Ftor>
-struct less_t {
-  typedef bool result_type;
-
-  less_t(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t < m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline less_t<Type, Ftor>
-less(Type t, Ftor f) {
-  return less_t<Type, Ftor>(t, f);
-}
-
-template <typename Type, typename Ftor>
-struct less_equal_t {
-  typedef bool result_type;
-
-  less_equal_t(Type t, Ftor f) : m_t(t), m_f(f) {}
-
-  template <typename Arg>
-  bool operator () (Arg& a) {
-    return m_t <= m_f(a);
-  }
-
-  Type m_t;
-  Ftor m_f;
-};
-
-template <typename Type, typename Ftor>
-inline less_equal_t<Type, Ftor>
-less_equal(Type t, Ftor f) {
-  return less_equal_t<Type, Ftor>(t, f);
-}
-
-template <typename Src, typename Dest>
-struct on_t : public std::unary_function<typename Src::argument_type, typename Dest::result_type> {
-  typedef typename Dest::result_type result_type;
-
-  on_t(Src s, Dest d) : m_dest(d), m_src(s) {}
-
-  result_type operator () (typename reference_fix<typename Src::argument_type>::type arg) {
-    return m_dest(m_src(arg));
-  }
-
-  Dest m_dest;
-  Src m_src;
-};
-    
-template <typename Src, typename Dest>
-inline on_t<Src, Dest>
-on(Src s, Dest d) {
-  return on_t<Src, Dest>(s, d);
-}  
-
-template <typename T>
-struct call_delete : public std::unary_function<T*, void> {
-  void operator () (T* t) {
-    delete t;
-  }
-};
-
-template <typename Container>
+template <typename Container, typename... Args>
 inline void
-slot_list_call(const Container& slot_list) {
-  if (slot_list.empty())
-    return;
-
-  typename Container::const_iterator first = slot_list.begin();
-  typename Container::const_iterator next = slot_list.begin();
-
-  while (++next != slot_list.end()) {
-    (*first)();
-    first = next;
+slot_list_call(const Container& slot_list, Args&&... args) {
+  for (const auto& slot : slot_list) {
+    slot(std::forward<Args>(args)...);
   }
-
-  (*first)();
 }
 
-template <typename Container, typename Arg1>
-inline void
-slot_list_call(const Container& slot_list, Arg1 arg1) {
-  if (slot_list.empty())
-    return;
-
-  typename Container::const_iterator first = slot_list.begin();
-  typename Container::const_iterator next = slot_list.begin();
-
-  while (++next != slot_list.end()) {
-    (*first)(arg1);
-    first = next;
-  }
-
-  (*first)(arg1);
-}
-
-}
+} // namespace rak
 
 #endif

--- a/src/data/chunk_list.cc
+++ b/src/data/chunk_list.cc
@@ -37,7 +37,6 @@
 #include "config.h"
 
 #include <rak/error_number.h>
-#include <rak/functional.h>
 
 #include "torrent/exceptions.h"
 #include "torrent/chunk_manager.h"

--- a/src/data/hash_queue.cc
+++ b/src/data/hash_queue.cc
@@ -37,7 +37,6 @@
 #include "config.h"
 
 #include <functional>
-#include <rak/functional.h>
 #include <unistd.h>
 
 #include "torrent/exceptions.h"
@@ -106,7 +105,7 @@ HashQueue::push_back(ChunkHandle handle, HashQueueNode::id_type id, slot_done_ty
 
 bool
 HashQueue::has(HashQueueNode::id_type id) {
-  return std::find_if(begin(), end(), rak::equal(id, std::mem_fun_ref(&HashQueueNode::id))) != end();
+  return std::any_of(begin(), end(), [id](const auto& n) { return id == n.id(); });
 }
 
 bool
@@ -116,10 +115,11 @@ HashQueue::has(HashQueueNode::id_type id, uint32_t index) {
 
 void
 HashQueue::remove(HashQueueNode::id_type id) {
-  iterator itr = begin();
+  base_type::erase(std::remove_if(begin(), end(), [id, this](auto& itr) {
+    if (itr.id() != id)
+      return false;
   
-  while ((itr = std::find_if(itr, end(), rak::equal(id, std::mem_fun_ref(&HashQueueNode::id)))) != end()) {
-    HashChunk *hash_chunk = itr->get_chunk();
+    HashChunk *hash_chunk = itr.get_chunk();
 
     LT_LOG_DATA(id, DEBUG, "Removing index:%" PRIu32 " from queue.", hash_chunk->handle().index());
 
@@ -143,11 +143,12 @@ HashQueue::remove(HashQueueNode::id_type id) {
       pthread_mutex_unlock(&m_done_chunks_lock);
     }
 
-    itr->slot_done()(*hash_chunk->chunk(), NULL);
-    itr->clear();
+    itr.slot_done()(*hash_chunk->chunk(), NULL);
+    itr.clear();
 
-    itr = erase(itr);
-  }
+    return true;
+  }), end());
+
 }
 
 void

--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -38,7 +38,6 @@
 #include "globals.h"
 
 #include <sstream>
-#include <rak/functional.h>
 
 #include "torrent/dht_manager.h"
 #include "torrent/download_info.h"

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <rak/functional.h>
 
 #include "torrent/exceptions.h"
 #include "torrent/connection_manager.h"
@@ -132,8 +131,12 @@ DhtServer::DhtServer(DhtRouter* router) :
 DhtServer::~DhtServer() {
   stop();
 
-  std::for_each(m_highQueue.begin(), m_highQueue.end(), rak::call_delete<DhtTransactionPacket>());
-  std::for_each(m_lowQueue.begin(), m_lowQueue.end(), rak::call_delete<DhtTransactionPacket>());
+  for (const auto& packet : m_highQueue) {
+    delete packet;
+  }
+  for (const auto& packet : m_lowQueue) {
+    delete packet;
+  }
 
   manager->connection_manager()->dec_socket_count();
 }

--- a/src/download/chunk_selector.cc
+++ b/src/download/chunk_selector.cc
@@ -38,7 +38,6 @@
 
 #include <algorithm>
 #include <stdlib.h>
-#include <rak/functional.h>
 
 #include "protocol/peer_chunks.h"
 #include "torrent/exceptions.h"

--- a/src/download/download_wrapper.cc
+++ b/src/download/download_wrapper.cc
@@ -327,8 +327,9 @@ DownloadWrapper::receive_update_priorities() {
 
   m_main->chunk_selector()->update_priorities();
 
-  std::for_each(m_main->connection_list()->begin(), m_main->connection_list()->end(),
-                rak::on(std::mem_fun(&Peer::m_ptr), std::mem_fun(&PeerConnectionBase::update_interested)));
+  for (const auto& peer : *m_main->connection_list()) {
+    peer->m_ptr()->update_interested();
+  }
 
   // The 'partially_done/restarted' signal only gets triggered when a
   // download is active and not completed.

--- a/src/net/throttle_internal.cc
+++ b/src/net/throttle_internal.cc
@@ -36,7 +36,6 @@
 
 #include "config.h"
 
-#include <rak/functional.h>
 #include <rak/timer.h> 
 #include <rak/priority_queue_default.h> 
 
@@ -69,7 +68,9 @@ ThrottleInternal::~ThrottleInternal() {
   if (is_root())
     priority_queue_erase(&taskScheduler, &m_taskTick);
 
-  std::for_each(m_slaveList.begin(), m_slaveList.end(), rak::call_delete<ThrottleInternal>());
+  for (const auto& t : m_slaveList) {
+    delete t;
+  }
 }
 
 void

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -41,7 +41,7 @@ handshake_manager_delete_handshake(Handshake* h) {
 
 HandshakeManager::size_type
 HandshakeManager::size_info(DownloadMain* info) const {
-  return std::count_if(base_type::begin(), base_type::end(), rak::equal(info, std::mem_fun(&Handshake::download)));
+  return std::count_if(base_type::begin(), base_type::end(), [info](Handshake* h) { return info == h->download(); });
 }
 
 void

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -39,7 +39,6 @@
 #include <cstdio>
 #include <fcntl.h>
 #include <rak/error_number.h>
-#include <rak/functional.h>
 #include <rak/string_manip.h>
 
 #include "data/chunk_iterator.h"

--- a/src/protocol/peer_connection_leech.cc
+++ b/src/protocol/peer_connection_leech.cc
@@ -38,7 +38,6 @@
 
 #include <cstring>
 #include <sstream>
-#include <rak/functional.h>
 #include <rak/string_manip.h>
 
 #include "data/chunk_list_node.h"

--- a/src/protocol/peer_connection_metadata.cc
+++ b/src/protocol/peer_connection_metadata.cc
@@ -48,7 +48,6 @@
 #include "torrent/download/choke_queue.h"
 #include "torrent/peer/connection_list.h"
 #include "torrent/peer/peer_info.h"
-#include "rak/functional.h"
 #include "torrent/utils/log.h"
 
 #include "extensions.h"

--- a/src/protocol/request_list.cc
+++ b/src/protocol/request_list.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <functional>
 #include <cinttypes>
-#include <rak/functional.h>
 
 #include "torrent/data/block.h"
 #include "torrent/data/block_list.h"

--- a/src/torrent/data/block.cc
+++ b/src/torrent/data/block.cc
@@ -38,7 +38,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <rak/functional.h>
 
 #include "peer/peer_info.h"
 #include "protocol/peer_connection_base.h"
@@ -383,7 +382,7 @@ Block::remove_non_leader_transfers() {
 
 BlockTransfer*
 Block::find_queued(const PeerInfo* p) {
-  transfer_list_type::iterator itr = std::find_if(m_queued.begin(), m_queued.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
+  auto itr = std::find_if(m_queued.begin(), m_queued.end(), [p](BlockTransfer* t) { return p == t->peer_info(); });
 
   if (itr == m_queued.end())
     return NULL;
@@ -393,7 +392,7 @@ Block::find_queued(const PeerInfo* p) {
 
 const BlockTransfer*
 Block::find_queued(const PeerInfo* p) const {
-  transfer_list_type::const_iterator itr = std::find_if(m_queued.begin(), m_queued.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
+  auto itr = std::find_if(m_queued.begin(), m_queued.end(), [p](BlockTransfer* t) { return p == t->peer_info(); });
 
   if (itr == m_queued.end())
     return NULL;
@@ -403,7 +402,7 @@ Block::find_queued(const PeerInfo* p) const {
 
 BlockTransfer*
 Block::find_transfer(const PeerInfo* p) {
-  transfer_list_type::iterator itr = std::find_if(m_transfers.begin(), m_transfers.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
+  auto itr = std::find_if(m_transfers.begin(), m_transfers.end(), [p](BlockTransfer* t) { return p == t->peer_info(); });
 
   if (itr == m_transfers.end())
     return NULL;
@@ -413,7 +412,7 @@ Block::find_transfer(const PeerInfo* p) {
 
 const BlockTransfer*
 Block::find_transfer(const PeerInfo* p) const {
-  transfer_list_type::const_iterator itr = std::find_if(m_transfers.begin(), m_transfers.end(), rak::equal(p, std::mem_fun(&BlockTransfer::peer_info)));
+  auto itr = std::find_if(m_transfers.begin(), m_transfers.end(), [p](BlockTransfer* t) { return p == t->peer_info(); });
 
   if (itr == m_transfers.end())
     return NULL;

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -9,7 +9,6 @@
 #include <rak/error_number.h>
 #include <rak/file_stat.h>
 #include <rak/fs_stat.h>
-#include <rak/functional.h>
 
 #include "data/chunk.h"
 #include "data/memory_chunk.h"

--- a/src/torrent/data/transfer_list.cc
+++ b/src/torrent/data/transfer_list.cc
@@ -39,7 +39,6 @@
 #include <algorithm>
 #include <functional>
 #include <set>
-#include <rak/functional.h>
 #include <rak/timer.h>
 
 #include "data/chunk.h"
@@ -68,18 +67,22 @@ TransferList::~TransferList() {
 
 TransferList::iterator
 TransferList::find(uint32_t index) {
-  return std::find_if(begin(), end(), rak::equal(index, std::mem_fun(&BlockList::index)));
+  return std::find_if(begin(), end(), [index](BlockList* b) { return index == b->index(); });
 }
 
 TransferList::const_iterator
 TransferList::find(uint32_t index) const {
-  return std::find_if(begin(), end(), rak::equal(index, std::mem_fun(&BlockList::index)));
+  return std::find_if(begin(), end(), [index](BlockList* b) { return index == b->index(); });
 }
 
 void
 TransferList::clear() {
-  std::for_each(begin(), end(), std::bind(m_slot_canceled, std::bind(&BlockList::index, std::placeholders::_1)));
-  std::for_each(begin(), end(), rak::call_delete<BlockList>());
+  for (const auto& block_list : *this) {
+    m_slot_canceled(block_list->index());
+  }
+  for (const auto& block_list : *this) {
+    delete block_list;
+  }
 
   base_type::clear();
 }

--- a/src/torrent/download/choke_queue.cc
+++ b/src/torrent/download/choke_queue.cc
@@ -4,7 +4,6 @@
 #include <cstdlib>
 #include <functional>
 #include <numeric>
-#include <rak/functional.h>
 
 #include "protocol/peer_connection_base.h"
 #include "torrent/download/group_entry.h"

--- a/src/torrent/download/download_manager.cc
+++ b/src/torrent/download/download_manager.cc
@@ -36,7 +36,6 @@
 
 #include "config.h"
 
-#include <rak/functional.h>
 
 #include "torrent/exceptions.h"
 
@@ -74,29 +73,28 @@ DownloadManager::clear() {
 
 DownloadManager::iterator
 DownloadManager::find(const std::string& hash) {
-  return std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                 rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  return find(*HashString::cast_from(hash));
 }
 
 DownloadManager::iterator
 DownloadManager::find(const HashString& hash) {
-  return std::find_if(begin(), end(), rak::equal(hash, rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  return std::find_if(begin(), end(), [hash](const auto& wrapper){ return hash == wrapper->info()->hash(); });
 }
 
 DownloadManager::iterator
 DownloadManager::find(DownloadInfo* info) {
-  return std::find_if(begin(), end(), rak::equal(info, std::mem_fun(&DownloadWrapper::info)));
+  return std::find_if(begin(), end(), [info](const auto& wrapper){ return info == wrapper->info(); });
 }
 
 DownloadManager::iterator
 DownloadManager::find_chunk_list(ChunkList* cl) {
-  return std::find_if(begin(), end(), rak::equal(cl, std::mem_fun(&DownloadWrapper::chunk_list)));
+  return std::find_if(begin(), end(), [cl](const auto& wrapper){ return cl == wrapper->chunk_list(); });
 }
 
 DownloadMain*
 DownloadManager::find_main(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  auto hash_str = *HashString::cast_from(hash);
+  auto itr = std::find_if(begin(), end(), [hash_str](const auto& wrapper){ return hash_str == wrapper->info()->hash(); });
 
   if (itr == end())
     return NULL;
@@ -106,8 +104,8 @@ DownloadManager::find_main(const char* hash) {
 
 DownloadMain*
 DownloadManager::find_main_obfuscated(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash_obfuscated))));
+  auto hash_str = *HashString::cast_from(hash);
+  auto itr = std::find_if(begin(), end(), [hash_str](const auto& wrapper){ return hash_str == wrapper->info()->hash_obfuscated(); });
 
   if (itr == end())
     return NULL;

--- a/src/torrent/object.cc
+++ b/src/torrent/object.cc
@@ -38,7 +38,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <rak/functional.h>
 
 #include "object.h"
 #include "object_stream.h"

--- a/src/torrent/peer/peer_list.cc
+++ b/src/torrent/peer/peer_list.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <rak/functional.h>
 #include <rak/socket_address.h>
 
 #include "download/available_list.h"

--- a/src/torrent/poll_kqueue.cc
+++ b/src/torrent/poll_kqueue.cc
@@ -11,7 +11,6 @@
 
 #include "poll_kqueue.h"
 #include "torrent.h"
-#include "rak/functional.h"
 #include "rak/timer.h"
 #include "rak/error_number.h"
 #include "utils/log.h"

--- a/src/torrent/tracker_list.cc
+++ b/src/torrent/tracker_list.cc
@@ -37,7 +37,6 @@
 #include "config.h"
 
 #include <functional>
-#include <rak/functional.h>
 
 #include "net/address_list.h"
 #include "torrent/utils/log.h"
@@ -125,7 +124,9 @@ TrackerList::disown_all_including(int event_bitmap) {
 
 void
 TrackerList::clear() {
-  std::for_each(begin(), end(), rak::call_delete<Tracker>());
+  for (const auto& tracker : *this) {
+    delete tracker;
+  }
   base_type::clear();
 }
 
@@ -266,12 +267,12 @@ TrackerList::find_next_to_request(iterator itr) {
 
 TrackerList::iterator
 TrackerList::begin_group(unsigned int group) {
-  return std::find_if(begin(), end(), rak::less_equal(group, std::mem_fun(&Tracker::group)));
+  return std::find_if(begin(), end(), [group](Tracker* t) { return group <= t->group(); });
 }
 
 TrackerList::const_iterator
 TrackerList::begin_group(unsigned int group) const {
-  return std::find_if(begin(), end(), rak::less_equal(group, std::mem_fun(&Tracker::group)));
+  return std::find_if(begin(), end(), [group](Tracker* t) { return group <= t->group(); });
 }
 
 TrackerList::size_type

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -4,7 +4,6 @@
 
 #import <iomanip>
 #import <sstream>
-#import <rak/functional.h>
 #import <rak/string_manip.h>
 
 #import "net/address_list.h"


### PR DESCRIPTION
This is the final cleanup for functional.h. `slot_list_call` doesn't have a clear equivalent, so I just simplified it and left it in the same file.

There is a logic change in HashQueue::remove(), so that it does the removal in a single pass rather than erasing then re-finding individual iterators: https://github.com/rakshasa/libtorrent/compare/master...kannibalox:libtorrent:feature/rakfn-to-lambda#diff-0445aee53785eeeccbb508f105cb7fc2665fa18637ee474c9317dc150c2a9546L118-L151