### PR TITLE
Fix undefined behavior in extents::insert

### DIFF
--- a/src/torrent/utils/extents.h
+++ b/src/torrent/utils/extents.h
@@ -64,7 +64,7 @@ void extents<Address, Value, Compare>::insert(key_type address_start, key_type a
     if(do_delete_due_to_overlap || do_delete_due_to_total_overlap) {
       range_map.erase (delete_key);
     }
-    else {
+    else if (iter != range_map.end()) {
       ignore_due_to_total_overlap = ignore_due_to_total_overlap || ( iter->first <= address_start && (iter->second).first >= address_end );
     }
   }


### PR DESCRIPTION
The extents::insert may dereference the end iterator, which is undefined behavior. This occurs when there is no element that is greater than the specified key. In which case, iter will point to the element before the end pointer. The loop body will then increment the iter (causing it to point to the end pointer) and dereference it, unless there is an overlap.

The "borders" test case from `test_extents.cc` triggers this behavior and causes test failures on some architectures. You can single-step through it with GDB to confirm this, Specifically, this was encountered on the Alpine Linux Edge armhf/x86 builders.

*If* I understand the semantics correctly, then if we ran into the end iterator at this point we don't need to update `ignore_due_to_total_overlap` and can leave it as-is.