### PR TITLE
0.15.2: Missing header <algorithm>

### DIFF
--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <errno.h>
 #include <unistd.h>
+#include <algorithm>
 
 #ifdef HAVE_INOTIFY
 #include <sys/inotify.h>


### PR DESCRIPTION
std=c++17 error :

>utils/directory_events.cc:118:40: error: no member named 'find_if' in namespace 'std'; did you mean '__find_if'?
>  118 |     wd_list::const_iterator itr = std::find_if(m_wd_list.begin(), m_wd_list.end(),
>      |                                   ~~~~~^~~~~~~
>      |                                        __find_if