### PR TITLE
Align torrent block vectors

### DIFF
--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -42,6 +42,8 @@
 #include <torrent/data/block_transfer.h>
 #include <cstdlib>
 
+#include "rak/allocators.h"
+
 namespace torrent {
 
 // If you start adding slots, make sure the rest of the code creates
@@ -52,8 +54,8 @@ public:
   // Using vectors as they will remain small, thus the cost of erase
   // should be small. Later we can do faster erase by ignoring the
   // ordering.
-  typedef std::vector<BlockTransfer*>              transfer_list_type;
-  typedef uint32_t                                 size_type;
+  typedef std::vector<BlockTransfer*, rak::cacheline_allocator<BlockTransfer*>> transfer_list_type;
+  typedef uint32_t                                                              size_type;
 
   typedef enum {
     STATE_INCOMPLETE,
@@ -127,9 +129,9 @@ public:
   static void               release(BlockTransfer* transfer);
 
   // Only allow move constructions
-  Block(const Block&) = delete;
-  void operator = (const Block&) = delete;
-  Block(Block&&) = default;
+  //Block(const Block&) = delete;
+  //void operator = (const Block&) = delete;
+  //Block(Block&&) = default;
 
 private:
 

--- a/src/torrent/data/block_list.h
+++ b/src/torrent/data/block_list.h
@@ -43,12 +43,14 @@
 #include <torrent/data/block.h>
 #include <torrent/data/piece.h>
 
+#include "rak/allocators.h"
+
 namespace torrent {
 
-class LIBTORRENT_EXPORT BlockList : private std::vector<Block> {
+class LIBTORRENT_EXPORT BlockList : private std::vector<Block, rak::cacheline_allocator<Block>> {
 public:
-  typedef uint32_t           size_type;
-  typedef std::vector<Block> base_type;
+  typedef uint32_t                                            size_type;
+  typedef std::vector<Block, rak::cacheline_allocator<Block>> base_type;
 
   using base_type::value_type;
   using base_type::reference;


### PR DESCRIPTION
This pull request implements memory alignment for a few vectors. We're no longer allowed to delete some Block constructors because we're implementing the `rak::cacheline_allocator` class.  This code has been commented out.

Download throughput is improved by approximately 25-30%, with a significant reduction in CPU usage. It's a hot path to the torrent download delegator, which uses the majority of the CPU usage when downloading torrents. Testing on an i3-12100 successfully obtained in excess of 300MB/s download speeds with more headroom. This is my connection speed limit.