### PR TITLE
avoid new string allocation

### DIFF
--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -122,7 +122,7 @@ directory_events::event_read() {
 
     if (itr != m_wd_list.end()) {
       std::string sname(event->name);
-      if((sname.substr(sname.find_last_of(".") ) == ".torrent"))
+      if (sname.size() >= 8 && sname.compare(sname.size() - 8, 8, ".torrent") == 0)
         itr->slot(itr->path + event->name);
     }
 


### PR DESCRIPTION
substr allocates a whole new string. No need just to check the end.