### PR TITLE
treewide: default/delete constructors

### DIFF
--- a/rak/partial_queue.h
+++ b/rak/partial_queue.h
@@ -59,8 +59,10 @@ public:
 
   static const size_type num_layers = 8;
 
-  partial_queue() : m_data(NULL), m_maxLayerSize(0) {}
+  partial_queue() = default;
   ~partial_queue() { disable(); }
+  partial_queue(const partial_queue&) = delete;
+  partial_queue& operator=(const partial_queue&) = delete;
 
   bool                is_full() const                         { return m_ceiling == 0; }
   bool                is_layer_full(size_type l) const        { return m_layers[l].second >= m_maxLayerSize; }
@@ -95,15 +97,12 @@ public:
   mapped_type         pop();
 
 private:
-  partial_queue(const partial_queue&);
-  void operator = (const partial_queue&);
-
   static size_type    ceiling(size_type layer)                { return (2 << layer) - 1; }
 
   void                find_non_empty();
 
-  mapped_type*        m_data;
-  size_type           m_maxLayerSize;
+  mapped_type*        m_data{};
+  size_type           m_maxLayerSize{};
 
   size_type           m_index;
   size_type           m_ceiling;

--- a/rak/priority_queue_default.h
+++ b/rak/priority_queue_default.h
@@ -14,13 +14,15 @@ class priority_item {
 public:
   typedef std::function<void (void)> slot_void;
 
-  priority_item() {}
+  priority_item() = default;
   ~priority_item() {
     assert(!is_queued() && "priority_item::~priority_item() called on a queued item.");
 
     m_time = timer();
     m_slot = slot_void();
   }
+  priority_item(const priority_item&) = delete;
+  priority_item& operator=(const priority_item&) = delete;
 
   bool                is_valid() const              { return (bool)m_slot; }
   bool                is_queued() const             { return m_time != timer(); }
@@ -34,9 +36,6 @@ public:
   bool                compare(const timer& t) const { return m_time > t; }
 
 private:
-  priority_item(const priority_item&);
-  void operator = (const priority_item&);
-
   timer               m_time;
   slot_void           m_slot;
 };

--- a/src/data/chunk.h
+++ b/src/data/chunk.h
@@ -30,8 +30,10 @@ public:
   using base_type::front;
   using base_type::back;
 
-  Chunk() : m_chunkSize(0), m_prot(~0) {}
+  Chunk() = default;
   ~Chunk() { clear(); }
+  Chunk(const Chunk&) = delete;
+  Chunk& operator=(const Chunk&) = delete;
 
   bool                is_all_valid() const;
 
@@ -68,11 +70,8 @@ public:
   bool                compare_buffer(const void* buffer, uint32_t position, uint32_t length);
 
 private:
-  Chunk(const Chunk&);
-  void operator = (const Chunk&);
-
-  uint32_t            m_chunkSize;
-  int                 m_prot;
+  uint32_t            m_chunkSize{};
+  int                 m_prot{~0};
 };
 
 inline Chunk::iterator

--- a/src/data/socket_file.h
+++ b/src/data/socket_file.h
@@ -25,8 +25,10 @@ public:
   static const int flag_fallocate          = (1 << 0);
   static const int flag_fallocate_blocking = (1 << 1);
 
-  SocketFile() : m_fd(invalid_fd) {}
+  SocketFile() = default;
   SocketFile(fd_type fd) : m_fd(fd) {}
+  SocketFile(const SocketFile&) = delete;
+  SocketFile& operator=(const SocketFile&) = delete;
 
   bool                is_open() const                                   { return m_fd != invalid_fd; }
 
@@ -45,11 +47,7 @@ public:
 
 private:
   // Use custom flags if stuff like file locking etc is implemented.
-
-  SocketFile(const SocketFile&);
-  void operator = (const SocketFile&);
-
-  fd_type             m_fd;
+  fd_type             m_fd{invalid_fd};
 };
 
 }

--- a/src/dht/dht_node.h
+++ b/src/dht/dht_node.h
@@ -59,6 +59,9 @@ public:
 
   DhtNode(const HashString& id, const rak::socket_address* sa);
   DhtNode(const std::string& id, const Object& cache);
+  ~DhtNode() = default;
+  DhtNode(const DhtNode&) = delete;
+  DhtNode& operator=(const DhtNode&) = delete;
 
   const HashString&           id() const                 { return *this; }
   raw_string                  id_raw_string() const      { return raw_string(data(), size_data); }
@@ -94,8 +97,6 @@ public:
   Object*                     store_cache(Object* container) const;
 
 private:
-  DhtNode();
-
   void                        set_good();
   void                        set_bad();
 

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -100,6 +100,8 @@ public:
 
   DhtSearch(const HashString& target, const DhtBucket& contacts);
   virtual ~DhtSearch();
+  DhtSearch(const DhtSearch&) = delete;
+  DhtSearch& operator=(const DhtSearch&) = delete;
 
   // Wrapper for iterators, allowing more convenient access to the key
   // and element values, which also makes it easier to change the container
@@ -161,8 +163,6 @@ protected:
   const_accessor       m_next;
 
 private:
-  DhtSearch(const DhtSearch& s);
-
   bool                 node_uncontacted(const DhtNode* node) const;
 
   HashString           m_target;
@@ -278,6 +278,8 @@ private:
 class DhtTransaction {
 public:
   virtual ~DhtTransaction();
+  DhtTransaction(const DhtTransaction&) = delete;
+  DhtTransaction& operator=(const DhtTransaction&) = delete;
 
   typedef enum {
     DHT_PING,
@@ -323,8 +325,6 @@ protected:
   bool                   m_hasQuickTimeout;
 
 private:
-  DhtTransaction(const DhtTransaction& t);
-
   rak::socket_address    m_sa;
   int                    m_timeout;
   int                    m_quickTimeout;

--- a/src/download/chunk_statistics.h
+++ b/src/download/chunk_statistics.h
@@ -61,8 +61,10 @@ public:
 
   static const size_type max_accounted = 255;
 
-  ChunkStatistics() : m_complete(0), m_accounted(0) {}
-  ~ChunkStatistics() {}
+  ChunkStatistics() = default;
+  ~ChunkStatistics() = default;
+  ChunkStatistics(const ChunkStatistics&) = delete;
+  ChunkStatistics& operator=(const ChunkStatistics&) = delete;
 
   size_type           complete() const              { return m_complete; }
   //size_type           incomplete() const;
@@ -102,12 +104,8 @@ public:
 
 private:
   inline bool         should_add(PeerChunks* pc);
-
-  ChunkStatistics(const ChunkStatistics&);
-  void operator = (const ChunkStatistics&);
-
-  size_type           m_complete;
-  size_type           m_accounted;
+  size_type           m_complete{};
+  size_type           m_accounted{};
 };
 
 }

--- a/src/download/download_main.h
+++ b/src/download/download_main.h
@@ -38,6 +38,8 @@ public:
 
   DownloadMain();
   ~DownloadMain();
+  DownloadMain(const DownloadMain&) = delete;
+  DownloadMain& operator=(const DownloadMain&) = delete;
 
   void                open(int flags);
   void                close();
@@ -125,10 +127,6 @@ public:
   rak::priority_item& delay_disconnect_peers() { return m_delayDisconnectPeers; }
 
 private:
-  // Disable copy ctor and assignment.
-  DownloadMain(const DownloadMain&);
-  void operator = (const DownloadMain&);
-
   void                setup_start();
   void                setup_stop();
 

--- a/src/download/download_wrapper.h
+++ b/src/download/download_wrapper.h
@@ -21,6 +21,8 @@ class DownloadWrapper {
 public:
   DownloadWrapper();
   ~DownloadWrapper();
+  DownloadWrapper(const DownloadWrapper&) = delete;
+  DownloadWrapper& operator=(const DownloadWrapper&) = delete;
 
   DownloadInfo*       info()                                  { return m_main->info(); }
   download_data*      data()                                  { return m_main->file_list()->mutable_data(); }
@@ -69,9 +71,6 @@ public:
   void                receive_update_priorities();
 
 private:
-  DownloadWrapper(const DownloadWrapper&);
-  void operator = (const DownloadWrapper&);
-
   void                finished_download();
 
   DownloadMain*       m_main;

--- a/src/net/socket_base.h
+++ b/src/net/socket_base.h
@@ -49,6 +49,8 @@ class SocketBase : public Event {
 public:
   SocketBase() { set_fd(SocketFd()); }
   virtual ~SocketBase();
+  SocketBase(const SocketBase&) = delete;
+  SocketBase& operator=(const SocketBase&) = delete;
 
   // Ugly hack... But the alternative is to include SocketFd as part
   // of the library API or make SocketFd::m_fd into an non-modifiable
@@ -64,10 +66,6 @@ public:
   void                receive_throttle_up_activate();
 
 protected:
-  // Disable copying
-  SocketBase(const SocketBase&);
-  void operator = (const SocketBase&);
-
   static const size_t null_buffer_size = 1 << 17;
 
   static char*        m_nullBuffer;

--- a/src/net/throttle_node.h
+++ b/src/net/throttle_node.h
@@ -55,6 +55,8 @@ public:
   typedef std::function<void ()> slot_void;
 
   ThrottleNode(uint32_t rateSpan) : m_rate(rateSpan)  { clear_quota(); }
+  ThrottleNode(const ThrottleNode&) = delete;
+  ThrottleNode& operator=(const ThrottleNode&) = delete;
 
   Rate*               rate()                          { return &m_rate; }
   const Rate*         rate() const                    { return &m_rate; }
@@ -72,9 +74,6 @@ public:
   slot_void&          slot_activate()                 { return m_slot_activate; }
 
 private:
-  ThrottleNode(const ThrottleNode&);
-  void operator = (const ThrottleNode&);
-
   uint32_t            m_quota;
   iterator            m_listIterator;
 

--- a/src/protocol/handshake.h
+++ b/src/protocol/handshake.h
@@ -60,6 +60,8 @@ public:
 
   Handshake(SocketFd fd, HandshakeManager* m, int encryption_options);
   ~Handshake();
+  Handshake(const Handshake&) = delete;
+  Handshake& operator=(const Handshake&) = delete;
 
   const char*         type_name() const { return "handshake"; }
 
@@ -99,9 +101,6 @@ public:
   int                 retry_options();
 
 protected:
-  Handshake(const Handshake&);
-  void operator = (const Handshake&);
-
   void                read_done();
   void                write_done();
 

--- a/src/torrent/bitfield.h
+++ b/src/torrent/bitfield.h
@@ -50,8 +50,10 @@ public:
   typedef value_type*           iterator;
   typedef const value_type*     const_iterator;
 
-  Bitfield() : m_size(0), m_set(0), m_data(NULL)    {}
+  Bitfield() = default;
   ~Bitfield()                                       { clear(); }
+  Bitfield(const Bitfield&) = delete;
+  Bitfield& operator=(const Bitfield&) = delete;
 
   bool                empty() const                 { return m_data == NULL; }
 
@@ -112,13 +114,10 @@ public:
   static value_type   mask_from(size_type idx)      { return (value_type)~0 >> idx; }
 
 private:
-  Bitfield(const Bitfield& bf);
-  Bitfield& operator = (const Bitfield& bf);
+  size_type           m_size{};
+  size_type           m_set{};
 
-  size_type           m_size;
-  size_type           m_set;
-
-  value_type*         m_data;
+  value_type*         m_data{};
 };
 
 }

--- a/src/torrent/chunk_manager.h
+++ b/src/torrent/chunk_manager.h
@@ -63,6 +63,8 @@ public:
 
   ChunkManager();
   ~ChunkManager();
+  ChunkManager(const ChunkManager&) = delete;
+  ChunkManager& operator=(const ChunkManager&) = delete;
   
   uint64_t            memory_usage() const                      { return m_memoryUsage; }
   uint64_t            sync_queue_memory_usage() const;
@@ -143,9 +145,6 @@ public:
   void                inc_stats_not_preloaded()                 { m_statsNotPreloaded++; }
 
 private:
-  ChunkManager(const ChunkManager&);
-  void operator = (const ChunkManager&);
-
   void                sync_all(int flags, uint64_t target) LIBTORRENT_NO_EXPORT;
 
   uint64_t            m_memoryUsage;

--- a/src/torrent/connection_manager.h
+++ b/src/torrent/connection_manager.h
@@ -106,6 +106,8 @@ public:
 
   ConnectionManager();
   ~ConnectionManager();
+  ConnectionManager(const ConnectionManager&) = delete;
+  ConnectionManager& operator=(const ConnectionManager&) = delete;
   
   // Check that we have not surpassed the max number of open sockets
   // and that we're allowed to connect to the socket address.
@@ -177,9 +179,6 @@ public:
   void                set_prefer_ipv6(bool v) { m_prefer_ipv6 = v; }
 
 private:
-  ConnectionManager(const ConnectionManager&);
-  void operator = (const ConnectionManager&);
-
   size_type           m_size;
   size_type           m_maxSize;
 

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -28,6 +28,12 @@ public:
   Block();
   ~Block();
 
+  // Only allow move constructions
+  //Block(const Block&) = delete;
+  //Block& operator=(const Block&) = delete;
+  //Block(Block&&) = default;
+  //Block& operator=(Block&&) = default;
+
   bool                      is_stalled() const                           { return m_notStalled == 0; }
   bool                      is_finished() const                          { return m_leader != NULL && m_leader->is_finished(); }
   bool                      is_transfering() const                       { return m_leader != NULL && !m_leader->is_finished(); }
@@ -89,12 +95,6 @@ public:
   // will just delete the object. Made static so it can be called when
   // block == NULL.
   static void               release(BlockTransfer* transfer);
-
-  // Only allow move constructions
-  //Block(const Block&) = delete;
-  //void operator = (const Block&) = delete;
-  //Block(Block&&) = default;
-
 private:
 
   void                      invalidate_transfer(BlockTransfer* transfer) LIBTORRENT_NO_EXPORT;

--- a/src/torrent/data/block_failed.h
+++ b/src/torrent/data/block_failed.h
@@ -69,6 +69,8 @@ public:
 
   BlockFailed() : m_current(invalid_index) {}
   ~BlockFailed();
+  BlockFailed(const BlockFailed&) = delete;
+  BlockFailed& operator=(const BlockFailed&) = delete;
 
   size_type           current() const                   { return m_current; }
   iterator            current_iterator()                { return begin() + m_current; }
@@ -82,9 +84,6 @@ public:
   reverse_iterator    reverse_max_element();
 
 private:
-  BlockFailed(const BlockFailed&);
-  void operator = (const BlockFailed&);
-
   static void         delete_entry(value_type e)                    { delete [] e.first; }
   static bool         compare_entries(value_type e1, value_type e2) { return e1.second < e2.second; }
 

--- a/src/torrent/data/block_list.h
+++ b/src/torrent/data/block_list.h
@@ -29,6 +29,9 @@ public:
 
   BlockList(const Piece& piece, uint32_t blockLength);
   ~BlockList();
+  BlockList(const BlockList&) = delete;
+  BlockList& operator=(const BlockList&) = delete;
+
   bool                is_all_finished() const       { return m_finished == size(); }
 
   const Piece&        piece() const                 { return m_piece; }
@@ -60,9 +63,6 @@ public:
   void                do_all_failed();
 
 private:
-  BlockList(const BlockList&);
-  void operator = (const BlockList&);
-
   Piece               m_piece;
   priority_t          m_priority;
 

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -25,6 +25,8 @@ public:
 
   BlockTransfer();
   ~BlockTransfer();
+  BlockTransfer(const BlockTransfer&) = delete;
+  BlockTransfer& operator=(const BlockTransfer&) = delete;
 
   // TODO: Do we need to also check for peer_info?...
   bool                is_valid() const              { return m_block != NULL; }
@@ -66,9 +68,6 @@ public:
   void                set_failed_index(uint32_t i)  { m_failedIndex = i; }
 
 private:
-  BlockTransfer(const BlockTransfer&);
-  void operator = (const BlockTransfer&);
-
   key_type            m_peer_info;
   Block*              m_block;
   Piece               m_piece;

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -58,8 +58,11 @@ public:
   static const int flag_prioritize_last    = (1 << 6);
 
   static const int flag_attr_padding       = (1 << 7);
+
   File();
   ~File();
+  File(const File&) = delete;
+  File& operator=(const File&) = delete;
 
   bool                is_created() const;
   bool                is_open() const                          { return m_fd != -1; }
@@ -136,9 +139,6 @@ protected:
   void                set_match_depth_next(uint32_t l)         { m_matchDepthNext = l; }
 
 private:
-  File(const File&);
-  void operator = (const File&);
-
   bool                resize_file();
 
   int                 m_fd;

--- a/src/torrent/data/file_manager.h
+++ b/src/torrent/data/file_manager.h
@@ -60,6 +60,8 @@ public:
 
   FileManager();
   ~FileManager();
+  FileManager(const FileManager&) = delete;
+  FileManager& operator=(const FileManager&) = delete;
 
   size_type           open_files() const              { return base_type::size(); }
 
@@ -77,9 +79,6 @@ public:
   uint64_t            files_failed_counter() const { return m_filesFailedCounter; }
 
 private:
-  FileManager(const FileManager&) LIBTORRENT_NO_EXPORT;
-  void operator = (const FileManager&) LIBTORRENT_NO_EXPORT;
-
   size_type           m_maxOpenFiles;
 
   uint64_t            m_filesOpenedCounter;

--- a/src/torrent/data/transfer_list.h
+++ b/src/torrent/data/transfer_list.h
@@ -67,6 +67,8 @@ public:
 
   TransferList();
   ~TransferList();
+  TransferList(const TransferList&) = delete;
+  TransferList& operator=(const TransferList&) = delete;
 
   iterator            find(uint32_t index);
   const_iterator      find(uint32_t index) const;
@@ -99,9 +101,6 @@ public:
   slot_peer_info&     slot_corrupt()   { return m_slot_corrupt; }
 
 private:
-  TransferList(const TransferList&);
-  void operator = (const TransferList&);
-
   unsigned int        update_failed(BlockList* blockList, Chunk* chunk);
   void                mark_failed_peers(BlockList* blockList, Chunk* chunk);
 

--- a/src/torrent/http.h
+++ b/src/torrent/http.h
@@ -61,8 +61,10 @@ class LIBTORRENT_EXPORT Http {
   static const int flag_delete_self   = 0x1;
   static const int flag_delete_stream = 0x2;
 
-  Http() : m_flags(0), m_stream(NULL), m_timeout(0) {}
+  Http() = default;
   virtual ~Http();
+  Http(const Http&) = delete;
+  Http& operator=(const Http&) = delete;
 
   // Start must never throw on bad input. Calling start/stop on an
   // object in the wrong state should throw a torrent::internal_error.
@@ -98,18 +100,15 @@ protected:
   void               trigger_done();
   void               trigger_failed(const std::string& message);
 
-  int                m_flags;
+  int                m_flags{};
   std::string        m_url;
-  std::iostream*     m_stream;
-  uint32_t           m_timeout;
+  std::iostream*     m_stream{};
+  uint32_t           m_timeout{};
 
   signal_void        m_signal_done;
   signal_string      m_signal_failed;
 
 private:
-  Http(const Http&);
-  void               operator = (const Http&);
-
   static slot_http   m_factory;
 };
 

--- a/src/torrent/object.h
+++ b/src/torrent/object.h
@@ -98,7 +98,6 @@ public:
     TYPE_DICT_KEY
   };
 
-  Object()                     : m_flags(TYPE_NONE) {}
   Object(const value_type v)   : m_flags(TYPE_VALUE) { new (&_value()) value_type(v); }
   Object(const char* s)        : m_flags(TYPE_STRING) { new (&_string()) string_type(s); }
   Object(const string_type& s) : m_flags(TYPE_STRING) { new (&_string()) string_type(s); }
@@ -106,9 +105,11 @@ public:
   Object(const raw_string& r)  : m_flags(TYPE_RAW_STRING) { new (&_raw_string()) raw_string(r); }
   Object(const raw_list& r)    : m_flags(TYPE_RAW_LIST) { new (&_raw_list()) raw_list(r); }
   Object(const raw_map& r)     : m_flags(TYPE_RAW_MAP) { new (&_raw_map()) raw_map(r); }
-  Object(const Object& b);
 
+  Object() {}
   ~Object() { clear(); }
+  Object(const Object& b);
+  Object& operator=(const Object& b);
 
   // TODO: Move this out of the class namespace, call them
   // make_object_. 
@@ -241,8 +242,6 @@ public:
                                  uint32_t skip_mask = flag_static_data,
                                  uint32_t maxDepth = ~uint32_t());
 
-  Object&             operator = (const Object& b);
-
   // Internal:
   void                swap_same_type(Object& left, Object& right);
 
@@ -252,7 +251,7 @@ public:
 
   template <typename T> void check_value_throw(const char* err_msg) const;
 
-  uint32_t            m_flags;
+  uint32_t            m_flags{TYPE_NONE};
 
 #ifndef HAVE_STDCXX_0X
   value_type&         _value()             { return t_value; }

--- a/src/torrent/peer/connection_list.h
+++ b/src/torrent/peer/connection_list.h
@@ -97,6 +97,9 @@ public:
   static const int disconnect_delayed   = (1 << 3);
 
   ConnectionList(DownloadMain* download);
+  ~ConnectionList() = default;
+  ConnectionList(const ConnectionList&) = delete;
+  ConnectionList& operator=(const ConnectionList&) = delete;
 
   // Make these protected?
   iterator            erase(iterator pos, int flags);
@@ -142,9 +145,6 @@ protected:
   void                disconnect_queued() LIBTORRENT_NO_EXPORT;
 
 private:
-  ConnectionList(const ConnectionList&) LIBTORRENT_NO_EXPORT;
-  void operator = (const ConnectionList&) LIBTORRENT_NO_EXPORT;
-
   DownloadMain*       m_download;
 
   size_type           m_minSize;

--- a/src/torrent/peer/peer.h
+++ b/src/torrent/peer/peer.h
@@ -54,6 +54,9 @@ class PeerConnectionBase;
 // date. 
 class LIBTORRENT_EXPORT Peer {
 public:
+  Peer(const Peer&) = delete;
+  Peer& operator=(const Peer&) = delete;
+
   // Does not check if it has been removed from the download.
   bool                 is_incoming() const                { return peer_info()->is_incoming(); }
   bool                 is_encrypted() const;
@@ -104,11 +107,8 @@ public:
   const PeerConnectionBase* c_ptr() const { return reinterpret_cast<const PeerConnectionBase*>(this); }
 
 protected:
-  Peer() {}
-  virtual ~Peer() {}
-
-  Peer(const Peer&);
-  void operator = (const Peer&);
+  Peer() = default;
+  virtual ~Peer() = default;
 
   bool                 operator == (const Peer& p) const;
 

--- a/src/torrent/peer/peer_info.h
+++ b/src/torrent/peer/peer_info.h
@@ -64,6 +64,8 @@ public:
 
   PeerInfo(const sockaddr* address);
   ~PeerInfo();
+  PeerInfo(const PeerInfo&) = delete;
+  PeerInfo& operator=(const PeerInfo&) = delete;
 
   bool                is_connected() const                  { return m_flags & flag_connected; }
   bool                is_incoming() const                   { return m_flags & flag_incoming; }
@@ -123,9 +125,6 @@ protected:
   void                set_connection(PeerConnectionBase* c) { m_connection = c; }
 
 private:
-  PeerInfo(const PeerInfo&);
-  void operator = (const PeerInfo&);
-
   // Replace id with a char buffer, or a cheap struct?
   int                 m_flags;
   HashString          m_id;

--- a/src/torrent/peer/peer_list.h
+++ b/src/torrent/peer/peer_list.h
@@ -51,6 +51,8 @@ public:
 
   PeerList();
   ~PeerList();
+  PeerList(const PeerList&) = delete;
+  PeerList& operator=(const PeerList&) = delete;
 
   PeerInfo*           insert_address(const sockaddr* address, int flags);
 
@@ -80,9 +82,6 @@ protected:
   iterator            disconnected(iterator itr, int flags) LIBTORRENT_NO_EXPORT;
 
 private:
-  PeerList(const PeerList&);
-  void operator = (const PeerList&);
-
   static ipv4_table   m_ipv4_table;
 
   DownloadInfo*       m_info;

--- a/src/torrent/poll_select.h
+++ b/src/torrent/poll_select.h
@@ -53,6 +53,8 @@ class LIBTORRENT_EXPORT PollSelect : public Poll {
 public:
   static PollSelect*  create(int maxOpenSockets);
   virtual ~PollSelect();
+  PollSelect(const PollSelect&) = delete;
+  PollSelect& operator=(const PollSelect&) = delete;
 
   virtual uint32_t    open_max() const;
 
@@ -80,9 +82,7 @@ public:
   virtual void        remove_error(Event* event);
 
 private:
-  PollSelect() {}
-  PollSelect(const PollSelect&);
-  void operator = (const PollSelect&);
+  PollSelect() = default;
 
   SocketSet*          m_readSet;
   SocketSet*          m_writeSet;

--- a/src/torrent/tracker.h
+++ b/src/torrent/tracker.h
@@ -49,7 +49,9 @@ public:
   static constexpr int min_normal_interval     = 600;
   static constexpr int max_normal_interval     = 8 * 3600;
 
-  virtual ~Tracker() {}
+  virtual ~Tracker() = default;
+  Tracker(const Tracker&) = delete;
+  Tracker& operator=(const Tracker&) = delete;
 
   int                 flags() const { return m_flags; }
 
@@ -85,8 +87,6 @@ public:
 
 protected:
   Tracker(TrackerList* parent, const std::string& url, int flags = 0);
-  Tracker(const Tracker& t);
-  void operator = (const Tracker& t);
 
   // TODO: Rename to send_event.
   virtual void        send_state(int state) = 0;

--- a/src/torrent/tracker_controller.h
+++ b/src/torrent/tracker_controller.h
@@ -49,6 +49,8 @@ public:
 
   TrackerController(TrackerList* trackers);
   ~TrackerController();
+  TrackerController() = delete;
+  TrackerController& operator=(const TrackerController&) = delete;
 
   int                 flags() const               { return m_flags; }
 
@@ -104,9 +106,6 @@ private:
   void                update_timeout(uint32_t seconds_to_next);
 
   inline int          current_send_state() const;
-
-  TrackerController();
-  void operator = (const TrackerController&);
 
   int                 m_flags;
   TrackerList*        m_tracker_list;

--- a/src/torrent/tracker_list.h
+++ b/src/torrent/tracker_list.h
@@ -52,6 +52,9 @@ public:
   using base_type::operator[];
 
   TrackerList();
+  ~TrackerList() = default;
+  TrackerList(const TrackerList&) = delete;
+  TrackerList& operator=(const TrackerList&) = delete;
 
   bool                has_active() const;
   bool                has_active_not_scrape() const;
@@ -129,9 +132,6 @@ protected:
   void                set_state(int s)                        { m_state = s; }
 
 private:
-  TrackerList(const TrackerList&) LIBTORRENT_NO_EXPORT;
-  void operator = (const TrackerList&) LIBTORRENT_NO_EXPORT;
-
   DownloadInfo*       m_info;
   int                 m_state;
 

--- a/src/utils/diffie_hellman.h
+++ b/src/utils/diffie_hellman.h
@@ -15,6 +15,9 @@ public:
 
   DiffieHellman(const unsigned char prime[], int primeLength,
                 const unsigned char generator[], int generatorLength);
+  ~DiffieHellman() = default;
+  DiffieHellman(const DiffieHellman&) = delete;
+  DiffieHellman& operator=(const DiffieHellman&) = delete;
 
   bool         is_valid() const;
 
@@ -27,9 +30,6 @@ public:
   std::string  secret_str() const   { return std::string(m_secret.get(), m_size); }
 
 private:
-  DiffieHellman(const DiffieHellman& dh);
-  DiffieHellman& operator = (const DiffieHellman& dh);
-
   dh_ptr       m_dh;
   secret_ptr   m_secret;
   int          m_size;


### PR DESCRIPTION
Moves to modern C++11 standards. Deleted functions should be public.