### PR TITLE
Don't free memory not allocated by getaddrinfo(3) with freeaddrinfo

### DIFF
--- a/src/torrent/net/address_info.h
+++ b/src/torrent/net/address_info.h
@@ -19,8 +19,8 @@ typedef std::unique_ptr<addrinfo, ai_deleter> ai_unique_ptr;
 typedef std::unique_ptr<const addrinfo, ai_deleter> c_ai_unique_ptr;
 typedef std::function<void (const sockaddr*)> ai_sockaddr_func;
 
-inline void          ai_clear(addrinfo* ai);
-inline ai_unique_ptr ai_make_hint(int flags, int family, int socktype);
+inline void                      ai_clear(addrinfo* ai);
+inline std::unique_ptr<addrinfo> ai_make_hint(int flags, int family, int socktype);
 
 int ai_get_addrinfo(const char* nodename, const char* servname, const addrinfo* hints, ai_unique_ptr& res) LIBTORRENT_EXPORT;
 
@@ -52,11 +52,11 @@ ai_clear(addrinfo* ai) {
   std::memset(ai, 0, sizeof(addrinfo));  
 }
 
-inline ai_unique_ptr
+inline std::unique_ptr<addrinfo>
 ai_make_hint(int flags, int family, int socktype) {
-  ai_unique_ptr aip(new addrinfo);
+  std::unique_ptr<addrinfo> aip(new addrinfo);
 
-  aip_clear(aip);
+  ai_clear(aip.get());
   aip->ai_flags = flags;
   aip->ai_family = family;
   aip->ai_socktype = socktype;


### PR DESCRIPTION
ai_unique_ptr frees objects via a custom deleter using freeaddrinfo(3). However, in ai_make_hint the ai_unique_ptr is used for a addrinfo structure allocated via new. This is undefined behavior as freeaddrinfo is only defined for structures returned by getaddrinfo().

This commit fixes this by using a standard std::unique_ptr here with the default delete function which frees the memory using delete.

Just like #319 this has been discovered due to test failures on certain Alpine Linux Edge architectures.