### PR TITLE
clang-tidy: default initialize members

### DIFF
--- a/src/data/hash_torrent.cc
+++ b/src/data/hash_torrent.cc
@@ -15,11 +15,8 @@
 namespace torrent {
 
 HashTorrent::HashTorrent(ChunkList* c) :
-  m_position(0),
-  m_outstanding(-1),
-  m_errno(0),
-
-  m_chunk_list(c) {
+  m_chunk_list(c)
+{
 }
 
 bool

--- a/src/data/hash_torrent.h
+++ b/src/data/hash_torrent.h
@@ -46,11 +46,11 @@ public:
 private:
   void                queue(bool quick);
 
-  unsigned int        m_position;
-  int                 m_outstanding;
+  unsigned int        m_position{0};
+  int                 m_outstanding{-1};
   Ranges              m_ranges;
 
-  int                 m_errno;
+  int                 m_errno{0};
 
   ChunkList*          m_chunk_list;
 

--- a/src/dht/dht_bucket.cc
+++ b/src/dht/dht_bucket.cc
@@ -44,16 +44,6 @@
 namespace torrent {
 
 DhtBucket::DhtBucket(const HashString& begin, const HashString& end) :
-  m_parent(NULL),
-  m_child(NULL),
-
-  m_lastChanged(cachedTime.seconds()),
-
-  m_good(0),
-  m_bad(0),
-
-  m_fullCacheLength(0),
-
   m_begin(begin),
   m_end(end) {
 

--- a/src/dht/dht_bucket.h
+++ b/src/dht/dht_bucket.h
@@ -125,15 +125,15 @@ private:
 
   void                build_full_cache();
 
-  DhtBucket*          m_parent;
-  DhtBucket*          m_child;
+  DhtBucket*          m_parent{};
+  DhtBucket*          m_child{};
   
-  int32_t             m_lastChanged;
+  int32_t             m_lastChanged{cachedTime.seconds()};
 
-  unsigned int        m_good;
-  unsigned int        m_bad;
+  unsigned int        m_good{0};
+  unsigned int        m_bad{0};
 
-  size_t              m_fullCacheLength;
+  size_t              m_fullCacheLength{0};
 
   // These are 40 bytes together, so might as well put them last.
   // m_end is const because it is used as key for the DhtRouter routing table

--- a/src/dht/dht_node.cc
+++ b/src/dht/dht_node.cc
@@ -53,10 +53,7 @@ namespace torrent {
 DhtNode::DhtNode(const HashString& id, const rak::socket_address* sa) :
   HashString(id),
   m_socketAddress(*sa),
-  m_lastSeen(0),
-  m_recentlyActive(false),
-  m_recentlyInactive(0),
-  m_bucket(NULL) {
+  m_lastSeen(0) {
 
   // TODO: Change this to use the id hash similar to how peer info
   // hash'es are logged.
@@ -68,10 +65,7 @@ DhtNode::DhtNode(const HashString& id, const rak::socket_address* sa) :
 }
 
 DhtNode::DhtNode(const std::string& id, const Object& cache) :
-  HashString(*HashString::cast_from(id.c_str())),
-  m_recentlyActive(false),
-  m_recentlyInactive(0),
-  m_bucket(NULL) {
+  HashString(*HashString::cast_from(id.c_str())) {
 
   // TODO: Check how DHT handles inet6.
   rak::socket_address_inet* sa = m_socketAddress.sa_inet();

--- a/src/dht/dht_node.h
+++ b/src/dht/dht_node.h
@@ -102,9 +102,9 @@ private:
 
   rak::socket_address m_socketAddress;
   unsigned int        m_lastSeen;
-  bool                m_recentlyActive;
-  unsigned int        m_recentlyInactive;
-  DhtBucket*          m_bucket;
+  bool                m_recentlyActive{};
+  unsigned int        m_recentlyInactive{};
+  DhtBucket*          m_bucket{};
 };
 
 inline void

--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -29,8 +29,6 @@ HashString DhtRouter::zero_id;
 DhtRouter::DhtRouter(const Object& cache, const rak::socket_address* sa) :
   DhtNode(zero_id, sa),  // actual ID is set later
   m_server(this),
-  m_contacts(NULL),
-  m_numRefresh(0),
   m_curToken(random()),
   m_prevToken(random()) {
 

--- a/src/dht/dht_router.h
+++ b/src/dht/dht_router.h
@@ -121,14 +121,14 @@ private:
 
   rak::priority_item  m_taskTimeout;
 
-  DhtServer           m_server;
+  DhtServer           m_server{nullptr};
   DhtNodeList         m_nodes;
   DhtBucketList       m_routingTable;
   DhtTrackerList      m_trackers;
 
-  std::deque<contact_t>* m_contacts;
+  std::deque<contact_t>* m_contacts{};
 
-  int                 m_numRefresh;
+  int                 m_numRefresh{0};
 
   bool                m_networkUp;
 

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -80,9 +80,9 @@ DhtServer::DhtServer(DhtRouter* router) :
   m_downloadNode(60),
 
   m_uploadThrottle(manager->upload_throttle()->throttle_list()),
-  m_downloadThrottle(manager->download_throttle()->throttle_list()),
+  m_downloadThrottle(manager->download_throttle()->throttle_list())
 
-  m_networkUp(false) {
+  {
 
   get_fd().clear();
   reset_statistics();

--- a/src/dht/dht_server.h
+++ b/src/dht/dht_server.h
@@ -151,7 +151,7 @@ private:
   unsigned int        m_errorsReceived;
   unsigned int        m_errorsCaught;
 
-  bool                m_networkUp;
+  bool                m_networkUp{false};
 };
 
 }

--- a/src/dht/dht_transaction.cc
+++ b/src/dht/dht_transaction.cc
@@ -13,12 +13,6 @@ namespace torrent {
 
 DhtSearch::DhtSearch(const HashString& target, const DhtBucket& contacts)
   : base_type(dht_compare_closer(target)),
-    m_pending(0),
-    m_contacted(0),
-    m_replied(0),
-    m_concurrency(3),
-    m_restart(false),
-    m_started(false),
     m_next(end()),
     m_target(target) {
 
@@ -229,9 +223,7 @@ DhtTransaction::DhtTransaction(int quick_timeout, int timeout, const HashString&
     m_hasQuickTimeout(quick_timeout > 0),
     m_sa(*sa),
     m_timeout(cachedTime.seconds() + timeout),
-    m_quickTimeout(cachedTime.seconds() + quick_timeout),
-    m_packet(NULL) {
-
+    m_quickTimeout(cachedTime.seconds() + quick_timeout) {
 }
 
 DhtTransaction::~DhtTransaction() {

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -150,13 +150,13 @@ protected:
   void                 set_node_active(const_accessor& n, bool active);
 
   // Statistics about contacted nodes.
-  unsigned int         m_pending;
-  unsigned int         m_contacted;
-  unsigned int         m_replied;
-  unsigned int         m_concurrency;
+  unsigned int         m_pending{0};
+  unsigned int         m_contacted{0};
+  unsigned int         m_replied{0};
+  unsigned int         m_concurrency{3};
 
-  bool                 m_restart;  // If true, trim nodes and reset m_next on the following get_contact call.
-  bool                 m_started;
+  bool                 m_restart{false};  // If true, trim nodes and reset m_next on the following get_contact call.
+  bool                 m_started{false};
 
   // Next node to return in get_contact, is end() if we have no more contactable nodes.
   const_accessor       m_next;
@@ -334,7 +334,7 @@ private:
   rak::socket_address    m_sa;
   int                    m_timeout;
   int                    m_quickTimeout;
-  DhtTransactionPacket*  m_packet;
+  DhtTransactionPacket*  m_packet{};
 };
 
 class DhtTransactionSearch : public DhtTransaction {

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -38,39 +38,13 @@
 
 namespace torrent {
 
-// TODO: Move to download_info.h.
-DownloadInfo::DownloadInfo() :
-  m_flags(flag_accepting_new_peers | flag_accepting_seeders | flag_pex_enabled | flag_pex_active),
-
-  m_upRate(60),
-  m_downRate(60),
-  m_skipRate(60),
-
-  m_uploadedBaseline(0),
-  m_completedBaseline(0),
-  m_sizePex(0),
-  m_maxSizePex(8),
-  m_metadataSize(0),
-
-  m_creationDate(0),
-  m_loadDate(rak::timer::current_seconds()),
-
-  m_upload_unchoked(0),
-  m_download_unchoked(0) {
-}
-
 DownloadMain::DownloadMain() :
   m_info(new DownloadInfo),
   m_tracker_list(new TrackerList),
 
-  m_choke_group(NULL),
   m_chunkList(new ChunkList),
   m_chunkSelector(new ChunkSelector(file_list()->mutable_data())),
-  m_chunkStatistics(new ChunkStatistics),
-
-  m_initialSeeding(NULL),
-  m_uploadThrottle(NULL),
-  m_downloadThrottle(NULL) {
+  m_chunkStatistics(new ChunkStatistics) {
 
   // Only set trivial values here, the rest is done in DownloadWrapper.
 

--- a/src/download/download_main.h
+++ b/src/download/download_main.h
@@ -137,7 +137,7 @@ private:
   tracker::TrackerControllerWrapper m_tracker_controller;
   TrackerList*                      m_tracker_list;
 
-  class choke_group*  m_choke_group;
+  class choke_group*  m_choke_group{};
 
   group_entry         m_up_group_entry;
   group_entry         m_down_group_entry;
@@ -148,7 +148,7 @@ private:
 
   Delegator           m_delegator;
   have_queue_type     m_haveQueue;
-  InitialSeeding*     m_initialSeeding;
+  InitialSeeding*     m_initialSeeding{};
 
   ConnectionList*     m_connectionList;
   FileList            m_fileList;
@@ -158,8 +158,8 @@ private:
   DataBuffer          m_ut_pex_initial;
   pex_list            m_ut_pex_list;
 
-  ThrottleList*       m_uploadThrottle;
-  ThrottleList*       m_downloadThrottle;
+  ThrottleList*       m_uploadThrottle{};
+  ThrottleList*       m_downloadThrottle{};
 
   slot_start_handshake_type m_slotStartHandshake;
   slot_stop_handshakes_type m_slotStopHandshakes;

--- a/src/net/socket_listen.cc
+++ b/src/net/socket_listen.cc
@@ -14,9 +14,6 @@
 
 namespace torrent {
 
-socket_listen::socket_listen() : m_backlog(SOMAXCONN) {
-}
-
 void
 socket_listen::set_backlog(int backlog) {
   if (backlog < 0 || backlog > SOMAXCONN)

--- a/src/net/socket_listen.h
+++ b/src/net/socket_listen.h
@@ -14,8 +14,6 @@ class socket_listen : public socket_event {
 public:
   using accepted_ftor = std::function<void(int, sa_unique_ptr)>;
 
-  socket_listen();
-
   int  backlog() const;
 
   void set_backlog(int backlog);
@@ -34,7 +32,7 @@ public:
 private:
   bool m_open_port(int fd, sa_unique_ptr& sap, uint16_t port);
 
-  int           m_backlog;
+  int           m_backlog{SOMAXCONN};
   accepted_ftor m_slot_accepted;
 };
 

--- a/src/net/throttle_internal.cc
+++ b/src/net/throttle_internal.cc
@@ -57,7 +57,6 @@ namespace torrent {
 ThrottleInternal::ThrottleInternal(int flags) :
   m_flags(flags),
   m_nextSlave(m_slaveList.end()),
-  m_unusedQuota(0),
   m_timeLastTick(cachedTime) {
 
   if (is_root())

--- a/src/net/throttle_internal.h
+++ b/src/net/throttle_internal.h
@@ -77,7 +77,7 @@ private:
   SlaveList           m_slaveList;
   SlaveList::iterator m_nextSlave;
 
-  uint32_t            m_unusedQuota;
+  uint32_t            m_unusedQuota{0};
 
   rak::timer          m_timeLastTick;
   rak::priority_item  m_taskTick;

--- a/src/net/throttle_list.cc
+++ b/src/net/throttle_list.cc
@@ -46,13 +46,6 @@
 namespace torrent {
 
 ThrottleList::ThrottleList() :
-  m_enabled(false),
-  m_size(0),
-  m_outstandingQuota(0),
-  m_unallocatedQuota(0),
-  m_unusedUnthrottledQuota(0),
-  m_rateAdded(0),
-
   m_minChunkSize(2 << 10),
   m_maxChunkSize(16 << 10),
 

--- a/src/net/throttle_list.h
+++ b/src/net/throttle_list.h
@@ -110,14 +110,14 @@ public:
 private:
   inline void         allocate_quota(ThrottleNode* node);
 
-  bool                m_enabled;
-  uint32_t            m_size;
+  bool                m_enabled{false};
+  uint32_t            m_size{0};
 
-  uint32_t            m_outstandingQuota;
-  uint32_t            m_unallocatedQuota;
-  uint32_t            m_unusedUnthrottledQuota;
+  uint32_t            m_outstandingQuota{0};
+  uint32_t            m_unallocatedQuota{0};
+  uint32_t            m_unusedUnthrottledQuota{0};
 
-  uint32_t            m_rateAdded;
+  uint32_t            m_rateAdded{0};
 
   uint32_t            m_minChunkSize;
   uint32_t            m_maxChunkSize;

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -55,18 +55,11 @@ public:
 };
 
 Handshake::Handshake(SocketFd fd, HandshakeManager* m, int encryptionOptions) :
-  m_state(INACTIVE),
-
   m_manager(m),
-  m_peerInfo(NULL),
-  m_download(NULL),
 
   // Use global throttles until we know which download it is.
   m_uploadThrottle(manager->upload_throttle()->throttle_list()),
   m_downloadThrottle(manager->download_throttle()->throttle_list()),
-
-  m_readDone(false),
-  m_writeDone(false),
 
   m_encryption(encryptionOptions),
   m_extensions(m->default_extensions()) {

--- a/src/protocol/handshake.h
+++ b/src/protocol/handshake.h
@@ -139,12 +139,12 @@ protected:
 
   static const char*  m_protocol;
 
-  State               m_state;
+  State               m_state{INACTIVE};
 
   HandshakeManager*   m_manager;
 
-  PeerInfo*           m_peerInfo;
-  DownloadMain*       m_download;
+  PeerInfo*           m_peerInfo{};
+  DownloadMain*       m_download{};
   Bitfield            m_bitfield;
 
   ThrottleList*       m_uploadThrottle;
@@ -156,8 +156,8 @@ protected:
   uint32_t            m_readPos;
   uint32_t            m_writePos;
 
-  bool                m_readDone;
-  bool                m_writeDone;
+  bool                m_readDone{false};
+  bool                m_writeDone{false};
 
   bool                m_incoming;
 

--- a/src/protocol/initial_seed.cc
+++ b/src/protocol/initial_seed.cc
@@ -52,7 +52,6 @@ PeerInfo* const InitialSeeding::chunk_unknown = (PeerInfo*) 1;
 PeerInfo* const InitialSeeding::chunk_done    = (PeerInfo*) 2;
 
 InitialSeeding::InitialSeeding(DownloadMain* download) :
-    m_nextChunk(0),
     m_chunksLeft(download->file_list()->size_chunks()),
     m_download(download),
     m_peerChunks(std::make_unique<PeerInfo*[]>(m_chunksLeft)) {

--- a/src/protocol/initial_seed.h
+++ b/src/protocol/initial_seed.h
@@ -77,7 +77,7 @@ private:
   void                complete(PeerConnectionBase* pcb);
   void                unblock_all();
 
-  uint32_t            m_nextChunk;
+  uint32_t            m_nextChunk{0};
   uint32_t            m_chunksLeft;
   DownloadMain*       m_download;
   std::unique_ptr<PeerInfo*[]> m_peerChunks;

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -92,27 +92,10 @@ log_mincore_stats_func(bool is_incore, bool new_index, bool& continous) {
 }
 
 PeerConnectionBase::PeerConnectionBase() :
-  m_download(NULL),
-  
   m_down(new ProtocolRead()),
-  m_up(new ProtocolWrite()),
+  m_up(new ProtocolWrite()) {
 
-  m_downStall(0),
-
-  m_downInterested(false),
-  m_downUnchoked(false),
-
-  m_sendChoked(false),
-  m_sendInterested(false),
-  m_tryRequest(true),
-  m_sendPEXMask(0),
-
-  m_encryptBuffer(NULL),
-  m_extensions(NULL),
-
-  m_incoreContinous(false) {
-
-  m_peerInfo = NULL;
+  m_peerInfo = nullptr;
 }
 
 PeerConnectionBase::~PeerConnectionBase() {

--- a/src/protocol/peer_connection_base.h
+++ b/src/protocol/peer_connection_base.h
@@ -154,7 +154,7 @@ protected:
   bool                send_pex_message();
   bool                send_ext_message();
 
-  DownloadMain*       m_download;
+  DownloadMain*       m_download{};
 
   ProtocolRead*       m_down;
   ProtocolWrite*      m_up;
@@ -163,7 +163,7 @@ protected:
 
   RequestList         m_request_list;
   ChunkHandle         m_downChunk;
-  uint32_t            m_downStall;
+  uint32_t            m_downStall{0};
 
   Piece               m_upPiece;
   ChunkHandle         m_upChunk;
@@ -181,25 +181,25 @@ protected:
   choke_status        m_upChoke;
   choke_status        m_downChoke;
 
-  bool                m_downInterested;
-  bool                m_downUnchoked;
+  bool                m_downInterested{false};
+  bool                m_downUnchoked{false};
 
-  bool                m_sendChoked;
-  bool                m_sendInterested;
-  bool                m_tryRequest;
+  bool                m_sendChoked{false};
+  bool                m_sendInterested{false};
+  bool                m_tryRequest{true};
 
-  int                 m_sendPEXMask;
+  int                 m_sendPEXMask{0};
 
   rak::timer          m_timeLastRead;
 
   DataBuffer          m_extensionMessage;
   uint32_t            m_extensionOffset;
 
-  EncryptBuffer*      m_encryptBuffer;
+  EncryptBuffer*      m_encryptBuffer{};
   EncryptionInfo      m_encryption;
-  ProtocolExtension*  m_extensions;
+  ProtocolExtension*  m_extensions{};
 
-  bool m_incoreContinous;
+  bool m_incoreContinous{false};
 };
 
 inline void

--- a/src/torrent/download_info.h
+++ b/src/torrent/download_info.h
@@ -9,6 +9,8 @@
 #include <torrent/rate.h>
 #include <torrent/hash_string.h>
 
+#include <rak/timer.h>
+
 namespace torrent {
 
 class FileList;
@@ -45,8 +47,6 @@ public:
   static const int public_flags = flag_accepting_seeders;
 
   static const uint32_t unlimited = ~uint32_t();
-
-  DownloadInfo();
 
   const std::string&  name() const                                 { return m_name; }
   void                set_name(const std::string& s)               { m_name = s; }
@@ -140,23 +140,23 @@ private:
   HashString          m_hashObfuscated{HashString::new_zero()};
   HashString          m_localId{HashString::new_zero()};
 
-  mutable int         m_flags;
+  mutable int         m_flags{flag_accepting_new_peers | flag_accepting_seeders | flag_pex_enabled | flag_pex_active};
 
-  mutable Rate        m_upRate;
-  mutable Rate        m_downRate;
-  mutable Rate        m_skipRate;
+  mutable Rate        m_upRate{60};
+  mutable Rate        m_downRate{60};
+  mutable Rate        m_skipRate{60};
 
-  uint64_t            m_uploadedBaseline;
-  uint64_t            m_completedBaseline;
-  uint32_t            m_sizePex;
-  uint32_t            m_maxSizePex;
-  size_t              m_metadataSize;
+  uint64_t            m_uploadedBaseline{0};
+  uint64_t            m_completedBaseline{0};
+  uint32_t            m_sizePex{0};
+  uint32_t            m_maxSizePex{8};
+  size_t              m_metadataSize{0};
 
-  uint32_t            m_creationDate;
-  uint32_t            m_loadDate;
+  uint32_t            m_creationDate{0};
+  uint32_t            m_loadDate = rak::timer::current_seconds();
 
-  uint32_t            m_upload_unchoked;
-  uint32_t            m_download_unchoked;
+  uint32_t            m_upload_unchoked{0};
+  uint32_t            m_download_unchoked{0};
 
   slot_stat_type      m_slotStatLeft;
   slot_stat_type      m_slotStatCompleted;

--- a/src/tracker/tracker_dht.cc
+++ b/src/tracker/tracker_dht.cc
@@ -23,8 +23,8 @@ const char* TrackerDht::states[] = { "Idle", "Searching", "Announcing" };
 bool TrackerDht::is_allowed() { return manager->dht_controller()->is_valid(); }
 
 TrackerDht::TrackerDht(const TrackerInfo& info, int flags) :
-  TrackerWorker(info, flags),
-  m_dht_state(state_idle) {
+  TrackerWorker(info, flags)
+  {
 
   if (!manager->dht_controller()->is_valid())
     throw internal_error("Trying to add DHT tracker with no DHT manager.");

--- a/src/tracker/tracker_dht.h
+++ b/src/tracker/tracker_dht.h
@@ -54,7 +54,7 @@ public:
 
 private:
   AddressList  m_peers;
-  state_type   m_dht_state;
+  state_type   m_dht_state{state_idle};
 
   int          m_replied;
   int          m_contacted;

--- a/src/utils/diffie_hellman.cc
+++ b/src/utils/diffie_hellman.cc
@@ -40,7 +40,7 @@ static const BIGNUM* dh_get_pub_key(const DiffieHellman::dh_ptr& dh) {
 
 DiffieHellman::DiffieHellman(const unsigned char *prime, int primeLength,
                              const unsigned char *generator, int generatorLength) :
-  m_dh(dh_new()), m_size(0) {
+  m_dh(dh_new()) {
 
   BIGNUM* dh_p = BN_bin2bn(prime, primeLength, nullptr);
   BIGNUM* dh_g = BN_bin2bn(generator, generatorLength, nullptr);

--- a/src/utils/diffie_hellman.h
+++ b/src/utils/diffie_hellman.h
@@ -32,7 +32,7 @@ public:
 private:
   dh_ptr       m_dh;
   secret_ptr   m_secret;
-  int          m_size;
+  int          m_size{0};
 };
 
 };


### PR DESCRIPTION
Found with modernize-use-default-member-init