### PR TITLE
clang-tidy: fix special-member-functions warnings

### DIFF
--- a/src/data/chunk_list.h
+++ b/src/data/chunk_list.h
@@ -55,6 +55,7 @@ public:
 
   static const int flag_active       = (1 << 0);
 
+  ChunkList() = default;
   ~ChunkList() { clear(); }
 
   int                 flags() const                       { return m_flags; }
@@ -96,6 +97,9 @@ public:
   chunk_address_result find_address(void* ptr);
 
 private:
+  ChunkList(const ChunkList&) = delete;
+  ChunkList& operator=(const ChunkList&) = delete;
+
   inline bool         is_queued(ChunkListNode* node);
 
   inline void         clear_chunk(ChunkListNode* node, int flags = 0);

--- a/src/data/memory_chunk.h
+++ b/src/data/memory_chunk.h
@@ -37,8 +37,10 @@ class MemoryChunk {
   static const int sync_async             = MS_ASYNC;
   static const int sync_invalidate        = MS_INVALIDATE;
 
-  MemoryChunk() { clear(); }
+  MemoryChunk() = default;
   ~MemoryChunk() { clear(); }
+  MemoryChunk(const MemoryChunk&) = default;
+  MemoryChunk& operator=(const MemoryChunk&) = default;
 
   // Doesn't allow ptr == NULL, use the default ctor instead.
   MemoryChunk(char* ptr, char* begin, char* end, int prot, int flags);
@@ -85,12 +87,12 @@ private:
 
   static uint32_t     m_pagesize;
 
-  char*               m_ptr;
-  char*               m_begin;
-  char*               m_end;
+  char*               m_ptr{};
+  char*               m_begin{};
+  char*               m_end{};
 
   int                 m_prot;
-  int                 m_flags;
+  int                 m_flags{PROT_NONE};
 };
 
 inline bool

--- a/src/data/socket_file.h
+++ b/src/data/socket_file.h
@@ -24,9 +24,8 @@ public:
   static const int flag_fallocate_blocking = (1 << 1);
 
   SocketFile() = default;
+  ~SocketFile() = default;
   SocketFile(fd_type fd) : m_fd(fd) {}
-  SocketFile(const SocketFile&) = delete;
-  SocketFile& operator=(const SocketFile&) = delete;
 
   bool                is_open() const                                   { return m_fd != invalid_fd; }
 
@@ -44,6 +43,9 @@ public:
   fd_type             fd() const                                        { return m_fd; }
 
 private:
+  SocketFile(const SocketFile&) = delete;
+  SocketFile& operator=(const SocketFile&) = delete;
+
   // Use custom flags if stuff like file locking etc is implemented.
   fd_type             m_fd{invalid_fd};
 };

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -100,8 +100,6 @@ public:
 
   DhtSearch(const HashString& target, const DhtBucket& contacts);
   virtual ~DhtSearch();
-  DhtSearch(const DhtSearch&) = delete;
-  DhtSearch& operator=(const DhtSearch&) = delete;
 
   // Wrapper for iterators, allowing more convenient access to the key
   // and element values, which also makes it easier to change the container
@@ -163,6 +161,9 @@ protected:
   const_accessor       m_next;
 
 private:
+  DhtSearch(const DhtSearch&) = delete;
+  DhtSearch& operator=(const DhtSearch&) = delete;
+
   bool                 node_uncontacted(const DhtNode* node) const;
 
   HashString           m_target;
@@ -263,6 +264,9 @@ public:
   DhtTransaction*             transaction()             { return m_transaction; }
 
 private:
+  DhtTransactionPacket(const DhtTransactionPacket&) = delete;
+  DhtTransactionPacket& operator=(const DhtTransactionPacket&) = delete;
+
   void                        build_buffer(const DhtMessage& data);
 
   rak::socket_address   m_sa;
@@ -278,8 +282,6 @@ private:
 class DhtTransaction {
 public:
   virtual ~DhtTransaction();
-  DhtTransaction(const DhtTransaction&) = delete;
-  DhtTransaction& operator=(const DhtTransaction&) = delete;
 
   typedef enum {
     DHT_PING,
@@ -325,6 +327,9 @@ protected:
   bool                   m_hasQuickTimeout;
 
 private:
+  DhtTransaction(const DhtTransaction&) = delete;
+  DhtTransaction& operator=(const DhtTransaction&) = delete;
+
   rak::socket_address    m_sa;
   int                    m_timeout;
   int                    m_quickTimeout;

--- a/src/net/throttle_node.h
+++ b/src/net/throttle_node.h
@@ -55,8 +55,7 @@ public:
   typedef std::function<void ()> slot_void;
 
   ThrottleNode(uint32_t rateSpan) : m_rate(rateSpan)  { clear_quota(); }
-  ThrottleNode(const ThrottleNode&) = delete;
-  ThrottleNode& operator=(const ThrottleNode&) = delete;
+  ~ThrottleNode() = default;
 
   Rate*               rate()                          { return &m_rate; }
   const Rate*         rate() const                    { return &m_rate; }
@@ -74,6 +73,9 @@ public:
   slot_void&          slot_activate()                 { return m_slot_activate; }
 
 private:
+  ThrottleNode(const ThrottleNode&) = delete;
+  ThrottleNode& operator=(const ThrottleNode&) = delete;
+
   uint32_t            m_quota;
   iterator            m_listIterator;
 

--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -47,6 +47,8 @@ public:
 
   ProtocolExtension();
   ~ProtocolExtension() { delete [] m_read; }
+  ProtocolExtension(const ProtocolExtension&) = default;
+  ProtocolExtension& operator=(const ProtocolExtension&) = default;
 
   void                cleanup();
 

--- a/src/protocol/handshake_manager.h
+++ b/src/protocol/handshake_manager.h
@@ -59,6 +59,9 @@ public:
   ProtocolExtension*  default_extensions() const                        { return &DefaultExtensions; }
 
 private:
+  HandshakeManager(const HandshakeManager&) = delete;
+  HandshakeManager& operator=(const HandshakeManager&) = delete;
+
   void                create_outgoing(const rak::socket_address& sa, DownloadMain* info, int encryptionOptions);
   void                erase(Handshake* handshake);
 

--- a/src/protocol/initial_seed.h
+++ b/src/protocol/initial_seed.h
@@ -61,6 +61,9 @@ public:
   bool                should_upload(uint32_t index);
 
 private:
+  InitialSeeding(const InitialSeeding&) = delete;
+  InitialSeeding& operator=(const InitialSeeding&) = delete;
+
   static PeerInfo* const chunk_unsent;  // Chunk never sent to anyone.
   static PeerInfo* const chunk_unknown; // Peer has chunk, we don't know who we sent it to.
   static PeerInfo* const chunk_done;    // Chunk properly distributed by peer.

--- a/src/protocol/peer_connection_leech.h
+++ b/src/protocol/peer_connection_leech.h
@@ -59,6 +59,7 @@ template<> struct PeerConnectionData<Download::CONNECTION_INITIAL_SEED> {
 template<Download::ConnectionType type>
 class PeerConnection : public PeerConnectionBase {
 public:
+  PeerConnection() = default;
   ~PeerConnection();
 
   virtual void        initialize_custom();
@@ -69,6 +70,9 @@ public:
   virtual void        event_write();
 
 private:
+  PeerConnection(const PeerConnection&) = delete;
+  PeerConnection& operator=(const PeerConnection&) = delete;
+
   inline bool         read_message();
   void                read_have_chunk(uint32_t index);
 

--- a/src/torrent/data/block.h
+++ b/src/torrent/data/block.h
@@ -29,10 +29,10 @@ public:
   ~Block();
 
   // Only allow move constructions
-  //Block(const Block&) = delete;
-  //Block& operator=(const Block&) = delete;
-  //Block(Block&&) = default;
-  //Block& operator=(Block&&) = default;
+  Block(const Block&) = delete;
+  Block& operator=(const Block&) = delete;
+  Block(Block&&) = default;
+  Block& operator=(Block&&) = default;
 
   bool                      is_stalled() const                           { return m_notStalled == 0; }
   bool                      is_finished() const                          { return m_leader != NULL && m_leader->is_finished(); }

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -153,6 +153,9 @@ public:
   void                modify_currently_unchoked(int value)     { m_currently_unchoked += value; }
 
 private:
+  choke_queue(const choke_queue&) = delete;
+  choke_queue& operator=(const choke_queue&) = delete;
+
   group_stats         prepare_weights(group_stats gs);
   group_stats         retrieve_connections(group_stats gs, container_type* queued, container_type* unchoked);
   void                rebuild_containers(container_type* queued, container_type* unchoked);

--- a/src/torrent/download/download_manager.h
+++ b/src/torrent/download/download_manager.h
@@ -37,7 +37,9 @@
 #ifndef LIBTORRENT_DOWNLOAD_MANAGER_H
 #define LIBTORRENT_DOWNLOAD_MANAGER_H
 
+#include <string>
 #include <vector>
+
 #include <torrent/common.h>
 
 namespace torrent {
@@ -71,7 +73,10 @@ public:
   using base_type::rbegin;
   using base_type::rend;
 
+  DownloadManager() = default;
   ~DownloadManager() { clear(); }
+  DownloadManager(const DownloadManager&) = default;
+  DownloadManager& operator=(const DownloadManager&) = default;
 
   iterator            find(const std::string& hash);
   iterator            find(const HashString& hash);

--- a/src/torrent/download/resource_manager.h
+++ b/src/torrent/download/resource_manager.h
@@ -150,6 +150,9 @@ public:
   void                receive_tick();
 
 private:
+  ResourceManager(const ResourceManager&) = delete;
+  ResourceManager& operator=(const ResourceManager&) = delete;
+
   iterator            insert(const resource_manager_entry& entry);
 
   void                update_group_iterators();

--- a/src/torrent/peer/client_list.h
+++ b/src/torrent/peer/client_list.h
@@ -63,6 +63,8 @@ public:
   
   ClientList();
   ~ClientList();
+  ClientList(const ClientList&) = delete;
+  ClientList& operator=(const ClientList&) = delete;
 
   iterator            insert(ClientInfo::id_type type, const char* key, const char* version, const char* upperVersion);
 

--- a/src/torrent/poll_epoll.h
+++ b/src/torrent/poll_epoll.h
@@ -85,6 +85,8 @@ public:
 
 private:
   PollEPoll(int fd, int maxEvents, int maxOpenSockets);
+  PollEPoll(const PollEPoll&) = delete;
+  PollEPoll& operator=(const PollEPoll&) = delete;
 
   inline uint32_t     event_mask(Event* e);
   inline void         set_event_mask(Event* e, uint32_t m);

--- a/src/torrent/poll_kqueue.h
+++ b/src/torrent/poll_kqueue.h
@@ -89,6 +89,8 @@ public:
 
 private:
   PollKQueue(int fd, int maxEvents, int maxOpenSockets) LIBTORRENT_NO_EXPORT;
+  PollKQueue(const PollKQueue&) = delete;
+  PollKQueue& operator=(const PollKQueue&) = delete;
 
   inline uint32_t     event_mask(Event* e) LIBTORRENT_NO_EXPORT;
   inline void         set_event_mask(Event* e, uint32_t m) LIBTORRENT_NO_EXPORT;

--- a/src/torrent/utils/extents.h
+++ b/src/torrent/utils/extents.h
@@ -15,11 +15,6 @@ public:
   typedef std::pair<Address, Value>                mapped_type;        // End address, value mapped to ip range
   typedef std::map<key_type, mapped_type, Compare> range_map_type;     // The map itself 
 
-  extents();
-  ~extents();
-  extents(const extents&) = default;
-  extents& operator=(const extents&) = default;
-
   void              insert(key_type address_start, key_type address_end, mapped_value_type value);
   bool              defined(key_type address_start, key_type address_end);
   bool              defined(key_type address);
@@ -30,24 +25,6 @@ public:
 
   range_map_type    range_map;
 };
-
-///////////////////////////////////////
-// CONSTRUCTOR [PLACEHOLDER]
-///////////////////////////////////////
-template <class Address, class Value, class Compare >
-extents<Address, Value, Compare>::extents() {
-  //nothing to do
-  return;
-}
-
-///////////////////////////////////////
-// DESTRUCTOR [PLACEHOLDER]
-///////////////////////////////////////
-template <class Address, class Value, class Compare >
-extents<Address, Value, Compare>::~extents() {
-  //nothing to do. map destructor can handle cleanup. 
-  return;
-}
 
 //////////////////////////////////////////////////////////////////////////////////
 // INSERT O(log N) assuming no overlapping ranges

--- a/src/torrent/utils/extents.h
+++ b/src/torrent/utils/extents.h
@@ -17,6 +17,8 @@ public:
 
   extents();
   ~extents();
+  extents(const extents&) = default;
+  extents& operator=(const extents&) = default;
 
   void              insert(key_type address_start, key_type address_end, mapped_value_type value);
   bool              defined(key_type address_start, key_type address_end);

--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -37,6 +37,8 @@ struct log_cache_entry {
 struct log_gz_output {
   log_gz_output(const char* filename, bool append) { gz_file = gzopen(filename, append ? "a" : "w"); }
   ~log_gz_output() { if (gz_file != NULL) gzclose(gz_file); }
+  log_gz_output(const log_gz_output&) = delete;
+  log_gz_output& operator=(const log_gz_output&) = delete;
 
   bool is_valid() { return gz_file != Z_NULL; }
 

--- a/src/tracker/tracker_worker.h
+++ b/src/tracker/tracker_worker.h
@@ -37,10 +37,6 @@ public:
   TrackerWorker(TrackerInfo info, int flags = 0);
   virtual ~TrackerWorker() = default;
 
-  TrackerWorker() = delete;
-  TrackerWorker(const TrackerWorker&) = delete;
-  TrackerWorker& operator=(const TrackerWorker&) = delete;
-
   // Public members do not require locking:
 
   const TrackerInfo&   info() const { return m_info; }
@@ -101,6 +97,9 @@ protected:
   std::function<TrackerParameters()> m_slot_parameters;
 
 private:
+  TrackerWorker(const TrackerWorker&) = delete;
+  TrackerWorker& operator=(const TrackerWorker&) = delete;
+
   mutable std::mutex    m_mutex;
 
   TrackerInfo           m_info;


### PR DESCRIPTION
Mostly missing deleted member functions.