### PR TITLE
Convert dedicated dict_key type to a 1-element map

### DIFF
--- a/src/torrent/object.cc
+++ b/src/torrent/object.cc
@@ -201,7 +201,6 @@ Object::operator = (const Object& src) {
   case TYPE_STRING:   new (&_string()) string_type(src._string()); break;
   case TYPE_LIST:     new (&_list()) list_type(src._list()); break;
   case TYPE_MAP:      _map_ptr() = new map_type(src._map()); break;
-  case TYPE_DICT_KEY: new (&_dict_key()) dict_key_type(src._dict_key()); _dict_key().second = new Object(*src._dict_key().second); break;
   default: t_pod = src.t_pod; break;
   }
 

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -555,6 +555,9 @@ object_write_bencode_c_object(object_write_data_t* output, const Object* object,
     break;
 
   case Object::TYPE_MAP:
+    if (object->is_dict_key())
+      throw torrent::bencode_error("Cannot bencode internal dict_key type.");
+
     object_write_bencode_c_char(output, 'd');
 
     for (Object::map_const_iterator itr = object->as_map().begin(), last = object->as_map().end(); itr != last; ++itr) {
@@ -566,9 +569,6 @@ object_write_bencode_c_object(object_write_data_t* output, const Object* object,
     }
 
     object_write_bencode_c_char(output, 'e');
-    break;
-  case Object::TYPE_DICT_KEY:
-    throw torrent::bencode_error("Cannot bencode internal dict_key type.");
     break;
   }
 }

--- a/test/torrent/object_test.cc
+++ b/test/torrent/object_test.cc
@@ -78,29 +78,6 @@ swap_compare(const char* left, const char* right) {
   return true;
 }
 
-static bool
-swap_compare_dict_key(const char* left_key, const char* left_obj, const char* right_key, const char* right_obj) {
-  torrent::Object obj_left = torrent::Object::create_dict_key();
-  torrent::Object obj_right = torrent::Object::create_dict_key();
-
-  obj_left.as_dict_key()  = left_key;
-  obj_left.as_dict_obj()  = create_bencode(left_obj);
-  obj_right.as_dict_key() = right_key;
-  obj_right.as_dict_obj() = create_bencode(right_obj);
-
-  obj_left.swap(obj_right);
-  if (obj_left.as_dict_key() != right_key || !compare_bencode(obj_left.as_dict_obj(), right_obj) ||
-      obj_right.as_dict_key() != left_key || !compare_bencode(obj_right.as_dict_obj(), left_obj))
-    return false;
-
-  obj_left.swap(obj_right);
-  if (obj_left.as_dict_key() != left_key || !compare_bencode(obj_left.as_dict_obj(), left_obj) ||
-      obj_right.as_dict_key() != right_key || !compare_bencode(obj_right.as_dict_obj(), right_obj))
-    return false;
-
-  return true;
-}
-
 void
 ObjectTest::test_swap_and_move() {
   CPPUNIT_ASSERT(swap_compare(TEST_VALUE_A, TEST_VALUE_B));
@@ -117,8 +94,6 @@ ObjectTest::test_swap_and_move() {
   CPPUNIT_ASSERT(swap_compare("i1e", TEST_MAP_A));
   CPPUNIT_ASSERT(swap_compare("i1e", TEST_LIST_A));
 
-  CPPUNIT_ASSERT(swap_compare_dict_key("a", TEST_VALUE_A, "b", TEST_STRING_B));
-  CPPUNIT_ASSERT(swap_compare_dict_key("a", TEST_STRING_A, "b", TEST_STRING_B));
 }
 
 void


### PR DESCRIPTION
This shaves 8 bits off an Object (48 -> 40). Some of this is immediately made back up by the overhead of dealing with a full-fledged map instead of a pair, but the use of dict_key is largely limited to function definitions.

This is just an initial proof-of-concept, if you don't have any problems with it I can remove the `{is/as}_dict_{key/obj}` methods entirely and refactor the rtorrent PR to match.