### PR TITLE
fix: remove `rak::equal` and `rak::mem_ref` refs

### DIFF
--- a/src/torrent/poll_kqueue.cc
+++ b/src/torrent/poll_kqueue.cc
@@ -279,7 +279,7 @@ PollKQueue::close(Event* event) {
       itr->udata = NULL;
 
   m_changedEvents = std::remove_if(m_changes, m_changes + m_changedEvents,
-                                   rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
+                                   [event](const struct kevent& ke) { return ke.udata == event; }) - m_changes;
 }
 
 void
@@ -305,7 +305,7 @@ PollKQueue::closed(Event* event) {
       itr->udata = NULL;
 
   m_changedEvents = std::remove_if(m_changes, m_changes + m_changedEvents,
-                                   rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
+                                   [event](const struct kevent& ke) { return ke.udata == event; }) - m_changes;
 }
 
 // Use custom defines for EPOLL* to make the below code compile with


### PR DESCRIPTION
seeing some build failure while building against libtorrent 0.15.0 rel

```
  poll_kqueue.cc:282:41: error: no member named 'equal' in namespace 'rak'
    282 |                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
        |                                    ~~~~~^
  poll_kqueue.cc:282:59: error: no member named 'mem_ref' in namespace 'rak'
    282 |                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
        |                                                      ~~~~~^
  poll_kqueue.cc:308:41: error: no member named 'equal' in namespace 'rak'
    308 |                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
        |                                    ~~~~~^
  poll_kqueue.cc:308:59: error: no member named 'mem_ref' in namespace 'rak'
    308 |                                    rak::equal(event, rak::mem_ref(&kevent::udata))) - m_changes;
        |                                                      ~~~~~^
  4 errors generated.
  make[3]: *** [poll_kqueue.lo] Error 1
```

relates to https://github.com/Homebrew/homebrew-core/pull/202503