### PR TITLE
Remove register (C++17)

### DIFF
--- a/src/utils/sha_fast.cc
+++ b/src/utils/sha_fast.cc
@@ -102,8 +102,8 @@ SHA1_Begin(SHA1Context *ctx)
 void 
 SHA1_Update(SHA1Context *ctx, const unsigned char *dataIn, unsigned int len) 
 {
-  register unsigned int lenB = ctx->sizeLo & 63;
-  register unsigned int togo;
+  unsigned int lenB = ctx->sizeLo & 63;
+  unsigned int togo;
 
   if (!len)
     return;
@@ -146,7 +146,7 @@ void
 SHA1_End(SHA1Context *ctx, unsigned char *hashout,
          unsigned int *pDigestLen, unsigned int maxDigestLen)
 {
-  register uint32_t sizeHi, sizeLo, lenB;
+  uint32_t sizeHi, sizeLo, lenB;
   static const unsigned char bulk_pad[64] = { 0x80,0,0,0,0,0,0,0,0,0,
           0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
           0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0  };
@@ -198,7 +198,7 @@ SHA1_End(SHA1Context *ctx, unsigned char *hashout,
 static void 
 shaCompress(SHA1Context *ctx) 
 {
-  register uint32_t A, B, C, D, E;
+  uint32_t A, B, C, D, E;
 
 #if defined(IS_LITTLE_ENDIAN)
   SHA_BYTESWAP(ctx->W[0]);


### PR DESCRIPTION
This error occurs only with clang.

> libtool: compile:  clang++ -std=c++17 -DHAVE_CONFIG_H -I. -I.. -I. -I.. -pthread -O2 -pipe -frecord-gcc-switches -DNDEBUG -> Wall -isysroot / -fvisibility=hidden -c utils/sha_fast.cc  -fPIC -DPIC -o utils/.libs/sha_fast.o utils/sha_fast.cc:105:3: error: ISO C+
> +17 does not allow 'register' storage class specifier [-Wregister]
>  105 |   register unsigned int lenB = ctx->sizeLo & 63;
>       |   ^~~~~~~~
> utils/sha_fast.cc:106:3: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
>  106 |   register unsigned int togo;
>      |   ^~~~~~~~
> utils/sha_fast.cc:149:3: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
> 149 |   register uint32_t sizeHi, sizeLo, lenB;