### PR TITLE
clang-tidy: use const ref and std::move

### DIFF
--- a/src/data/hash_queue.cc
+++ b/src/data/hash_queue.cc
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <unistd.h>
+#include <utility>
 
 #include "globals.h"
 #include "data/chunk.h"
@@ -58,7 +59,7 @@ HashQueue::push_back(ChunkHandle handle, HashQueueNode::id_type id, slot_done_ty
 
   HashChunk* hash_chunk = new HashChunk(handle);
 
-  base_type::push_back(HashQueueNode(id, hash_chunk, d));
+  base_type::push_back(HashQueueNode(id, hash_chunk, std::move(d)));
 
   m_thread_disk->hash_queue()->push_back(hash_chunk);
   m_thread_disk->interrupt();

--- a/src/data/hash_queue_node.h
+++ b/src/data/hash_queue_node.h
@@ -40,6 +40,7 @@
 #include <cinttypes>
 #include <functional>
 #include <string>
+#include <utility>
 
 #include "chunk_handle.h"
 #include "hash_chunk.h"
@@ -54,7 +55,7 @@ public:
   typedef download_data* id_type;
 
   HashQueueNode(id_type id, HashChunk* c, slot_done_type d) :
-    m_id(id), m_chunk(c), m_willneed(false), m_slot_done(d) {}
+      m_id(id), m_chunk(c), m_willneed(false), m_slot_done(std::move(d)) {}
 
   id_type             id() const                    { return m_id; }
   ChunkHandle&        handle()                      { return *m_chunk->chunk(); }

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -294,7 +294,7 @@ DownloadConstructor::parse_multi_files(const Object& b, uint32_t chunk_size) {
 }
 
 inline Path
-DownloadConstructor::create_path(const Object::list_type& plist, const std::string enc) {
+DownloadConstructor::create_path(const Object::list_type& plist, const std::string& enc) {
   // Make sure we are given a proper file path.
   if (plist.empty())
     throw input_error("Bad torrent file, \"path\" has zero entries.");

--- a/src/download/download_constructor.h
+++ b/src/download/download_constructor.h
@@ -39,7 +39,7 @@ private:
   void                parse_single_file(const Object& b, uint32_t chunkSize);
   void                parse_multi_files(const Object& b, uint32_t chunkSize);
 
-  inline Path         create_path(const Object::list_type& plist, const std::string enc);
+  inline Path         create_path(const Object::list_type& plist, const std::string& enc);
   inline Path         choose_path(std::list<Path>* pathList);
 
   DownloadWrapper*    m_download;

--- a/src/download/download_main.h
+++ b/src/download/download_main.h
@@ -2,6 +2,7 @@
 #define LIBTORRENT_DOWNLOAD_MAIN_H
 
 #include <deque>
+#include <utility>
 
 #include "globals.h"
 
@@ -101,10 +102,10 @@ public:
   typedef std::function<void(const rak::socket_address&, DownloadMain*)> slot_start_handshake_type;
   typedef std::function<void(DownloadMain*)>                             slot_stop_handshakes_type;
 
-  void                slot_start_handshake(slot_start_handshake_type s) { m_slotStartHandshake = s; }
-  void                slot_stop_handshakes(slot_stop_handshakes_type s) { m_slotStopHandshakes = s; }
-  void                slot_count_handshakes(slot_count_handshakes_type s) { m_slotCountHandshakes = s; }
-  void                slot_hash_check_add(slot_hash_check_add_type s)     { m_slotHashCheckAdd = s; }
+  void                slot_start_handshake(slot_start_handshake_type s) { m_slotStartHandshake = std::move(s); }
+  void                slot_stop_handshakes(slot_stop_handshakes_type s) { m_slotStopHandshakes = std::move(s); }
+  void                slot_count_handshakes(slot_count_handshakes_type s) { m_slotCountHandshakes = std::move(s); }
+  void                slot_hash_check_add(slot_hash_check_add_type s)     { m_slotHashCheckAdd = std::move(s); }
 
   void                add_peer(const rak::socket_address& sa);
 

--- a/src/torrent/connection_manager.cc
+++ b/src/torrent/connection_manager.cc
@@ -16,7 +16,7 @@ namespace torrent {
 
 // Fix TrackerUdp, etc, if this is made async.
 static ConnectionManager::slot_resolver_result_type*
-resolve_host(const char* host, int family, int socktype, ConnectionManager::slot_resolver_result_type slot) {
+resolve_host(const char* host, int family, int socktype, const ConnectionManager::slot_resolver_result_type& slot) {
   if (manager->thread_main()->is_current())
     thread_base::release_global_lock();
 

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -42,6 +42,7 @@
 #include <cinttypes>
 #include <functional>
 #include <list>
+#include <utility>
 #include <vector>
 
 #include <torrent/download/group_entry.h>
@@ -144,9 +145,9 @@ public:
   heuristics_enum     heuristics() const                       { return m_heuristics; }
   void                set_heuristics(heuristics_enum hs)       { m_heuristics = hs; }
 
-  void                set_slot_unchoke(slot_unchoke s)         { m_slotUnchoke = s; }
-  void                set_slot_can_unchoke(slot_can_unchoke s) { m_slotCanUnchoke = s; }
-  void                set_slot_connection(slot_connection s)   { m_slotConnection = s; }
+  void                set_slot_unchoke(slot_unchoke s)         { m_slotUnchoke = std::move(s); }
+  void                set_slot_can_unchoke(slot_can_unchoke s) { m_slotCanUnchoke = std::move(s); }
+  void                set_slot_connection(slot_connection s)   { m_slotConnection = std::move(s); }
 
   // TODO: Consider putting this in queue_group.
   group_container_type& group_container()                      { return m_group_container; }

--- a/src/torrent/net/address_info.cc
+++ b/src/torrent/net/address_info.cc
@@ -27,7 +27,7 @@ ai_get_first_sa(const char* nodename, const char* servname, const addrinfo* hint
 }
 
 int
-ai_each_inet_inet6_first(const char* nodename, ai_sockaddr_func lambda) {
+ai_each_inet_inet6_first(const char* nodename, const ai_sockaddr_func& lambda) {
   int err;
   ai_unique_ptr ai;
 
@@ -39,5 +39,4 @@ ai_each_inet_inet6_first(const char* nodename, ai_sockaddr_func lambda) {
   lambda(ai->ai_addr);
   return 0;
 }
-
 }

--- a/src/torrent/net/address_info.h
+++ b/src/torrent/net/address_info.h
@@ -30,7 +30,7 @@ int ai_get_addrinfo(const char* nodename, const char* servname, const addrinfo* 
 // TODO: ai_get_first_sa_err that returns a tuple?
 sa_unique_ptr ai_get_first_sa(const char* nodename, const char* servname = nullptr, const addrinfo* hints = nullptr) LIBTORRENT_EXPORT;
 
-int ai_each_inet_inet6_first(const char* nodename, ai_sockaddr_func lambda) LIBTORRENT_EXPORT;
+int ai_each_inet_inet6_first(const char* nodename, const ai_sockaddr_func& lambda) LIBTORRENT_EXPORT;
 
 // Get all addrinfo's, iterate, etc.
 

--- a/src/torrent/tracker/manager.cc
+++ b/src/torrent/tracker/manager.cc
@@ -3,6 +3,7 @@
 #include "torrent/tracker/manager.h"
 
 #include <cassert>
+#include <utility>
 
 #include "src/manager.h"
 #include "torrent/exceptions.h"
@@ -61,7 +62,7 @@ Manager::add_event(TrackerList* tracker_list, std::function<void()> event) {
 
   std::lock_guard<std::mutex> guard(m_events_lock);
 
-  m_tracker_list_events.push_back(TrackerListEvent{tracker_list, event});
+  m_tracker_list_events.push_back(TrackerListEvent{tracker_list, std::move(event)});
 
   torrent::manager->thread_main()->send_event_signal(m_main_thread_signal);
 }

--- a/src/torrent/tracker/tracker.cc
+++ b/src/torrent/tracker/tracker.cc
@@ -137,7 +137,7 @@ Tracker::status() const {
 }
 
 void
-Tracker::lock_and_call_state(std::function<void(const TrackerState&)> f) const {
+Tracker::lock_and_call_state(const std::function<void(const TrackerState&)>& f) const {
   auto lock_guard = m_worker->lock_guard();
 
   f(m_worker->state());

--- a/src/torrent/tracker/tracker.h
+++ b/src/torrent/tracker/tracker.h
@@ -30,14 +30,14 @@ public:
   torrent::tracker_enum type() const;
   const std::string&    url() const;
 
-  std::string         tracker_id() const;
-  TrackerState        state() const;;
-  std::string         status() const;
+  std::string           tracker_id() const;
+  TrackerState          state() const;
+  std::string           status() const;
 
   // If the tracker group is changed, it not be updated for Tracker objects outside of TrackerList.
   uint32_t            group() const { return m_group; }
 
-  void                lock_and_call_state(std::function<void(const TrackerState&)> f) const;
+  void                lock_and_call_state(const std::function<void(const TrackerState&)>& f) const;
 
   bool                operator< (const Tracker& rhs) const { return m_worker < rhs.m_worker; }
   bool                operator==(const Tracker& rhs) const { return m_worker == rhs.m_worker; }

--- a/src/torrent/tracker/wrappers.cc
+++ b/src/torrent/tracker/wrappers.cc
@@ -2,6 +2,8 @@
 
 #include "torrent/tracker/wrappers.h"
 
+#include <utility>
+
 #include "torrent/tracker_controller.h"
 #include "torrent/utils/log.h"
 
@@ -104,8 +106,8 @@ TrackerControllerWrapper::scrape_request(uint32_t seconds_to_request) {
 
 void
 TrackerControllerWrapper::set_slots(slot_address_list success, slot_string failure) {
-  m_ptr->slot_success() = success;
-  m_ptr->slot_failure() = failure;
+  m_ptr->slot_success() = std::move(success);
+  m_ptr->slot_failure() = std::move(failure);
 }
 
 } // namespace torrent

--- a/src/torrent/tracker_list.cc
+++ b/src/torrent/tracker_list.cc
@@ -283,7 +283,7 @@ TrackerList::insert_url(unsigned int group, const std::string& url, bool extra_t
 
 TrackerList::iterator
 TrackerList::find_url(const std::string& url) {
-  return std::find_if(begin(), end(), [&url](auto tracker) { return tracker.url() == url; });
+  return std::find_if(begin(), end(), [&url](const auto& tracker) { return tracker.url() == url; });
 }
 
 TrackerList::iterator

--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -245,7 +245,7 @@ log_find_output_name(const char* name) {
 }
 
 void
-log_open_output(const char* name, log_slot slot) {
+log_open_output(const char* name, const log_slot& slot) {
   auto lock = std::scoped_lock(log_mutex);
 
   if (log_outputs.size() >= log_group::max_size_outputs()) {

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -206,9 +206,9 @@ extern log_group_list log_groups LIBTORRENT_EXPORT;
 void log_initialize() LIBTORRENT_EXPORT;
 void log_cleanup() LIBTORRENT_EXPORT;
 
-void log_open_output(const char* name, log_slot slot) LIBTORRENT_EXPORT;
+void log_open_output(const char* name, const log_slot& slot) LIBTORRENT_EXPORT;
 void log_close_output(const char* name) LIBTORRENT_EXPORT;
-void log_close_output_str(const std::string name) LIBTORRENT_EXPORT;
+void log_close_output_str(const std::string& name) LIBTORRENT_EXPORT;
 
 void log_add_group_output(int group, const char* name) LIBTORRENT_EXPORT;
 void log_remove_group_output(int group, const char* name) LIBTORRENT_EXPORT;
@@ -223,7 +223,7 @@ void log_open_gz_file_output(const char* name, const char* filename, bool append
 // Implementation:
 //
 
-inline void log_close_output_str(const std::string name) { log_close_output(name.c_str()); }
+inline void log_close_output_str(const std::string& name) { log_close_output(name.c_str()); }
 
 }
 

--- a/src/torrent/utils/log_buffer.h
+++ b/src/torrent/utils/log_buffer.h
@@ -6,11 +6,13 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 
 namespace torrent {
 
 struct log_entry {
-  log_entry(int32_t t, int32_t grp, const std::string& msg) : timestamp(t), group(grp), message(msg) {}
+  log_entry(int32_t t, int32_t grp, std::string msg) :
+      timestamp(t), group(grp), message(std::move(msg)) {}
 
   bool        is_older_than(int32_t t) const { return timestamp < t; }
   bool        is_younger_than(int32_t t) const { return timestamp > t; }

--- a/src/torrent/utils/signal_bitfield.cc
+++ b/src/torrent/utils/signal_bitfield.cc
@@ -11,7 +11,7 @@ const unsigned int signal_bitfield::max_size;
 
 // Only the thread owning this signal bitfield should add signals.
 unsigned int
-signal_bitfield::add_signal(slot_type slot) {
+signal_bitfield::add_signal(const slot_type& slot) {
   if (m_thread_id != std::this_thread::get_id())
     throw internal_error("signal_bitfield::add_signal(...): Only the owning thread can add signals.");
 

--- a/src/torrent/utils/signal_bitfield.h
+++ b/src/torrent/utils/signal_bitfield.h
@@ -20,7 +20,7 @@ public:
 
   signal_bitfield() : m_thread_id(std::this_thread::get_id()), m_size(0), m_bitfield(0) {}
 
-  unsigned int  add_signal(slot_type slot);
+  unsigned int  add_signal(const slot_type& slot);
   bool          has_signal(unsigned int index) const { return m_bitfield & (1 << index); }
 
   void          signal(unsigned int index) { m_bitfield |= 1 << index; }

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -6,6 +6,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <utility>
 #include <rak/string_manip.h>
 
 #include "net/address_list.h"
@@ -256,13 +257,13 @@ TrackerHttp::receive_done() {
 }
 
 void
-TrackerHttp::receive_signal_failed(std::string msg) {
+TrackerHttp::receive_signal_failed(const std::string& msg) {
   lock_and_clear_intervals();
   return receive_failed(msg);
 }
 
 void
-TrackerHttp::receive_failed(std::string msg) {
+TrackerHttp::receive_failed(const std::string& msg) {
   if (lt_log_is_valid(LOG_TRACKER_DEBUG)) {
     std::string dump = m_data->str();
     LT_LOG_TRACKER_DUMP(DEBUG, dump.c_str(), dump.size(), "Tracker HTTP failed.", 0);

--- a/src/tracker/tracker_http.h
+++ b/src/tracker/tracker_http.h
@@ -33,8 +33,8 @@ private:
   void                request_prefix(std::stringstream* stream, const std::string& url);
 
   void                receive_done();
-  void                receive_signal_failed(std::string msg);
-  void                receive_failed(std::string msg);
+  void                receive_signal_failed(const std::string& msg);
+  void                receive_failed(const std::string& msg);
 
   void                process_failure(const Object& object);
   void                process_success(const Object& object);

--- a/src/tracker/tracker_worker.h
+++ b/src/tracker/tracker_worker.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <iosfwd>
 #include <mutex>
+#include <utility>
 
 #include "torrent/common.h"
 #include "torrent/hash_string.h"
@@ -33,7 +34,7 @@ struct TrackerParameters {
 
 class TrackerWorker {
 public:
-  TrackerWorker(const TrackerInfo& info, int flags = 0);
+  TrackerWorker(TrackerInfo info, int flags = 0);
   virtual ~TrackerWorker() = default;
 
   TrackerWorker() = delete;
@@ -103,9 +104,8 @@ private:
   std::string           m_tracker_id;
 };
 
-inline
-TrackerWorker::TrackerWorker(const TrackerInfo& info, int flags) :
-  m_info(info) {
+inline TrackerWorker::TrackerWorker(TrackerInfo info, int flags) :
+    m_info(std::move(info)) {
   m_state.m_flags = flags;
 }
 


### PR DESCRIPTION
Found with modernize-pass-by-value
Found with performance-unnecessary-value-param
Found with performance-move-const-arg