### PR TITLE
Fix pthread_setname_np race condition in thread_base::event_loop

### DIFF
--- a/src/torrent/utils/thread_base.cc
+++ b/src/torrent/utils/thread_base.cc
@@ -92,7 +92,8 @@ thread_base::event_loop(thread_base* thread) {
 #if defined(HAS_PTHREAD_SETNAME_NP_DARWIN)
   pthread_setname_np(thread->name());
 #elif defined(HAS_PTHREAD_SETNAME_NP_GENERIC)
-  pthread_setname_np(thread->m_thread, thread->name());
+  // Cannot use thread->m_thread here as it may not be set before pthread_create returns.
+  pthread_setname_np(pthread_self(), thread->name());
 #endif
 
   lt_log_print(torrent::LOG_THREAD_NOTICE, "%s: Starting thread.", thread->name());


### PR DESCRIPTION
The `thread->m_thread` member is set via `pthread_create(3)`. However, it is not guaranteed that `pthread_create` writes this member before it returns. Since `thread_base::event_loop` is the function executed by `pthread_create`, we cannot assume that it is set. Instead, use `pthread_self()` which is guaranteed to return a meaningful value.