### PR TITLE
add back printf format attribute

### DIFF
--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -112,6 +112,7 @@ private:
   bool                parse_ut_pex();
   bool                parse_ut_metadata();
 
+  [[gnu::format(printf, 2, 3)]]
   static DataBuffer   build_bencode(size_t maxLength, const char* format, ...);
 
   void                peer_toggle_remote(int type, bool active);


### PR DESCRIPTION
This was mistakenly not added when the attribute was removed.