### PR TITLE
clang-tidy: use default member init

### DIFF
--- a/src/data/chunk_list.h
+++ b/src/data/chunk_list.h
@@ -55,7 +55,6 @@ public:
 
   static const int flag_active       = (1 << 0);
 
-  ChunkList() : m_data(NULL), m_manager(NULL), m_flags(0), m_chunk_size(0) {}
   ~ChunkList() { clear(); }
 
   int                 flags() const                       { return m_flags; }
@@ -109,12 +108,12 @@ private:
 
   std::pair<int,bool> sync_options(ChunkListNode* node, int flags);
 
-  download_data*      m_data;
-  ChunkManager*       m_manager;
+  download_data*      m_data{};
+  ChunkManager*       m_manager{};
   Queue               m_queue;
 
-  int                 m_flags;
-  uint32_t            m_chunk_size;
+  int                 m_flags{0};
+  uint32_t            m_chunk_size{0};
 
   slot_string         m_slot_storage_error;
   slot_chunk_index    m_slot_create_chunk;

--- a/src/data/chunk_list_node.h
+++ b/src/data/chunk_list_node.h
@@ -56,14 +56,6 @@ class lt_cacheline_aligned ChunkListNode {
 public:
   static const uint32_t invalid_index = ~uint32_t();
 
-  ChunkListNode() :
-    m_index(invalid_index),
-    m_chunk(NULL),
-    m_references(0),
-    m_writable(0),
-    m_blocking(0),
-    m_asyncTriggered(false) {}
-
   bool                is_valid() const               { return m_chunk != NULL; }
 
   uint32_t            index() const                  { return m_index; }
@@ -97,14 +89,14 @@ public:
   void                dec_rw()                       { dec_writable(); dec_references(); }
 
 private:
-  uint32_t            m_index;
-  Chunk*              m_chunk;
+  uint32_t            m_index{invalid_index};
+  Chunk*              m_chunk{};
 
-  int                 m_references;
-  int                 m_writable;
-  int                 m_blocking;
+  int                 m_references{0};
+  int                 m_writable{0};
+  int                 m_blocking{0};
 
-  bool                m_asyncTriggered;
+  bool                m_asyncTriggered{false};
 
   rak::timer          m_timeModified;
   rak::timer          m_timePreloaded;

--- a/src/data/chunk_part.h
+++ b/src/data/chunk_part.h
@@ -51,7 +51,7 @@ public:
   } mapped_type;
 
   ChunkPart(mapped_type mapped, const MemoryChunk& c, uint32_t pos) :
-    m_mapped(mapped), m_chunk(c), m_position(pos), m_file(NULL), m_file_offset(0) {}
+    m_mapped(mapped), m_chunk(c), m_position(pos) {}
 
   bool                is_valid() const                      { return m_chunk.is_valid(); }
   bool                is_contained(uint32_t p) const        { return p >= m_position && p < m_position + size(); }
@@ -87,8 +87,8 @@ private:
   // Currently used to figure out what file and where a SIGBUS
   // occurred. Can also be used in the future to indicate if a part is
   // temporary storage, etc.
-  File*               m_file;
-  uint64_t            m_file_offset;
+  File*               m_file{};
+  uint64_t            m_file_offset{0};
 };
 
 }

--- a/src/data/hash_queue_node.h
+++ b/src/data/hash_queue_node.h
@@ -55,7 +55,7 @@ public:
   typedef download_data* id_type;
 
   HashQueueNode(id_type id, HashChunk* c, slot_done_type d) :
-      m_id(id), m_chunk(c), m_willneed(false), m_slot_done(std::move(d)) {}
+      m_id(id), m_chunk(c),  m_slot_done(std::move(d)) {}
 
   id_type             id() const                    { return m_id; }
   ChunkHandle&        handle()                      { return *m_chunk->chunk(); }
@@ -78,7 +78,7 @@ public:
 private:
   id_type             m_id;
   HashChunk*          m_chunk;
-  bool                m_willneed;
+  bool                m_willneed{false};
 
   slot_done_type      m_slot_done;
 };

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -243,7 +243,7 @@ public:
 
   // non-transaction packet
   DhtTransactionPacket(const rak::socket_address* s, const DhtMessage& d)
-    : m_sa(*s), m_id(-cachedTime.seconds()), m_transaction(NULL) { build_buffer(d); };
+    : m_sa(*s), m_id(-cachedTime.seconds()) { build_buffer(d); };
 
   ~DhtTransactionPacket()                               { delete[] m_data; }
 
@@ -269,7 +269,7 @@ private:
   char*                 m_data;
   size_t                m_length;
   int                   m_id;
-  DhtTransaction*       m_transaction;
+  DhtTransaction*       m_transaction{};
 };
 
 // DHT Transaction classes. DhtTransaction and DhtTransactionSearch

--- a/src/download/download_constructor.h
+++ b/src/download/download_constructor.h
@@ -15,8 +15,6 @@ typedef std::list<std::string> EncodingList;
 
 class DownloadConstructor {
 public:
-  DownloadConstructor() : m_download(NULL), m_encodingList(NULL) {}
-
   void                initialize(Object& b);
 
   void                parse_tracker(const Object& b);
@@ -42,8 +40,8 @@ private:
   inline Path         create_path(const Object::list_type& plist, const std::string& enc);
   inline Path         choose_path(std::list<Path>* pathList);
 
-  DownloadWrapper*    m_download;
-  const EncodingList* m_encodingList;
+  DownloadWrapper*    m_download{};
+  const EncodingList* m_encodingList{};
 
   std::string         m_defaultEncoding;
 };

--- a/src/net/data_buffer.h
+++ b/src/net/data_buffer.h
@@ -44,8 +44,8 @@ namespace torrent {
 
 // Recipient must call clear() when done with the buffer.
 struct DataBuffer {
-  DataBuffer()                        : m_data(NULL), m_end(NULL), m_owned(true) {}
-  DataBuffer(char* data, char* end)   : m_data(data), m_end(end),  m_owned(true) {}
+  DataBuffer() = default;
+  DataBuffer(char* data, char* end)   : m_data(data), m_end(end) {}
 
   DataBuffer          clone() const        { DataBuffer d = *this; d.m_owned = false; return d; }
   DataBuffer          release()            { DataBuffer d = *this; set(NULL, NULL, false); return d; }
@@ -61,12 +61,12 @@ struct DataBuffer {
   void                set(char* data, char* end, bool owned);
 
 private:
-  char*               m_data;
-  char*               m_end;
+  char*               m_data{};
+  char*               m_end{};
 
   // Used to indicate if buffer held by PCB is its own and needs to be
   // deleted after transmission (false if shared with other connections).
-  bool                m_owned;
+  bool                m_owned{true};
 };
 
 inline void

--- a/src/net/listen.h
+++ b/src/net/listen.h
@@ -50,7 +50,6 @@ class Listen : public SocketBase {
 public:
   typedef std::function<void (SocketFd, const rak::socket_address&)> slot_connection;
 
-  Listen() : m_port(0) {}
   ~Listen() { close(); }
 
   bool                open(uint16_t first, uint16_t last, int backlog, const rak::socket_address* bindAddress);
@@ -67,7 +66,7 @@ public:
   virtual void        event_error();
 
 private:
-  uint64_t            m_port;
+  uint64_t            m_port{0};
 
   slot_connection     m_slot_accepted;
 };

--- a/src/net/socket_fd.h
+++ b/src/net/socket_fd.h
@@ -51,7 +51,7 @@ class SocketFd {
 public:
   typedef uint8_t priority_type;
 
-  SocketFd() : m_fd(-1) {}
+  SocketFd() = default;
   explicit SocketFd(int fd) : m_fd(fd) {}
   SocketFd(int fd, bool ipv6_socket) : m_fd(fd), m_ipv6_socket(ipv6_socket) {}
 
@@ -98,7 +98,7 @@ public:
 private:
   inline void         check_valid() const;
 
-  int                 m_fd;
+  int                 m_fd{-1};
   bool                m_ipv6_socket;
 };
 

--- a/src/protocol/encryption_info.h
+++ b/src/protocol/encryption_info.h
@@ -43,8 +43,6 @@ namespace torrent {
 
 class EncryptionInfo {
 public:
-  EncryptionInfo() : m_encrypted(false), m_obfuscated(false), m_decryptValid(false) {};
-
   void                encrypt(const void *indata, void *outdata, unsigned int length) { m_encrypt.crypt(indata, outdata, length); }
   void                encrypt(void *data, unsigned int length)                        { m_encrypt.crypt(data, length); }
   void                decrypt(const void *indata, void *outdata, unsigned int length) { m_decrypt.crypt(indata, outdata, length); }
@@ -59,9 +57,9 @@ public:
   void                set_decrypt(const RC4& decrypt)   { m_decrypt = decrypt; m_decryptValid = true; }
 
 private:
-  bool                m_encrypted;
-  bool                m_obfuscated;
-  bool                m_decryptValid;
+  bool                m_encrypted{false};
+  bool                m_obfuscated{false};
+  bool                m_decryptValid{false};
 
   RC4                 m_encrypt;
   RC4                 m_decrypt;

--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -121,17 +121,19 @@ private:
 
   uint32_t            m_maxQueueLength;
 
-  int                 m_flags;
-  PeerInfo*           m_peerInfo;
-  DownloadMain*       m_download;
-  PeerConnectionBase* m_connection;
+  // Set HANDSHAKE as enabled and supported. Those bits should not be
+  // touched.
+  int                 m_flags{flag_local_enabled_base | flag_remote_supported_base | flag_initial_handshake};
+  PeerInfo*           m_peerInfo{};
+  DownloadMain*       m_download{};
+  PeerConnectionBase* m_connection{};
 
-  uint8_t             m_readType;
+  uint8_t             m_readType{FIRST_INVALID};
   uint32_t            m_readLeft;
-  char*               m_read;
+  char*               m_read{};
   char*               m_readPos;
 
-  MessageType         m_pendingType;
+  MessageType         m_pendingType{HANDSHAKE};
   DataBuffer          m_pending;
 };
 
@@ -167,17 +169,8 @@ typedef static_map_type<ext_metadata_keys, key_metadata_LAST> ExtMetadataMessage
 //
 
 inline
-ProtocolExtension::ProtocolExtension() :
-  // Set HANDSHAKE as enabled and supported. Those bits should not be
-  // touched.
-  m_flags(flag_local_enabled_base | flag_remote_supported_base | flag_initial_handshake),
-  m_peerInfo(NULL),
-  m_download(NULL),
-  m_connection(NULL),
-  m_readType(FIRST_INVALID),
-  m_read(NULL),
-  m_pendingType(HANDSHAKE) {
-
+ProtocolExtension::ProtocolExtension()
+{
   reset();
   set_local_enabled(UT_METADATA);
 }

--- a/src/protocol/handshake_encryption.h
+++ b/src/protocol/handshake_encryption.h
@@ -66,12 +66,8 @@ public:
   static const unsigned int  vc_length = 8;
 
   HandshakeEncryption(int options) :
-    m_key(NULL),
-    m_options(options),
-    m_crypto(0),
-    m_retry(RETRY_NONE),
-    m_syncLength(0),
-    m_lengthIA(0) {}
+    m_options(options)
+    {}
 
   bool                has_crypto_plain() const                     { return m_crypto & crypto_plain; }
   bool                has_crypto_rc4() const                       { return m_crypto & crypto_rc4; }
@@ -113,20 +109,20 @@ public:
   static bool         compare_vc(const void* buf);
 
 private:
-  DiffieHellman*      m_key;
+  DiffieHellman*      m_key{};
 
   // A pointer instead?
   EncryptionInfo      m_info;
 
   int                 m_options;
-  int                 m_crypto;
+  int                 m_crypto{0};
 
-  Retry               m_retry;
+  Retry               m_retry{RETRY_NONE};
 
   char                m_sync[20];
-  unsigned int        m_syncLength;
+  unsigned int        m_syncLength{0};
 
-  unsigned int        m_lengthIA;
+  unsigned int        m_lengthIA{0};
 };
 
 }

--- a/src/protocol/peer_chunks.h
+++ b/src/protocol/peer_chunks.h
@@ -54,8 +54,6 @@ class PeerChunks {
 public:
   typedef std::list<Piece>    piece_list_type;
 
-  PeerChunks();
-
   bool                is_seeder() const             { return m_bitfield.is_all_set(); }
 
   PeerInfo*           peer_info()                   { return m_peerInfo; }
@@ -88,9 +86,9 @@ public:
   const ThrottleNode* upload_throttle() const       { return &m_uploadThrottle; }
 
 private:
-  PeerInfo*           m_peerInfo;
+  PeerInfo*           m_peerInfo{};
 
-  bool                m_usingCounter;
+  bool                m_usingCounter{false};
 
   Bitfield            m_bitfield;
 
@@ -101,24 +99,11 @@ private:
 
   rak::timer          m_haveTimer;
 
-  Rate                m_peerRate;
+  Rate                m_peerRate{600};
 
-  ThrottleNode        m_downloadThrottle;
-  ThrottleNode        m_uploadThrottle;
+  ThrottleNode        m_downloadThrottle{30};
+  ThrottleNode        m_uploadThrottle{30};
 };
-
-inline
-PeerChunks::PeerChunks() :
-  m_peerInfo(NULL),
-
-  m_usingCounter(false),
-
-  m_peerRate(600),
-
-  m_downloadThrottle(30),
-  m_uploadThrottle(30)
-{
-}
 
 }
 

--- a/src/protocol/protocol_base.h
+++ b/src/protocol/protocol_base.h
@@ -81,11 +81,8 @@ public:
     INTERNAL_ERROR
   } State;
 
-  ProtocolBase() :
-    m_state(IDLE),
-    m_lastCommand(NONE),
-    m_throttle(NULL) {
-
+  ProtocolBase()
+  {
     m_buffer.reset();
   }
 
@@ -155,9 +152,9 @@ public:
 
 
 protected:
-  State               m_state;
-  Protocol            m_lastCommand;
-  ThrottleList*       m_throttle;
+  State               m_state{IDLE};
+  Protocol            m_lastCommand{NONE};
+  ThrottleList*       m_throttle{};
 
   Buffer              m_buffer;
 };

--- a/src/protocol/request_list.h
+++ b/src/protocol/request_list.h
@@ -131,30 +131,26 @@ private:
   void                 prepare_process_unordered(queues_type::iterator itr);
   void                 delay_process_unordered();
 
-  Delegator*           m_delegator;
-  PeerChunks*          m_peerChunks;
+  Delegator*           m_delegator{};
+  PeerChunks*          m_peerChunks{};
 
-  BlockTransfer*       m_transfer;
+  BlockTransfer*       m_transfer{};
 
   queues_type          m_queues;
 
-  int32_t              m_affinity;
+  int32_t              m_affinity{-1};
 
   rak::timer           m_last_choke;
   rak::timer           m_last_unchoke;
-  size_t               m_last_unordered_position;
+  size_t               m_last_unordered_position{0};
 
   rak::priority_item   m_delay_remove_choked;
   rak::priority_item   m_delay_process_unordered;
 };
 
 inline
-RequestList::RequestList() :
-  m_delegator(NULL),
-  m_peerChunks(NULL),
-  m_transfer(NULL),
-  m_affinity(-1),
-  m_last_unordered_position(0) {
+RequestList::RequestList()
+{
   m_delay_remove_choked.slot() = std::bind(&RequestList::delay_remove_choked, this);
   m_delay_process_unordered.slot() = std::bind(&RequestList::delay_process_unordered, this);
 }

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -25,7 +25,7 @@ public:
     STATE_INVALID
   } state_type;
 
-  Block();
+  Block() = default;
   ~Block();
 
   // Only allow move constructions
@@ -105,23 +105,16 @@ private:
   BlockList*                m_parent;
   Piece                     m_piece;
 
-  state_type                m_state;
-  uint32_t                  m_notStalled;
+  state_type                m_state{STATE_INCOMPLETE};
+  uint32_t                  m_notStalled{0};
 
   transfer_list_type        m_queued;
   transfer_list_type        m_transfers;
 
-  BlockTransfer*            m_leader;
+  BlockTransfer*            m_leader{};
 
-  BlockFailed*              m_failedList;
+  BlockFailed*              m_failedList{};
 };
-
-inline
-Block::Block() :
-  m_state(STATE_INCOMPLETE),
-  m_notStalled(0),
-  m_leader(NULL),
-  m_failedList(NULL) { }
 
 inline BlockTransfer*
 Block::find(const PeerInfo* p) {

--- a/src/torrent/data/block_failed.h
+++ b/src/torrent/data/block_failed.h
@@ -67,7 +67,7 @@ public:
 
   static const uint32_t invalid_index = ~uint32_t();
 
-  BlockFailed() : m_current(invalid_index) {}
+  BlockFailed() = default;
   ~BlockFailed();
   BlockFailed(const BlockFailed&) = delete;
   BlockFailed& operator=(const BlockFailed&) = delete;
@@ -87,7 +87,7 @@ private:
   static void         delete_entry(value_type e)                    { delete [] e.first; }
   static bool         compare_entries(value_type e1, value_type e2) { return e1.second < e2.second; }
 
-  size_type           m_current;
+  size_type           m_current{invalid_index};
 };
 
 inline

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -23,7 +23,7 @@ public:
     STATE_NOT_LEADER
   } state_type;
 
-  BlockTransfer();
+  BlockTransfer() = default;
   ~BlockTransfer();
   BlockTransfer(const BlockTransfer&) = delete;
   BlockTransfer& operator=(const BlockTransfer&) = delete;
@@ -68,8 +68,8 @@ public:
   void                set_failed_index(uint32_t i)  { m_failedIndex = i; }
 
 private:
-  key_type            m_peer_info;
-  Block*              m_block;
+  key_type            m_peer_info{};
+  Block*              m_block{};
   Piece               m_piece;
 
   state_type          m_state;
@@ -79,13 +79,6 @@ private:
   uint32_t            m_stall;
   uint32_t            m_failedIndex;
 };
-
-inline
-BlockTransfer::BlockTransfer() :
-  m_peer_info(NULL),
-  m_block(NULL)
-{
-}
 
 inline
 BlockTransfer::~BlockTransfer() {

--- a/src/torrent/data/download_data.h
+++ b/src/torrent/data/download_data.h
@@ -25,7 +25,6 @@ public:
 
   typedef void (function_chunk_list_node_p)(ChunkListNode *); 
   typedef std::function<function_chunk_list_node_p> slot_chunk_list_node_p;
-  download_data() : m_wanted_chunks(0) {}
 
   const HashString&      hash() const                  { return m_hash; }
 
@@ -80,7 +79,7 @@ private:
   priority_ranges        m_high_priority;
   priority_ranges        m_normal_priority;
 
-  uint32_t               m_wanted_chunks;
+  uint32_t               m_wanted_chunks{0};
 
   mutable slot_void      m_slot_initial_hash;
   mutable slot_void      m_slot_download_done;

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -107,11 +107,8 @@ public:
   };
 
   choke_queue(int flags = 0) :
-    m_flags(flags),
-    m_heuristics(HEURISTICS_MAX_SIZE),
-    m_maxUnchoked(unlimited),
-    m_currently_queued(0),
-    m_currently_unchoked(0) {}
+    m_flags(flags)
+    {}
   ~choke_queue();
   
   bool                is_full() const                         { return !is_unlimited() && size_unchoked() >= m_maxUnchoked; }
@@ -169,12 +166,12 @@ private:
   static heuristics_type m_heuristics_list[HEURISTICS_MAX_SIZE];
 
   int                 m_flags;
-  heuristics_enum     m_heuristics;
+  heuristics_enum     m_heuristics{HEURISTICS_MAX_SIZE};
 
-  uint32_t            m_maxUnchoked;
+  uint32_t            m_maxUnchoked{unlimited};
 
-  uint32_t            m_currently_queued;
-  uint32_t            m_currently_unchoked;
+  uint32_t            m_currently_queued{0};
+  uint32_t            m_currently_unchoked{0};
 
   slot_unchoke        m_slotUnchoke;
   slot_can_unchoke    m_slotCanUnchoke;

--- a/src/torrent/download/group_entry.h
+++ b/src/torrent/download/group_entry.h
@@ -66,8 +66,6 @@ public:
 
   static const uint32_t unlimited = ~uint32_t();
 
-  group_entry() : m_max_slots(unlimited), m_min_slots(0) {}
-
   uint32_t            size_connections() const  { return m_queued.size() + m_unchoked.size(); }
 
   uint32_t            max_slots() const         { return m_max_slots; }
@@ -93,8 +91,8 @@ protected:
   void                connection_unqueued(PeerConnectionBase* pcb);
 
 private:
-  uint32_t            m_max_slots;
-  uint32_t            m_min_slots;
+  uint32_t            m_max_slots{unlimited};
+  uint32_t            m_min_slots{0};
 
   // After a cycle the end of the vector should have the
   // highest-priority connections, and any new connections get put at

--- a/src/torrent/event.h
+++ b/src/torrent/event.h
@@ -7,8 +7,7 @@ namespace torrent {
 
 class LIBTORRENT_EXPORT Event {
 public:
-  Event();
-  virtual ~Event();
+  virtual ~Event() = default;
 
   // TODO: Disable override.
   bool is_open() const;
@@ -26,14 +25,12 @@ protected:
   void close_file_descriptor();
   void set_file_descriptor(int fd);
 
-  int  m_fileDesc;
+  int  m_fileDesc{-1};
 
   // TODO: Deprecate.
-  bool m_ipv6_socket;
+  bool m_ipv6_socket{false};
 };
 
-inline Event::Event() : m_fileDesc(-1), m_ipv6_socket(false) {}
-inline Event::~Event() = default;
 inline bool Event::is_open() const { return file_descriptor() != -1; }
 inline int  Event::file_descriptor() const { return m_fileDesc; }
 inline void Event::set_file_descriptor(int fd) { m_fileDesc = fd; }

--- a/src/torrent/peer/choke_status.h
+++ b/src/torrent/peer/choke_status.h
@@ -45,14 +45,6 @@ class group_entry;
 
 class choke_status {
 public:
-  choke_status() :
-    m_group_entry(NULL),
-
-    m_queued(false),
-    m_unchoked(false),
-    m_snubbed(false),
-    m_timeLastChoke(0) {}
-
   group_entry*        entry() const                           { return m_group_entry; }
   void                set_entry(group_entry* grp_ent)         { m_group_entry = grp_ent; }
 
@@ -71,13 +63,13 @@ public:
 
 private:
   // TODO: Use flags.
-  group_entry*        m_group_entry;
+  group_entry*        m_group_entry{};
 
-  bool                m_queued;
-  bool                m_unchoked;
-  bool                m_snubbed;
+  bool                m_queued{false};
+  bool                m_unchoked{false};
+  bool                m_snubbed{false};
 
-  int64_t             m_timeLastChoke;
+  int64_t             m_timeLastChoke{0};
 };
 
 }

--- a/src/torrent/poll.h
+++ b/src/torrent/poll.h
@@ -51,7 +51,6 @@ public:
   static const int      poll_worker_thread     = 0x1;
   static const uint32_t flag_waive_global_lock = 0x1;
 
-  Poll() : m_flags(0) {}
   virtual ~Poll() = default;
 
   uint32_t            flags() const { return m_flags; }
@@ -96,7 +95,7 @@ public:
 private:
   static slot_poll    m_slot_create_poll;
 
-  uint32_t            m_flags;
+  uint32_t            m_flags{0};
 };
 
 }

--- a/src/torrent/rate.h
+++ b/src/torrent/rate.h
@@ -55,7 +55,7 @@ public:
   typedef std::pair<timer_type, rate_type> value_type;
   typedef std::deque<value_type>           queue_type;
 
-  Rate(timer_type span) : m_current(0), m_total(0), m_span(span) {}
+  Rate(timer_type span) :  m_span(span) {}
 
   // Bytes per second.
   rate_type           rate() const;
@@ -87,8 +87,8 @@ private:
 
   mutable queue_type  m_container;
 
-  mutable rate_type   m_current;
-  total_type          m_total;
+  mutable rate_type   m_current{0};
+  total_type          m_total{0};
   timer_type          m_span;
 };
 

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -159,7 +159,7 @@ class LIBTORRENT_EXPORT log_group {
 public:
   typedef std::bitset<64> outputs_type;
 
-  log_group() : m_first(NULL), m_last(NULL) {
+  log_group() {
     m_outputs.reset();
     m_cached_outputs.reset();
   }
@@ -195,8 +195,8 @@ private:
   outputs_type        m_outputs;
   outputs_type        m_cached_outputs;
 
-  log_slot*           m_first;
-  log_slot*           m_last;
+  log_slot*           m_first{};
+  log_slot*           m_last{};
 };
 
 typedef std::array<log_group, LOG_GROUP_MAX_SIZE> log_group_list;

--- a/src/torrent/utils/signal_bitfield.h
+++ b/src/torrent/utils/signal_bitfield.h
@@ -18,8 +18,6 @@ public:
 
   static const unsigned int max_size = 32;
 
-  signal_bitfield() : m_thread_id(std::this_thread::get_id()), m_size(0), m_bitfield(0) {}
-
   unsigned int  add_signal(const slot_type& slot);
   bool          has_signal(unsigned int index) const { return m_bitfield & (1 << index); }
 
@@ -29,11 +27,11 @@ public:
   void          handover(std::thread::id thread_id) { m_thread_id = thread_id; }
 
 private:
-  std::thread::id m_thread_id;
-  unsigned int    m_size;
+  std::thread::id m_thread_id{std::this_thread::get_id()};
+  unsigned int    m_size{0};
   slot_type       m_slots[max_size];
 
-  std::atomic<bitfield_type> m_bitfield;
+  std::atomic<bitfield_type> m_bitfield{};
 };
 
 }


### PR DESCRIPTION
Do so in headers only.