### PR TITLE
CI: test big endian platform as well

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['x86_64', 'x86']
+        platform: ['x86_64', 'x86', 's390x']
     defaults:
       run:
         shell: alpine.sh {0}


### PR DESCRIPTION
Slower than the others. Probably should be done as rtorrent is used on big endian platforms as well (mostly routers).