### PR TITLE
Fix invalid memory accesses on exit

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -71,6 +71,7 @@ Manager::~Manager() {
 
   m_handshake_manager->clear();
   m_download_manager->clear();
+  m_dht_controller.reset();
 
   Throttle::destroy_throttle(m_uploadThrottle);
   Throttle::destroy_throttle(m_downloadThrottle);

--- a/src/torrent/tracker/manager.cc
+++ b/src/torrent/tracker/manager.cc
@@ -49,7 +49,7 @@ Manager::remove_controller(TrackerControllerWrapper controller) {
                                        m_tracker_list_events.end(),
                                        [tl = controller.get()->tracker_list()](const TrackerListEvent& event) {
                                          return event.tracker_list == tl;
-                                       }));
+                                       }), m_tracker_list_events.end());
   }
 
   LT_LOG_TRACKER_EVENTS("removed controller: info_hash:%s", hash_string_to_hex_str(controller.info_hash()).c_str());


### PR DESCRIPTION
rtorrent now segfaults in `Manager::remove_controller` after adding a new magnet link when nothing is being downloaded yet.