### PR TITLE
clang-tidy: use default member init

### DIFF
--- a/src/torrent/chunk_manager.cc
+++ b/src/torrent/chunk_manager.cc
@@ -49,23 +49,7 @@
 
 namespace torrent {
 
-ChunkManager::ChunkManager() :
-  m_memoryUsage(0),
-  m_memoryBlockCount(0),
-
-  m_safeSync(false),
-  m_timeoutSync(600),
-  m_timeoutSafeSync(900),
-
-  m_preloadType(0),
-  m_preloadMinSize(256 << 10),
-  m_preloadRequiredRate(5 << 10),
-
-  m_statsPreloaded(0),
-  m_statsNotPreloaded(0),
-
-  m_timerStarved(0),
-  m_lastFreed(0) {
+ChunkManager::ChunkManager() {
 
   // 1/5 of the available memory should be enough for the client. If
   // the client really requires alot more memory it should call this

--- a/src/torrent/chunk_manager.h
+++ b/src/torrent/chunk_manager.h
@@ -110,24 +110,24 @@ private:
 
   void                sync_all(int flags, uint64_t target) LIBTORRENT_NO_EXPORT;
 
-  uint64_t            m_memoryUsage;
+  uint64_t            m_memoryUsage{0};
   uint64_t            m_maxMemoryUsage;
 
-  uint32_t            m_memoryBlockCount;
+  uint32_t            m_memoryBlockCount{0};
 
-  bool                m_safeSync;
-  uint32_t            m_timeoutSync;
-  uint32_t            m_timeoutSafeSync;
+  bool                m_safeSync{false};
+  uint32_t            m_timeoutSync{600};
+  uint32_t            m_timeoutSafeSync{900};
 
-  uint32_t            m_preloadType;
-  uint32_t            m_preloadMinSize;
-  uint32_t            m_preloadRequiredRate;
+  uint32_t            m_preloadType{0};
+  uint32_t            m_preloadMinSize{256 << 10};
+  uint32_t            m_preloadRequiredRate{5 << 10};
 
-  uint32_t            m_statsPreloaded;
-  uint32_t            m_statsNotPreloaded;
+  uint32_t            m_statsPreloaded{0};
+  uint32_t            m_statsNotPreloaded{0};
 
-  int32_t             m_timerStarved;
-  size_type           m_lastFreed;
+  int32_t             m_timerStarved{0};
+  size_type           m_lastFreed{0};
 };
 
 }

--- a/src/torrent/connection_manager.cc
+++ b/src/torrent/connection_manager.cc
@@ -13,21 +13,7 @@
 namespace torrent {
 
 ConnectionManager::ConnectionManager() :
-  m_size(0),
-  m_maxSize(0),
-
-  m_priority(iptos_throughput),
-  m_sendBufferSize(0),
-  m_receiveBufferSize(0),
-  m_encryptionOptions(encryption_none),
-
-  m_listen(new Listen),
-  m_listen_port(0),
-  m_listen_backlog(SOMAXCONN),
-
-  m_block_ipv4(false),
-  m_block_ipv6(false),
-  m_prefer_ipv6(false) {
+    m_listen(new Listen) {
 
   m_bindAddress = (new rak::socket_address())->c_sockaddr();
   m_localAddress = (new rak::socket_address())->c_sockaddr();

--- a/src/torrent/connection_manager.h
+++ b/src/torrent/connection_manager.h
@@ -131,28 +131,28 @@ public:
   void                set_prefer_ipv6(bool v) { m_prefer_ipv6 = v; }
 
 private:
-  size_type           m_size;
-  size_type           m_maxSize;
+  size_type           m_size{0};
+  size_type           m_maxSize{0};
 
-  priority_type       m_priority;
-  uint32_t            m_sendBufferSize;
-  uint32_t            m_receiveBufferSize;
-  int                 m_encryptionOptions;
+  priority_type       m_priority{iptos_throughput};
+  uint32_t            m_sendBufferSize{0};
+  uint32_t            m_receiveBufferSize{0};
+  int                 m_encryptionOptions{encryption_none};
 
   sockaddr*           m_bindAddress;
   sockaddr*           m_localAddress;
   sockaddr*           m_proxyAddress;
 
   Listen*             m_listen;
-  port_type           m_listen_port;
-  uint32_t            m_listen_backlog;
+  port_type           m_listen_port{0};
+  uint32_t            m_listen_backlog{SOMAXCONN};
 
   slot_filter_type    m_slot_filter;
   slot_throttle_type  m_slot_address_throttle;
 
-  bool                m_block_ipv4;
-  bool                m_block_ipv6;
-  bool                m_prefer_ipv6;
+  bool                m_block_ipv4{false};
+  bool                m_block_ipv6{false};
+  bool                m_prefer_ipv6{false};
 };
 
 }

--- a/src/torrent/data/block_list.cc
+++ b/src/torrent/data/block_list.cc
@@ -46,14 +46,9 @@
 namespace torrent {
 
 BlockList::BlockList(const Piece& piece, uint32_t blockLength) :
-  m_piece(piece),
-  m_priority(PRIORITY_OFF),
-  m_finished(0),
+    m_piece(piece)
 
-  m_failed(0),
-  m_attempt(0),
-
-  m_bySeeder(false) {
+{
 
   if (piece.length() == 0)
     throw internal_error("BlockList::BlockList(...) received zero length piece.");

--- a/src/torrent/data/block_list.h
+++ b/src/torrent/data/block_list.h
@@ -64,13 +64,13 @@ public:
 
 private:
   Piece               m_piece;
-  priority_t          m_priority;
+  priority_t          m_priority{PRIORITY_OFF};
 
-  size_type           m_finished;
-  uint32_t            m_failed;
-  uint32_t            m_attempt;
+  size_type           m_finished{0};
+  uint32_t            m_failed{0};
+  uint32_t            m_attempt{0};
 
-  bool                m_bySeeder;
+  bool                m_bySeeder{false};
 };
 
 }

--- a/src/torrent/data/transfer_list.cc
+++ b/src/torrent/data/transfer_list.cc
@@ -54,10 +54,6 @@
 
 namespace torrent {
 
-TransferList::TransferList() :
-  m_succeededCount(0),
-  m_failedCount(0) { }
-
 // TODO: Derp if transfer list isn't cleared...
 
 TransferList::~TransferList() {

--- a/src/torrent/data/transfer_list.h
+++ b/src/torrent/data/transfer_list.h
@@ -28,7 +28,7 @@ public:
   using base_type::rbegin;
   using base_type::rend;
 
-  TransferList();
+  TransferList() = default;
   ~TransferList();
   TransferList(const TransferList&) = delete;
   TransferList& operator=(const TransferList&) = delete;
@@ -76,8 +76,8 @@ private:
 
   completed_list_type m_completedList;
 
-  uint32_t            m_succeededCount;
-  uint32_t            m_failedCount;
+  uint32_t            m_succeededCount{0};
+  uint32_t            m_failedCount{0};
 };
 
 }

--- a/src/torrent/download/choke_group.cc
+++ b/src/torrent/download/choke_group.cc
@@ -8,11 +8,6 @@
 
 namespace torrent {
 
-choke_group::choke_group() :
-    m_tracker_mode(TRACKER_MODE_NORMAL),
-    m_down_queue(choke_queue::flag_unchoke_all_new),
-    m_first(nullptr), m_last(nullptr) {}
-
 uint64_t
 choke_group::up_rate() const {
   return std::accumulate(m_first, m_last, (uint64_t)0, [](uint64_t i, auto r) { return i + r.up_rate()->rate(); });

--- a/src/torrent/download/choke_group.h
+++ b/src/torrent/download/choke_group.h
@@ -58,8 +58,6 @@ public:
     TRACKER_MODE_AGGRESSIVE
   };
 
-  choke_group();
-  
   const std::string&  name() const { return m_name; }
   void                set_name(const std::string& name) { m_name = name; }
 
@@ -97,13 +95,13 @@ public:
 
 private:
   std::string             m_name;
-  tracker_mode_enum       m_tracker_mode;
+  tracker_mode_enum       m_tracker_mode{TRACKER_MODE_NORMAL};
 
   choke_queue             m_up_queue;
-  choke_queue             m_down_queue;
+  choke_queue             m_down_queue{choke_queue::flag_unchoke_all_new};
 
-  resource_manager_entry* m_first;
-  resource_manager_entry* m_last;
+  resource_manager_entry* m_first{};
+  resource_manager_entry* m_last{};
 };
 
 }

--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -24,14 +24,6 @@ namespace torrent {
 const Rate* resource_manager_entry::up_rate() const { return m_download->info()->up_rate(); }
 const Rate* resource_manager_entry::down_rate() const { return m_download->info()->down_rate(); }
 
-ResourceManager::ResourceManager() :
-  m_currentlyUploadUnchoked(0),
-  m_currentlyDownloadUnchoked(0),
-  m_maxUploadUnchoked(0),
-  m_maxDownloadUnchoked(0)
-{
-}
-
 ResourceManager::~ResourceManager() {
   if (m_currentlyUploadUnchoked != 0)
     throw internal_error("ResourceManager::~ResourceManager() called but m_currentlyUploadUnchoked != 0.");

--- a/src/torrent/download/resource_manager.h
+++ b/src/torrent/download/resource_manager.h
@@ -102,7 +102,7 @@ public:
   using base_type::size;
   using base_type::capacity;
 
-  ResourceManager();
+  ResourceManager() = default;
   ~ResourceManager();
 
   void                insert(DownloadMain* d, uint16_t priority) { insert(value_type(d, priority)); }
@@ -159,11 +159,11 @@ private:
 
   int                 balance_unchoked(unsigned int weight, unsigned int max_unchoked, bool is_up);
 
-  unsigned int        m_currentlyUploadUnchoked;
-  unsigned int        m_currentlyDownloadUnchoked;
+  unsigned int        m_currentlyUploadUnchoked{0};
+  unsigned int        m_currentlyDownloadUnchoked{0};
 
-  unsigned int        m_maxUploadUnchoked;
-  unsigned int        m_maxDownloadUnchoked;
+  unsigned int        m_maxUploadUnchoked{0};
+  unsigned int        m_maxDownloadUnchoked{0};
 };
 
 }

--- a/src/torrent/peer/connection_list.cc
+++ b/src/torrent/peer/connection_list.cc
@@ -30,7 +30,7 @@ const int ConnectionList::disconnect_unwanted;
 const int ConnectionList::disconnect_delayed;
 
 ConnectionList::ConnectionList(DownloadMain* download) :
-  m_download(download), m_minSize(50), m_maxSize(100) {
+    m_download(download) {
 }
 
 void

--- a/src/torrent/peer/connection_list.h
+++ b/src/torrent/peer/connection_list.h
@@ -147,8 +147,8 @@ protected:
 private:
   DownloadMain*       m_download;
 
-  size_type           m_minSize;
-  size_type           m_maxSize;
+  size_type           m_minSize{50};
+  size_type           m_maxSize{100};
 
   signal_peer_type    m_signalConnected;
   signal_peer_type    m_signalDisconnected;

--- a/src/torrent/peer/peer_info.cc
+++ b/src/torrent/peer/peer_info.cc
@@ -51,17 +51,7 @@ namespace torrent {
 // Move this to peer_info.cc when these are made into the public API.
 //
 // TODO: Use a safer socket address parameter.
-PeerInfo::PeerInfo(const sockaddr* address) : 
-  m_flags(0),
-
-  m_failedCounter(0),
-  m_transferCounter(0),
-  m_lastConnection(0),
-  m_lastHandshake(0),
-  m_listenPort(0),
-
-  m_connection(NULL)
-{
+PeerInfo::PeerInfo(const sockaddr* address) {
   rak::socket_address* sa = new rak::socket_address();
   *sa = *rak::socket_address::cast_from(address);
 

--- a/src/torrent/peer/peer_info.h
+++ b/src/torrent/peer/peer_info.h
@@ -126,7 +126,7 @@ protected:
 
 private:
   // Replace id with a char buffer, or a cheap struct?
-  int                 m_flags;
+  int                 m_flags{0};
   HashString          m_id;
   char                m_id_hex[40];
 
@@ -134,18 +134,18 @@ private:
 
   char                m_options[8];
 
-  uint32_t            m_failedCounter;
-  uint32_t            m_transferCounter;
-  uint32_t            m_lastConnection;
-  uint32_t            m_lastHandshake;
+  uint32_t            m_failedCounter{0};
+  uint32_t            m_transferCounter{0};
+  uint32_t            m_lastConnection{0};
+  uint32_t            m_lastHandshake{0};
 
-  uint16_t            m_listenPort;
+  uint16_t            m_listenPort{0};
 
   // Replace this with a union. Since the user never copies PeerInfo
   // it should be safe to not require sockaddr_in6 to be part of it.
   sockaddr*           m_address;
 
-  PeerConnectionBase* m_connection;
+  PeerConnectionBase* m_connection{};
 };
 
 inline void

--- a/src/torrent/poll_epoll.cc
+++ b/src/torrent/poll_epoll.cc
@@ -90,10 +90,9 @@ PollEPoll::create(int maxOpenSockets) {
 }
 
 PollEPoll::PollEPoll(int fd, int max_events, int max_open_sockets) :
-  m_fd(fd),
-  m_maxEvents(max_events),
-  m_waitingEvents(0),
-  m_events(new epoll_event[m_maxEvents]) {
+    m_fd(fd),
+    m_maxEvents(max_events),
+    m_events(new epoll_event[m_maxEvents]) {
 
   try {
     m_table.resize(max_open_sockets);

--- a/src/torrent/poll_epoll.h
+++ b/src/torrent/poll_epoll.h
@@ -94,7 +94,7 @@ private:
   int                 m_fd;
 
   int                 m_maxEvents;
-  int                 m_waitingEvents;
+  int                 m_waitingEvents{0};
 
   Table               m_table;
   epoll_event*        m_events;

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -48,9 +48,9 @@ TrackerController::current_send_event() const {
 }
 
 TrackerController::TrackerController(TrackerList* trackers) :
-  m_flags(0),
-  m_tracker_list(trackers),
-  m_private(new tracker_controller_private) {
+
+    m_tracker_list(trackers),
+    m_private(new tracker_controller_private) {
 
   m_private->task_timeout.slot() = [this] { do_timeout(); };
   m_private->task_scrape.slot()  = [this] { do_scrape(); };

--- a/src/torrent/tracker_controller.h
+++ b/src/torrent/tracker_controller.h
@@ -106,7 +106,7 @@ private:
 
   inline tracker::TrackerState::event_enum current_send_event() const;
 
-  int                 m_flags;
+  int                 m_flags{0};
   TrackerList*        m_tracker_list;
 
   slot_void           m_slot_timeout;


### PR DESCRIPTION
Found with modernize-use-default-member-init