### PR TITLE
directory_events.cc: add missing <algorithm> include

### DIFF
--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -6,6 +6,8 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <algorithm>
+
 #ifdef HAVE_INOTIFY
 #include <sys/inotify.h>
 #endif


### PR DESCRIPTION
This should address the compile problem mentioned in https://github.com/rakshasa/rtorrent/issues/1408#issuecomment-2764311334 (though not the original issue of that bug).