### PR TITLE
constexpr conversions

### DIFF
--- a/src/data/chunk_list.h
+++ b/src/data/chunk_list.h
@@ -41,19 +41,19 @@ public:
   using base_type::empty;
   using base_type::operator[];
 
-  static const int sync_all          = (1 << 0);
-  static const int sync_force        = (1 << 1);
-  static const int sync_safe         = (1 << 2);
-  static const int sync_sloppy       = (1 << 3);
-  static const int sync_use_timeout  = (1 << 4);
-  static const int sync_ignore_error = (1 << 5);
+  static constexpr int sync_all          = (1 << 0);
+  static constexpr int sync_force        = (1 << 1);
+  static constexpr int sync_safe         = (1 << 2);
+  static constexpr int sync_sloppy       = (1 << 3);
+  static constexpr int sync_use_timeout  = (1 << 4);
+  static constexpr int sync_ignore_error = (1 << 5);
 
-  static const int get_writable      = (1 << 0);
-  static const int get_blocking      = (1 << 1);
-  static const int get_dont_log      = (1 << 2);
-  static const int get_nonblock      = (1 << 3);
+  static constexpr int get_writable      = (1 << 0);
+  static constexpr int get_blocking      = (1 << 1);
+  static constexpr int get_dont_log      = (1 << 2);
+  static constexpr int get_nonblock      = (1 << 3);
 
-  static const int flag_active       = (1 << 0);
+  static constexpr int flag_active       = (1 << 0);
 
   ChunkList() = default;
   ~ChunkList() { clear(); }

--- a/src/data/chunk_list_node.h
+++ b/src/data/chunk_list_node.h
@@ -54,7 +54,7 @@ class Chunk;
 
 class lt_cacheline_aligned ChunkListNode {
 public:
-  static const uint32_t invalid_index = ~uint32_t();
+  static constexpr uint32_t invalid_index = ~uint32_t();
 
   bool                is_valid() const               { return m_chunk != NULL; }
 

--- a/src/data/memory_chunk.h
+++ b/src/data/memory_chunk.h
@@ -13,29 +13,29 @@ class MemoryChunk {
   // Consider information about whetever the memory maps to a file or
   // not, since mincore etc can only be called on files.
 
-  static const int prot_exec              = PROT_EXEC;
-  static const int prot_read              = PROT_READ;
-  static const int prot_write             = PROT_WRITE;
-  static const int prot_none              = PROT_NONE;
-  static const int map_shared             = MAP_SHARED;
-  static const int map_anon               = MAP_ANON;
+  static constexpr int prot_exec              = PROT_EXEC;
+  static constexpr int prot_read              = PROT_READ;
+  static constexpr int prot_write             = PROT_WRITE;
+  static constexpr int prot_none              = PROT_NONE;
+  static constexpr int map_shared             = MAP_SHARED;
+  static constexpr int map_anon               = MAP_ANON;
 
 #ifdef USE_MADVISE
-  static const int advice_normal          = MADV_NORMAL;
-  static const int advice_random          = MADV_RANDOM;
-  static const int advice_sequential      = MADV_SEQUENTIAL;
-  static const int advice_willneed        = MADV_WILLNEED;
-  static const int advice_dontneed        = MADV_DONTNEED;
+  static constexpr int advice_normal          = MADV_NORMAL;
+  static constexpr int advice_random          = MADV_RANDOM;
+  static constexpr int advice_sequential      = MADV_SEQUENTIAL;
+  static constexpr int advice_willneed        = MADV_WILLNEED;
+  static constexpr int advice_dontneed        = MADV_DONTNEED;
 #else
-  static const int advice_normal          = 0;
-  static const int advice_random          = 1;
-  static const int advice_sequential      = 2;
-  static const int advice_willneed        = 3;
-  static const int advice_dontneed        = 4;
+  static constexpr int advice_normal          = 0;
+  static constexpr int advice_random          = 1;
+  static constexpr int advice_sequential      = 2;
+  static constexpr int advice_willneed        = 3;
+  static constexpr int advice_dontneed        = 4;
 #endif
-  static const int sync_sync              = MS_SYNC;
-  static const int sync_async             = MS_ASYNC;
-  static const int sync_invalidate        = MS_INVALIDATE;
+  static constexpr int sync_sync              = MS_SYNC;
+  static constexpr int sync_async             = MS_ASYNC;
+  static constexpr int sync_invalidate        = MS_INVALIDATE;
 
   MemoryChunk() = default;
   ~MemoryChunk() { clear(); }

--- a/src/data/socket_file.h
+++ b/src/data/socket_file.h
@@ -14,14 +14,14 @@ class SocketFile {
 public:
   using fd_type = int;
 
-  static const fd_type invalid_fd         = -1;
+  static constexpr fd_type invalid_fd         = -1;
 
-  static const int o_create               = O_CREAT;
-  static const int o_truncate             = O_TRUNC;
-  static const int o_nonblock             = O_NONBLOCK;
+  static constexpr int o_create               = O_CREAT;
+  static constexpr int o_truncate             = O_TRUNC;
+  static constexpr int o_nonblock             = O_NONBLOCK;
 
-  static const int flag_fallocate          = (1 << 0);
-  static const int flag_fallocate_blocking = (1 << 1);
+  static constexpr int flag_fallocate          = (1 << 0);
+  static constexpr int flag_fallocate_blocking = (1 << 1);
 
   SocketFile() = default;
   ~SocketFile() = default;

--- a/src/dht/dht_bucket.h
+++ b/src/dht/dht_bucket.h
@@ -53,7 +53,7 @@ class DhtNode;
 // a power of 2.)
 class DhtBucket : private std::vector<DhtNode*> {
 public:
-  static const unsigned int num_nodes = 8;
+  static constexpr unsigned int num_nodes = 8;
 
   using base_type = std::vector<DhtNode*>;
 

--- a/src/dht/dht_hash_map.h
+++ b/src/dht/dht_hash_map.h
@@ -56,7 +56,7 @@ namespace torrent {
 // An offset of 64 bits provides 96 significant bits which is fine as long as
 // the size of size_t does not exceed 12 bytes, while still having correctly
 // aligned 64-bit access.
-static const unsigned int hashstring_hash_ofs = 8;
+static constexpr unsigned int hashstring_hash_ofs = 8;
 
 struct hashstring_ptr_hash {
   size_t operator () (const HashString* n) const {

--- a/src/dht/dht_node.h
+++ b/src/dht/dht_node.h
@@ -55,7 +55,7 @@ class DhtNode : public HashString {
 
 public:
   // A node is considered bad if it failed to reply to this many queries.
-  static const unsigned int max_failed_replies = 5;
+  static constexpr unsigned int max_failed_replies = 5;
 
   DhtNode(const HashString& id, const rak::socket_address* sa);
   DhtNode(const std::string& id, const Object& cache);

--- a/src/dht/dht_router.h
+++ b/src/dht/dht_router.h
@@ -23,13 +23,13 @@ class TrackerDht;
 class DhtRouter : public DhtNode {
 public:
   // How many bytes to return and verify from the 20-byte SHA token.
-  static const unsigned int size_token = 8;
+  static constexpr unsigned int size_token = 8;
 
-  static const unsigned int timeout_bootstrap_retry  =          60;  // Retry initial bootstrapping every minute.
-  static const unsigned int timeout_update           =     15 * 60;  // Regular housekeeping updates every 15 minutes.
-  static const unsigned int timeout_bucket_bootstrap =     15 * 60;  // Bootstrap idle buckets after 15 minutes.
-  static const unsigned int timeout_remove_node      = 4 * 60 * 60;  // Remove unresponsive nodes after 4 hours.
-  static const unsigned int timeout_peer_announce    =     30 * 60;  // Remove peers which haven't reannounced for 30 minutes.
+  static constexpr unsigned int timeout_bootstrap_retry  =          60;  // Retry initial bootstrapping every minute.
+  static constexpr unsigned int timeout_update           =     15 * 60;  // Regular housekeeping updates every 15 minutes.
+  static constexpr unsigned int timeout_bucket_bootstrap =     15 * 60;  // Bootstrap idle buckets after 15 minutes.
+  static constexpr unsigned int timeout_remove_node      = 4 * 60 * 60;  // Remove unresponsive nodes after 4 hours.
+  static constexpr unsigned int timeout_peer_announce    =     30 * 60;  // Remove peers which haven't reannounced for 30 minutes.
 
   // A node ID of all zero.
   static HashString zero_id;
@@ -94,10 +94,10 @@ private:
   using contact_t = std::pair<std::string, int>;
 
   // Number of nodes we need to consider the bootstrap process complete.
-  static const unsigned int num_bootstrap_complete = 32;
+  static constexpr unsigned int num_bootstrap_complete = 32;
 
   // Maximum number of potential contacts to keep until bootstrap complete.
-  static const unsigned int num_bootstrap_contacts = 64;
+  static constexpr unsigned int num_bootstrap_contacts = 64;
 
   using DhtBucketList = std::map<const HashString, DhtBucket*>;
 

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -27,13 +27,6 @@
 
 namespace torrent {
 
-const char* DhtServer::queries[] = {
-  "ping",
-  "find_node",
-  "get_peers",
-  "announce_peer",
-};
-
 // List of all possible keys we need/support in a DHT message.
 // Unsupported keys we receive are dropped (ignored) while decoding.
 // See torrent/object_static_map.h for how this works.

--- a/src/dht/dht_server.h
+++ b/src/dht/dht_server.h
@@ -73,10 +73,10 @@ public:
 
 private:
   // DHT error codes.
-  static const int dht_error_generic    = 201;
-  static const int dht_error_server     = 202;
-  static const int dht_error_protocol   = 203;
-  static const int dht_error_bad_method = 204;
+  static constexpr int dht_error_generic    = 201;
+  static constexpr int dht_error_server     = 202;
+  static constexpr int dht_error_protocol   = 203;
+  static constexpr int dht_error_bad_method = 204;
 
   struct [[gnu::packed]] compact_node_info {
     char                 _id[20];
@@ -97,9 +97,9 @@ private:
   static const char* queries[];
 
   // Priorities for the outgoing packets.
-  static const int packet_prio_high  = 2;  // For important queries we send (announces).
-  static const int packet_prio_low   = 1;  // For (relatively) unimportant queries we send.
-  static const int packet_prio_reply = 0;  // For replies to peer queries.
+  static constexpr int packet_prio_high  = 2;  // For important queries we send (announces).
+  static constexpr int packet_prio_low   = 1;  // For (relatively) unimportant queries we send.
+  static constexpr int packet_prio_reply = 0;  // For replies to peer queries.
 
   void                start_write();
 

--- a/src/dht/dht_server.h
+++ b/src/dht/dht_server.h
@@ -1,8 +1,10 @@
 #ifndef LIBTORRENT_DHT_SERVER_H
 #define LIBTORRENT_DHT_SERVER_H
 
-#include <map>
+#include <array>
 #include <deque>
+#include <map>
+
 #include <rak/priority_queue_default.h>
 #include <rak/socket_address.h>
 
@@ -94,7 +96,12 @@ private:
   using transaction_itr = transaction_map::iterator;
 
   // DHT transaction names for given transaction type.
-  static const char* queries[];
+  static constexpr std::array queries{
+    "ping",
+    "find_node",
+    "get_peers",
+    "announce_peer",
+  };
 
   // Priorities for the outgoing packets.
   static constexpr int packet_prio_high  = 2;  // For important queries we send (announces).

--- a/src/dht/dht_tracker.h
+++ b/src/dht/dht_tracker.h
@@ -55,12 +55,12 @@ public:
   // Needs to be small enough so that a packet with a payload of num_peers*6 bytes 
   // does not need fragmentation. Value chosen so that the size is approximately
   // equal to a FIND_NODE reply (8*26 bytes).
-  static const unsigned int max_peers = 32;
+  static constexpr unsigned int max_peers = 32;
 
   // Maximum number of peers we keep track of. For torrents with more peers,
   // we replace the oldest peer with each new announce to avoid excessively
   // large peer tables for very active torrents.
-  static const unsigned int max_size = 128;
+  static constexpr unsigned int max_size = 128;
 
   bool                empty() const                { return m_peers.empty(); }
   size_t              size() const                 { return m_peers.size(); }

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -94,10 +94,10 @@ public:
   using base_type = std::map<DhtNode*, DhtSearch*, dht_compare_closer>;
 
   // Number of closest potential contact nodes to keep.
-  static const unsigned int max_contacts = 18;
+  static constexpr unsigned int max_contacts = 18;
 
   // Number of closest nodes we actually announce to.
-  static const unsigned int max_announce = 3;
+  static constexpr unsigned int max_announce = 3;
 
   DhtSearch(const HashString& target, const DhtBucket& contacts);
   virtual ~DhtSearch();
@@ -231,7 +231,7 @@ public:
   // Never more than one of the above.
   // And additionally for queries we send:
   // - transaction ID (3 bytes)
-  static const size_t data_size = 64;
+  static constexpr size_t data_size = 64;
   char data[data_size];
   char* data_end;
 };

--- a/src/download/chunk_selector.h
+++ b/src/download/chunk_selector.h
@@ -59,7 +59,7 @@ class PeerChunks;
 
 class ChunkSelector {
 public:
-  static const auto invalid_chunk = ~uint32_t{0};
+  static constexpr auto invalid_chunk = ~uint32_t{0};
 
   ChunkSelector(download_data* data) : m_data(data) {}
 

--- a/src/download/chunk_statistics.h
+++ b/src/download/chunk_statistics.h
@@ -59,7 +59,7 @@ public:
   using base_type::empty;
   using base_type::size;
 
-  static const size_type max_accounted = 255;
+  static constexpr size_type max_accounted = 255;
 
   ChunkStatistics() = default;
   ~ChunkStatistics() = default;

--- a/src/download/delegator.h
+++ b/src/download/delegator.h
@@ -57,7 +57,7 @@ public:
   using slot_peer_chunk = std::function<uint32_t(PeerChunks*, bool)>;
   using slot_size       = std::function<uint32_t(uint32_t)>;
 
-  static const unsigned int block_size = 1 << 14;
+  static constexpr unsigned int block_size = 1 << 14;
 
   TransferList*       transfer_list()                     { return &m_transfers; }
   const TransferList* transfer_list() const               { return &m_transfers; }

--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -328,7 +328,7 @@ static const char*
 parse_base32_sha1(const char* pos, HashString& hash) {
   HashString::iterator hashItr = hash.begin();
 
-  static const int base_shift = 8+8-5;
+  static constexpr int base_shift = 8+8-5;
   int shift = base_shift;
   uint16_t decoded = 0;
 

--- a/src/net/socket_base.h
+++ b/src/net/socket_base.h
@@ -30,7 +30,7 @@ public:
   void                receive_throttle_up_activate();
 
 protected:
-  static const size_t null_buffer_size = 1 << 17;
+  static constexpr size_t null_buffer_size = 1 << 17;
 
   static char*        m_nullBuffer;
 };

--- a/src/net/socket_set.h
+++ b/src/net/socket_set.h
@@ -60,7 +60,7 @@ public:
   using base_type = std::vector<Event*, rak::cacheline_allocator<Event*>>;
   using Table     = std::vector<size_type, rak::cacheline_allocator<size_type>>;
 
-  static const auto npos = ~size_type{0};
+  static constexpr auto npos = ~size_type{0};
 
   using base_type::value_type;
 

--- a/src/net/throttle_internal.h
+++ b/src/net/throttle_internal.h
@@ -47,8 +47,8 @@ namespace torrent {
 
 class ThrottleInternal : public Throttle {
 public:
-  static const int flag_none = 0;
-  static const int flag_root = 1;
+  static constexpr int flag_none = 0;
+  static constexpr int flag_root = 1;
 
   ThrottleInternal(int flags);
   ~ThrottleInternal();
@@ -62,8 +62,8 @@ public:
 
 private:
   // Fraction is a fixed-precision value with the given number of bits after the decimal point.
-  static const uint32_t fraction_bits = 16;
-  static const uint32_t fraction_base = (1 << fraction_bits);
+  static constexpr uint32_t fraction_bits = 16;
+  static constexpr uint32_t fraction_base = (1 << fraction_bits);
 
   using SlaveList = std::vector<ThrottleInternal*>;
 

--- a/src/net/udns/rblcheck.c
+++ b/src/net/udns/rblcheck.c
@@ -44,7 +44,7 @@
 # include "getopt.c"
 #endif
 
-static const char *version = "udns-rblcheck " UDNS_VERSION;
+static constexpr auto version = "udns-rblcheck " UDNS_VERSION;
 static char *progname;
 
 static void error(int die, const char *fmt, ...) {

--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -28,22 +28,22 @@ public:
 
   using PEXList = std::vector<SocketAddressCompact>;
 
-  static const int    flag_default           = 1<<0;
-  static const int    flag_initial_handshake = 1<<1;
-  static const int    flag_initial_pex       = 1<<2;
-  static const int    flag_received_ext      = 1<<3;
+  static constexpr int    flag_default           = 1<<0;
+  static constexpr int    flag_initial_handshake = 1<<1;
+  static constexpr int    flag_initial_pex       = 1<<2;
+  static constexpr int    flag_received_ext      = 1<<3;
 
   // The base bit to shift by MessageType to check if the extension is
   // enabled locally or supported by the peer.
-  static const int    flag_local_enabled_base    = 1<<8;
-  static const int    flag_remote_supported_base = 1<<16;
+  static constexpr int    flag_local_enabled_base    = 1<<8;
+  static constexpr int    flag_remote_supported_base = 1<<16;
 
   // Number of extensions we support, not counting handshake.
-  static const int    extension_count = FIRST_INVALID - HANDSHAKE - 1;
+  static constexpr int    extension_count = FIRST_INVALID - HANDSHAKE - 1;
 
   // Fixed size of a metadata piece (16 KB).
-  static const size_t metadata_piece_shift = 14;
-  static const size_t metadata_piece_size  = 1 << metadata_piece_shift;
+  static constexpr size_t metadata_piece_shift = 14;
+  static constexpr size_t metadata_piece_size  = 1 << metadata_piece_shift;
 
   ProtocolExtension();
   ~ProtocolExtension() { delete [] m_read; }

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -34,8 +34,6 @@
 
 namespace torrent {
 
-const char* Handshake::m_protocol = "BitTorrent protocol";
-
 class handshake_error : public network_error {
 public:
   handshake_error(int type, int error) : m_type(type), m_error(error) {}

--- a/src/protocol/handshake.h
+++ b/src/protocol/handshake.h
@@ -20,20 +20,20 @@ class ThrottleList;
 
 class Handshake : public SocketStream {
 public:
-  static const uint32_t part1_size     = 20 + 28;
-  static const uint32_t part2_size     = 20;
-  static const uint32_t handshake_size = part1_size + part2_size;
-  static const uint32_t read_message_size = 2 * 5;
+  static constexpr uint32_t part1_size     = 20 + 28;
+  static constexpr uint32_t part2_size     = 20;
+  static constexpr uint32_t handshake_size = part1_size + part2_size;
+  static constexpr uint32_t read_message_size = 2 * 5;
 
-  static const uint32_t protocol_bitfield  = 5;
-  static const uint32_t protocol_port      = 9;
-  static const uint32_t protocol_extension = 20;
+  static constexpr uint32_t protocol_bitfield  = 5;
+  static constexpr uint32_t protocol_port      = 9;
+  static constexpr uint32_t protocol_extension = 20;
 
-  static const uint32_t enc_negotiation_size = 8 + 4 + 2;
-  static const uint32_t enc_pad_size         = 512;
-  static const uint32_t enc_pad_read_size    = 96 + enc_pad_size + 20;
+  static constexpr uint32_t enc_negotiation_size = 8 + 4 + 2;
+  static constexpr uint32_t enc_pad_size         = 512;
+  static constexpr uint32_t enc_pad_read_size    = 96 + enc_pad_size + 20;
 
-  static const uint32_t buffer_size = enc_pad_read_size + 20 + enc_negotiation_size + enc_pad_size + 2 + handshake_size + read_message_size;
+  static constexpr uint32_t buffer_size = enc_pad_read_size + 20 + enc_negotiation_size + enc_pad_size + 2 + handshake_size + read_message_size;
 
   using Buffer = ProtocolBuffer<buffer_size>;
 

--- a/src/protocol/handshake.h
+++ b/src/protocol/handshake.h
@@ -137,7 +137,7 @@ protected:
   uint32_t            read_unthrottled(void* buf, uint32_t length);
   uint32_t            write_unthrottled(const void* buf, uint32_t length);
 
-  static const char*  m_protocol;
+  static constexpr auto m_protocol = "BitTorrent protocol";
 
   State               m_state{INACTIVE};
 

--- a/src/protocol/handshake_encryption.h
+++ b/src/protocol/handshake_encryption.h
@@ -53,17 +53,17 @@ public:
     RETRY_ENCRYPTED,
   };
 
-  static const int           crypto_plain = 1;
-  static const int           crypto_rc4   = 2;
+  static constexpr int           crypto_plain = 1;
+  static constexpr int           crypto_rc4   = 2;
 
   static const unsigned char dh_prime[];
-  static const unsigned int  dh_prime_length = 96;
+  static constexpr unsigned int  dh_prime_length = 96;
 
   static const unsigned char dh_generator[];
-  static const unsigned int  dh_generator_length = 1;
+  static constexpr unsigned int  dh_generator_length = 1;
 
   static const unsigned char vc_data[];
-  static const unsigned int  vc_length = 8;
+  static constexpr unsigned int  vc_length = 8;
 
   HandshakeEncryption(int options) :
     m_options(options)

--- a/src/protocol/handshake_manager.h
+++ b/src/protocol/handshake_manager.h
@@ -25,7 +25,7 @@ public:
   using slot_download = std::function<DownloadMain*(const char*)>;
 
   // Do not connect to peers with this many or more failed chunks.
-  static const unsigned int max_failed = 3;
+  static constexpr unsigned int max_failed = 3;
 
   using base_type::empty;
 

--- a/src/protocol/initial_seed.h
+++ b/src/protocol/initial_seed.h
@@ -46,7 +46,7 @@ public:
   InitialSeeding(DownloadMain* download);
   ~InitialSeeding();
 
-  static const uint32_t no_offer = ~uint32_t();
+  static constexpr uint32_t no_offer = ~uint32_t();
 
   void                new_peer(PeerConnectionBase* pcb);
 

--- a/src/protocol/peer_connection_base.h
+++ b/src/protocol/peer_connection_base.h
@@ -40,12 +40,12 @@ public:
 #endif
 
   // Find an optimal number for this.
-  static const uint32_t read_size = 64;
+  static constexpr uint32_t read_size = 64;
 
   // Bitmasks for peer exchange messages to send.
-  static const int PEX_DO      = (1 << 0);
-  static const int PEX_ENABLE  = (1 << 1);
-  static const int PEX_DISABLE = (1 << 2);
+  static constexpr int PEX_DO      = (1 << 0);
+  static constexpr int PEX_ENABLE  = (1 << 1);
+  static constexpr int PEX_DISABLE = (1 << 2);
 
   PeerConnectionBase();
   virtual ~PeerConnectionBase();
@@ -114,7 +114,7 @@ public:
   bool                should_connection_unchoke(choke_queue* cq) const;
 
 protected:
-  static const uint32_t extension_must_encrypt = ~uint32_t();
+  static constexpr uint32_t extension_must_encrypt = ~uint32_t();
 
   inline bool         read_remaining();
   inline bool         write_remaining();

--- a/src/protocol/protocol_base.h
+++ b/src/protocol/protocol_base.h
@@ -50,7 +50,7 @@ public:
   using Buffer    = ProtocolBuffer<512>;
   using size_type = uint32_t;
 
-  static const size_type buffer_size = 512;
+  static constexpr size_type buffer_size = 512;
 
   enum Protocol {
     CHOKE = 0,
@@ -113,22 +113,22 @@ public:
   void                write_port(uint16_t port);
   void                write_extension(uint8_t id, uint32_t length);
 
-  static const size_type sizeof_keepalive    = 4;
-  static const size_type sizeof_choke        = 5;
-  static const size_type sizeof_interested   = 5;
-  static const size_type sizeof_have         = 9;
-  static const size_type sizeof_have_body    = 4;
-  static const size_type sizeof_bitfield     = 5;
-  static const size_type sizeof_request      = 17;
-  static const size_type sizeof_request_body = 12;
-  static const size_type sizeof_cancel       = 17;
-  static const size_type sizeof_cancel_body  = 12;
-  static const size_type sizeof_piece        = 13;
-  static const size_type sizeof_piece_body   = 8;
-  static const size_type sizeof_port         = 7;
-  static const size_type sizeof_port_body    = 2;
-  static const size_type sizeof_extension    = 6;
-  static const size_type sizeof_extension_body=1;
+  static constexpr size_type sizeof_keepalive    = 4;
+  static constexpr size_type sizeof_choke        = 5;
+  static constexpr size_type sizeof_interested   = 5;
+  static constexpr size_type sizeof_have         = 9;
+  static constexpr size_type sizeof_have_body    = 4;
+  static constexpr size_type sizeof_bitfield     = 5;
+  static constexpr size_type sizeof_request      = 17;
+  static constexpr size_type sizeof_request_body = 12;
+  static constexpr size_type sizeof_cancel       = 17;
+  static constexpr size_type sizeof_cancel_body  = 12;
+  static constexpr size_type sizeof_piece        = 13;
+  static constexpr size_type sizeof_piece_body   = 8;
+  static constexpr size_type sizeof_port         = 7;
+  static constexpr size_type sizeof_port_body    = 2;
+  static constexpr size_type sizeof_extension    = 6;
+  static constexpr size_type sizeof_extension_body=1;
 
   bool                can_write_keepalive() const             { return m_buffer.reserved_left() >= sizeof_keepalive; }
   bool                can_write_choke() const                 { return m_buffer.reserved_left() >= sizeof_choke; }

--- a/src/protocol/request_list.h
+++ b/src/protocol/request_list.h
@@ -52,7 +52,7 @@ class PeerChunks;
 class Delegator;
 
 struct request_list_constants {
-  static const int bucket_count = 4;
+  static constexpr int bucket_count = 4;
 
   static const torrent::instrumentation_enum instrumentation_added[bucket_count];
   static const torrent::instrumentation_enum instrumentation_moved[bucket_count];
@@ -67,14 +67,14 @@ class RequestList {
 public:
   using queues_type = torrent::queue_buckets<BlockTransfer*, request_list_constants>;
 
-  static const int bucket_queued    = 0;
-  static const int bucket_unordered = 1;
-  static const int bucket_stalled   = 2;
-  static const int bucket_choked    = 3;
+  static constexpr int bucket_queued    = 0;
+  static constexpr int bucket_unordered = 1;
+  static constexpr int bucket_stalled   = 2;
+  static constexpr int bucket_choked    = 3;
 
-  static const int timeout_remove_choked = 6;
-  static const int timeout_choked_received = 60;
-  static const int timeout_process_unordered = 60;
+  static constexpr int timeout_remove_choked = 6;
+  static constexpr int timeout_choked_received = 60;
+  static constexpr int timeout_process_unordered = 60;
 
   RequestList();
   ~RequestList();

--- a/src/torrent/chunk_manager.h
+++ b/src/torrent/chunk_manager.h
@@ -86,8 +86,8 @@ public:
   //
   // The primary user of these functions is ChunkList.
 
-  static const int allocate_revert_log = (1 << 0);
-  static const int allocate_dont_log   = (1 << 1);
+  static constexpr int allocate_revert_log = (1 << 0);
+  static constexpr int allocate_dont_log   = (1 << 1);
 
   bool                allocate(uint32_t size, int flags = 0);
   void                deallocate(uint32_t size, int flags = 0);

--- a/src/torrent/connection_manager.h
+++ b/src/torrent/connection_manager.h
@@ -22,30 +22,30 @@ public:
   using port_type     = uint16_t;
   using priority_type = uint8_t;
 
-  static const priority_type iptos_default     = 0;
-  static const priority_type iptos_lowdelay    = IPTOS_LOWDELAY;
-  static const priority_type iptos_throughput  = IPTOS_THROUGHPUT;
-  static const priority_type iptos_reliability = IPTOS_RELIABILITY;
+  static constexpr priority_type iptos_default     = 0;
+  static constexpr priority_type iptos_lowdelay    = IPTOS_LOWDELAY;
+  static constexpr priority_type iptos_throughput  = IPTOS_THROUGHPUT;
+  static constexpr priority_type iptos_reliability = IPTOS_RELIABILITY;
 
 #if defined IPTOS_MINCOST
-  static const priority_type iptos_mincost     = IPTOS_MINCOST;
+  static constexpr priority_type iptos_mincost     = IPTOS_MINCOST;
 #elif defined IPTOS_LOWCOST
-  static const priority_type iptos_mincost     = IPTOS_LOWCOST;
+  static constexpr priority_type iptos_mincost     = IPTOS_LOWCOST;
 #else
-  static const priority_type iptos_mincost     = iptos_throughput;
+  static constexpr priority_type iptos_mincost     = iptos_throughput;
 #endif
 
-  static const uint32_t encryption_none             = 0;
-  static const uint32_t encryption_allow_incoming   = (1 << 0);
-  static const uint32_t encryption_try_outgoing     = (1 << 1);
-  static const uint32_t encryption_require          = (1 << 2);
-  static const uint32_t encryption_require_RC4      = (1 << 3);
-  static const uint32_t encryption_enable_retry     = (1 << 4);
-  static const uint32_t encryption_prefer_plaintext = (1 << 5);
+  static constexpr uint32_t encryption_none             = 0;
+  static constexpr uint32_t encryption_allow_incoming   = (1 << 0);
+  static constexpr uint32_t encryption_try_outgoing     = (1 << 1);
+  static constexpr uint32_t encryption_require          = (1 << 2);
+  static constexpr uint32_t encryption_require_RC4      = (1 << 3);
+  static constexpr uint32_t encryption_enable_retry     = (1 << 4);
+  static constexpr uint32_t encryption_prefer_plaintext = (1 << 5);
 
   // Internal to libtorrent.
-  static const uint32_t encryption_use_proxy        = (1 << 6);
-  static const uint32_t encryption_retrying         = (1 << 7);
+  static constexpr uint32_t encryption_use_proxy        = (1 << 6);
+  static constexpr uint32_t encryption_retrying         = (1 << 7);
 
   enum {
     handshake_incoming           = 1,

--- a/src/torrent/data/block_failed.h
+++ b/src/torrent/data/block_failed.h
@@ -65,7 +65,7 @@ public:
 
   using base_type::operator[];
 
-  static const uint32_t invalid_index = ~uint32_t();
+  static constexpr uint32_t invalid_index = ~uint32_t();
 
   BlockFailed() = default;
   ~BlockFailed();

--- a/src/torrent/data/block_transfer.h
+++ b/src/torrent/data/block_transfer.h
@@ -12,7 +12,7 @@ namespace torrent {
 
 class LIBTORRENT_EXPORT BlockTransfer {
 public:
-  static const uint32_t invalid_index = ~uint32_t();
+  static constexpr uint32_t invalid_index = ~uint32_t();
 
   using key_type = PeerInfo*;
 

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -12,16 +12,16 @@ public:
 
   using range_type = std::pair<uint32_t, uint32_t>;
 
-  static const int flag_active             = (1 << 0);
-  static const int flag_create_queued      = (1 << 1);
-  static const int flag_resize_queued      = (1 << 2);
-  static const int flag_fallocate          = (1 << 3);
-  static const int flag_previously_created = (1 << 4);
+  static constexpr int flag_active             = (1 << 0);
+  static constexpr int flag_create_queued      = (1 << 1);
+  static constexpr int flag_resize_queued      = (1 << 2);
+  static constexpr int flag_fallocate          = (1 << 3);
+  static constexpr int flag_previously_created = (1 << 4);
 
-  static const int flag_prioritize_first   = (1 << 5);
-  static const int flag_prioritize_last    = (1 << 6);
+  static constexpr int flag_prioritize_first   = (1 << 5);
+  static constexpr int flag_prioritize_last    = (1 << 6);
 
-  static const int flag_attr_padding       = (1 << 7);
+  static constexpr int flag_attr_padding       = (1 << 7);
 
   File() =default;
   ~File();

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -117,8 +117,8 @@ public:
   bool                make_all_paths();
 
 protected:
-  static const int open_no_create        = (1 << 0);
-  static const int open_require_all_open = (1 << 1);
+  static constexpr int open_no_create        = (1 << 0);
+  static constexpr int open_require_all_open = (1 << 1);
 
   void                initialize(uint64_t torrentSize, uint32_t chunkSize) LIBTORRENT_NO_EXPORT;
 

--- a/src/torrent/data/piece.h
+++ b/src/torrent/data/piece.h
@@ -43,7 +43,7 @@ namespace torrent {
 
 class LIBTORRENT_EXPORT Piece {
 public:
-  static const uint32_t invalid_index = ~uint32_t();
+  static constexpr uint32_t invalid_index = ~uint32_t();
 
   Piece()  = default;
   ~Piece() = default;

--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -21,17 +21,17 @@ class download_data;
 
 class LIBTORRENT_EXPORT Download {
 public:
-  static const uint32_t numwanted_diabled = ~uint32_t();
+  static constexpr uint32_t numwanted_diabled = ~uint32_t();
 
   // Start and open flags can be stored in the same integer, same for
   // stop and close flags.
-  static const int open_enable_fallocate = (1 << 0);
+  static constexpr int open_enable_fallocate = (1 << 0);
 
-  static const int start_no_create       = (1 << 1);
-  static const int start_keep_baseline   = (1 << 2);
-  static const int start_skip_tracker    = (1 << 3);
+  static constexpr int start_no_create       = (1 << 1);
+  static constexpr int start_keep_baseline   = (1 << 2);
+  static constexpr int start_skip_tracker    = (1 << 3);
 
-  static const int stop_skip_tracker     = (1 << 0);
+  static constexpr int stop_skip_tracker     = (1 << 0);
 
   Download(DownloadWrapper* d = NULL) : m_ptr(d) {}
 
@@ -95,8 +95,8 @@ public:
   void                set_bitfield(bool allSet);
   void                set_bitfield(uint8_t* first, uint8_t* last);
 
-  static const int update_range_recheck = (1 << 0);
-  static const int update_range_clear   = (1 << 1);
+  static constexpr int update_range_recheck = (1 << 0);
+  static constexpr int update_range_clear   = (1 << 1);
 
   void                update_range(int flags, uint32_t first, uint32_t last);
 

--- a/src/torrent/download/choke_queue.h
+++ b/src/torrent/download/choke_queue.h
@@ -82,13 +82,13 @@ public:
 
   using slot_weight = void (*)(iterator first, iterator last);
 
-  static const int flag_unchoke_all_new = 0x1;
+  static constexpr int flag_unchoke_all_new = 0x1;
 
-  static const uint32_t order_base = (1 << 30);
-  static const uint32_t order_max_size = 4;
-  static const uint32_t weight_size_bytes = order_max_size * sizeof(uint32_t);
+  static constexpr uint32_t order_base = (1 << 30);
+  static constexpr uint32_t order_max_size = 4;
+  static constexpr uint32_t weight_size_bytes = order_max_size * sizeof(uint32_t);
 
-  static const uint32_t unlimited = ~uint32_t();
+  static constexpr uint32_t unlimited = ~uint32_t();
 
   struct heuristics_type {
     slot_weight         slot_choke_weight;

--- a/src/torrent/download/group_entry.h
+++ b/src/torrent/download/group_entry.h
@@ -64,7 +64,7 @@ class group_entry {
 public:
   using container_type = std::vector<weighted_connection>;
 
-  static const uint32_t unlimited = ~uint32_t();
+  static constexpr uint32_t unlimited = ~uint32_t();
 
   uint32_t            size_connections() const  { return m_queued.size() + m_unchoked.size(); }
 

--- a/src/torrent/download_info.h
+++ b/src/torrent/download_info.h
@@ -35,18 +35,18 @@ public:
     STOPPED
   };
 
-  static const int flag_open                = (1 << 0);
-  static const int flag_active              = (1 << 1);
-  static const int flag_accepting_new_peers = (1 << 3);
-  static const int flag_accepting_seeders   = (1 << 4); // Only used during leeching.
-  static const int flag_private             = (1 << 5);
-  static const int flag_meta_download       = (1 << 6);
-  static const int flag_pex_enabled         = (1 << 7);
-  static const int flag_pex_active          = (1 << 8);
+  static constexpr int flag_open                = (1 << 0);
+  static constexpr int flag_active              = (1 << 1);
+  static constexpr int flag_accepting_new_peers = (1 << 3);
+  static constexpr int flag_accepting_seeders   = (1 << 4); // Only used during leeching.
+  static constexpr int flag_private             = (1 << 5);
+  static constexpr int flag_meta_download       = (1 << 6);
+  static constexpr int flag_pex_enabled         = (1 << 7);
+  static constexpr int flag_pex_active          = (1 << 8);
 
-  static const int public_flags = flag_accepting_seeders;
+  static constexpr int public_flags = flag_accepting_seeders;
 
-  static const uint32_t unlimited = ~uint32_t();
+  static constexpr uint32_t unlimited = ~uint32_t();
 
   const std::string&  name() const                                 { return m_name; }
   void                set_name(const std::string& s)               { m_name = s; }

--- a/src/torrent/error.cc
+++ b/src/torrent/error.cc
@@ -40,7 +40,7 @@
 
 namespace torrent {
 
-static const char* errorStrings[e_last + 1] = {
+static const char* const errorStrings[e_last + 1] = {
   "unknown error",                      // e_none
 
   "not BitTorrent protocol",            // eh_not_bittorrent

--- a/src/torrent/error.cc
+++ b/src/torrent/error.cc
@@ -36,11 +36,13 @@
 
 #include "config.h"
 
+#include <array>
+
 #include "error.h"
 
 namespace torrent {
 
-static const char* const errorStrings[e_last + 1] = {
+static constexpr std::array<const char*, e_last + 1> errorStrings{
   "unknown error",                      // e_none
 
   "not BitTorrent protocol",            // eh_not_bittorrent

--- a/src/torrent/hash_string.h
+++ b/src/torrent/hash_string.h
@@ -23,7 +23,7 @@ public:
   using reverse_iterator       = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-  static const size_type size_data = 20;
+  static constexpr size_type size_data = 20;
 
   size_type           size() const                      { return size_data; }
 

--- a/src/torrent/http.h
+++ b/src/torrent/http.h
@@ -22,8 +22,8 @@ class LIBTORRENT_EXPORT Http {
    using signal_void   = std::list<slot_void>;
    using signal_string = std::list<slot_string>;
 
-   static const int flag_delete_self   = 0x1;
-   static const int flag_delete_stream = 0x2;
+   static constexpr int flag_delete_self   = 0x1;
+   static constexpr int flag_delete_stream = 0x2;
 
    Http() = default;
    virtual ~Http();

--- a/src/torrent/object.h
+++ b/src/torrent/object.h
@@ -71,19 +71,19 @@ public:
 
   // Flags in the range of 0xffff0000 may be set by the user, however
   // 0x00ff0000 are reserved for keywords defined by libtorrent.
-  static const uint32_t mask_type     = 0xff;
-  static const uint32_t mask_flags    = ~mask_type;
-  static const uint32_t mask_internal = 0xffff;
-  static const uint32_t mask_public   = ~mask_internal;
+  static constexpr uint32_t mask_type     = 0xff;
+  static constexpr uint32_t mask_flags    = ~mask_type;
+  static constexpr uint32_t mask_internal = 0xffff;
+  static constexpr uint32_t mask_public   = ~mask_internal;
 
-  static const uint32_t flag_unordered    = 0x100;    // bencode dictionary was not sorted
-  static const uint32_t flag_static_data  = 0x010000;  // Object does not change across sessions.
-  static const uint32_t flag_session_data = 0x020000;  // Object changes between sessions.
-  static const uint32_t flag_function     = 0x040000;  // A function object.
-  static const uint32_t flag_function_q1  = 0x080000;  // A quoted function object.
-  static const uint32_t flag_function_q2  = 0x100000;  // A double-quoted function object.
+  static constexpr uint32_t flag_unordered    = 0x100;    // bencode dictionary was not sorted
+  static constexpr uint32_t flag_static_data  = 0x010000;  // Object does not change across sessions.
+  static constexpr uint32_t flag_session_data = 0x020000;  // Object changes between sessions.
+  static constexpr uint32_t flag_function     = 0x040000;  // A function object.
+  static constexpr uint32_t flag_function_q1  = 0x080000;  // A quoted function object.
+  static constexpr uint32_t flag_function_q2  = 0x100000;  // A double-quoted function object.
 
-  static const uint32_t mask_function     = 0x1C0000;  // Mask for function objects.
+  static constexpr uint32_t mask_function     = 0x1C0000;  // Mask for function objects.
 
   enum type_type {
     TYPE_NONE,

--- a/src/torrent/object_static_map.h
+++ b/src/torrent/object_static_map.h
@@ -44,7 +44,7 @@
 namespace torrent {
 
 struct static_map_mapping_type {
-  static const size_t max_key_size = 16;
+  static constexpr size_t max_key_size = 16;
 
   bool        is_end() const { return key[0] == '\0'; }
   static bool is_not_key_char(char c) { return c == '\0' || c == ':' || c == '[' || c == '*'; }
@@ -70,7 +70,7 @@ public:
   typedef mapping_type    key_list_type[tmpl_length];
   typedef entry_type      value_list_type[tmpl_length];
 
-  static const size_t size = tmpl_length;
+  static constexpr size_t size = tmpl_length;
   static const key_list_type keys;
 
   entry_type*         values() { return m_values; }

--- a/src/torrent/peer/client_info.h
+++ b/src/torrent/peer/client_info.h
@@ -57,8 +57,8 @@ public:
     const char*         m_shortDescription;
   };    
 
-  static const uint32_t max_key_size = 2;
-  static const uint32_t max_version_size = 4;
+  static constexpr uint32_t max_key_size = 2;
+  static constexpr uint32_t max_version_size = 4;
 
   id_type             type() const                            { return m_type; }
 

--- a/src/torrent/peer/connection_list.h
+++ b/src/torrent/peer/connection_list.h
@@ -91,10 +91,10 @@ public:
   using base_type::rend;
   
   // Make sure any change here match PeerList's flags.
-  static const int disconnect_available = (1 << 0);
-  static const int disconnect_quick     = (1 << 1);
-  static const int disconnect_unwanted  = (1 << 2);
-  static const int disconnect_delayed   = (1 << 3);
+  static constexpr int disconnect_available = (1 << 0);
+  static constexpr int disconnect_quick     = (1 << 1);
+  static constexpr int disconnect_unwanted  = (1 << 2);
+  static constexpr int disconnect_delayed   = (1 << 3);
 
   ConnectionList(DownloadMain* download);
   ~ConnectionList() = default;

--- a/src/torrent/peer/peer_info.h
+++ b/src/torrent/peer/peer_info.h
@@ -52,15 +52,15 @@ public:
   friend class PeerList;
   friend class ProtocolExtension;
 
-  static const int flag_connected = (1 << 0);
-  static const int flag_incoming  = (1 << 1);
-  static const int flag_handshake = (1 << 2);
-  static const int flag_blocked   = (1 << 3);   // For initial seeding.
-  static const int flag_restart   = (1 << 4);
-  static const int flag_unwanted  = (1 << 5);
-  static const int flag_preferred = (1 << 6);
+  static constexpr int flag_connected = (1 << 0);
+  static constexpr int flag_incoming  = (1 << 1);
+  static constexpr int flag_handshake = (1 << 2);
+  static constexpr int flag_blocked   = (1 << 3);   // For initial seeding.
+  static constexpr int flag_restart   = (1 << 4);
+  static constexpr int flag_unwanted  = (1 << 5);
+  static constexpr int flag_preferred = (1 << 6);
 
-  static const int mask_ip_table = flag_unwanted | flag_preferred;
+  static constexpr int mask_ip_table = flag_unwanted | flag_preferred;
 
   PeerInfo(const sockaddr* address);
   ~PeerInfo();

--- a/src/torrent/peer/peer_list.h
+++ b/src/torrent/peer/peer_list.h
@@ -35,20 +35,20 @@ public:
   using base_type::size;
   using base_type::empty;
 
-  static const int address_available       = (1 << 0);
+  static constexpr int address_available       = (1 << 0);
 
-  static const int connect_incoming        = (1 << 0);
-  static const int connect_keep_handshakes = (1 << 1);
-  static const int connect_filter_recent   = (1 << 2);
+  static constexpr int connect_incoming        = (1 << 0);
+  static constexpr int connect_keep_handshakes = (1 << 1);
+  static constexpr int connect_filter_recent   = (1 << 2);
 
   // Make sure any change here match ConnectionList's flags.
-  static const int disconnect_available    = (1 << 0);
-  static const int disconnect_quick        = (1 << 1);
-  static const int disconnect_unwanted     = (1 << 2);
-  static const int disconnect_set_time     = (1 << 3);
+  static constexpr int disconnect_available    = (1 << 0);
+  static constexpr int disconnect_quick        = (1 << 1);
+  static constexpr int disconnect_unwanted     = (1 << 2);
+  static constexpr int disconnect_set_time     = (1 << 3);
 
-  static const int cull_old                = (1 << 0);
-  static const int cull_keep_interesting   = (1 << 1);
+  static constexpr int cull_old                = (1 << 0);
+  static constexpr int cull_keep_interesting   = (1 << 1);
 
   PeerList();
   ~PeerList();

--- a/src/torrent/poll.h
+++ b/src/torrent/poll.h
@@ -48,8 +48,8 @@ class LIBTORRENT_EXPORT Poll {
 public:
   using slot_poll = std::function<Poll*()>;
 
-  static const int      poll_worker_thread     = 0x1;
-  static const uint32_t flag_waive_global_lock = 0x1;
+  static constexpr int      poll_worker_thread     = 0x1;
+  static constexpr uint32_t flag_waive_global_lock = 0x1;
 
   virtual ~Poll() = default;
 

--- a/src/torrent/poll_kqueue.h
+++ b/src/torrent/poll_kqueue.h
@@ -48,9 +48,9 @@ class LIBTORRENT_EXPORT PollKQueue : public torrent::Poll {
 public:
   using Table = std::vector<std::pair<uint32_t, Event*>>;
 
-  static const uint32_t flag_read  = (1 << 0);
-  static const uint32_t flag_write = (1 << 1);
-  static const uint32_t flag_error = (1 << 2);
+  static constexpr uint32_t flag_read  = (1 << 0);
+  static constexpr uint32_t flag_write = (1 << 1);
+  static constexpr uint32_t flag_error = (1 << 2);
 
   static PollKQueue*   create(int maxOpenSockets);
   virtual ~PollKQueue();

--- a/src/torrent/tracker/tracker_state.h
+++ b/src/torrent/tracker/tracker_state.h
@@ -26,13 +26,13 @@ public:
     EVENT_SCRAPE
   };
 
-  static const int flag_enabled       = 0x1;
-  static const int flag_extra_tracker = 0x2;
-  static const int flag_scrapable     = 0x4;
+  static constexpr int flag_enabled       = 0x1;
+  static constexpr int flag_extra_tracker = 0x2;
+  static constexpr int flag_scrapable     = 0x4;
 
   // TODO: Remove these:
-  // static const int max_flag_size   = 0x10;
-  // static const int mask_base_flags = 0x10 - 1;
+  // static constexpr int max_flag_size   = 0x10;
+  // static constexpr int mask_base_flags = 0x10 - 1;
 
   static constexpr int default_min_interval = 600;
   static constexpr int min_min_interval     = 300;

--- a/src/torrent/tracker_controller.h
+++ b/src/torrent/tracker_controller.h
@@ -28,22 +28,22 @@ public:
   using slot_address_list = std::function<uint32_t(AddressList*)>;
   using slot_tracker      = std::function<void(const tracker::Tracker&)>;
 
-  static const int flag_send_update      = 0x1;
-  static const int flag_send_completed   = 0x2;
-  static const int flag_send_start       = 0x4;
-  static const int flag_send_stop        = 0x8;
+  static constexpr int flag_send_update      = 0x1;
+  static constexpr int flag_send_completed   = 0x2;
+  static constexpr int flag_send_start       = 0x4;
+  static constexpr int flag_send_stop        = 0x8;
 
-  static const int flag_active           = 0x10;
-  static const int flag_requesting       = 0x20;
-  static const int flag_failure_mode     = 0x40;
-  static const int flag_promiscuous_mode = 0x80;
+  static constexpr int flag_active           = 0x10;
+  static constexpr int flag_requesting       = 0x20;
+  static constexpr int flag_failure_mode     = 0x40;
+  static constexpr int flag_promiscuous_mode = 0x80;
 
-  static const int mask_send = flag_send_update | flag_send_start | flag_send_stop | flag_send_completed;
+  static constexpr int mask_send = flag_send_update | flag_send_start | flag_send_stop | flag_send_completed;
 
-  static const int enable_dont_reset_stats = 0x1;
+  static constexpr int enable_dont_reset_stats = 0x1;
 
-  static const int close_disown_stop       = 0x1 << tracker::TrackerState::EVENT_STOPPED;
-  static const int close_disown_completed  = 0x1 << tracker::TrackerState::EVENT_COMPLETED;
+  static constexpr int close_disown_stop       = 0x1 << tracker::TrackerState::EVENT_STOPPED;
+  static constexpr int close_disown_completed  = 0x1 << tracker::TrackerState::EVENT_COMPLETED;
 
   TrackerController(TrackerList* trackers);
   ~TrackerController();

--- a/src/torrent/utils/directory_events.h
+++ b/src/torrent/utils/directory_events.h
@@ -24,9 +24,9 @@ public:
   using wd_list     = std::vector<watch_descriptor>;
   using slot_string = watch_descriptor::slot_string;
 
-  static const int flag_on_added   = 0x1;
-  static const int flag_on_removed = 0x2;
-  static const int flag_on_updated = 0x3;
+  static constexpr int flag_on_added   = 0x1;
+  static constexpr int flag_on_removed = 0x2;
+  static constexpr int flag_on_updated = 0x3;
 
   directory_events() { m_fileDesc = -1; }
   ~directory_events() = default;

--- a/src/torrent/utils/signal_bitfield.h
+++ b/src/torrent/utils/signal_bitfield.h
@@ -16,7 +16,7 @@ public:
   using bitfield_type = uint32_t;
   using slot_type     = std::function<void()>;
 
-  static const unsigned int max_size = 32;
+  static constexpr unsigned int max_size = 32;
 
   signal_bitfield() = default;
 

--- a/src/torrent/utils/thread.h
+++ b/src/torrent/utils/thread.h
@@ -38,11 +38,11 @@ public:
     STATE_INACTIVE
   };
 
-  static const int flag_do_shutdown  = 0x1;
-  static const int flag_did_shutdown = 0x2;
-  static const int flag_polling      = 0x4;
+  static constexpr int flag_do_shutdown  = 0x1;
+  static constexpr int flag_did_shutdown = 0x2;
+  static constexpr int flag_polling      = 0x4;
 
-  static const int flag_main_thread  = 0x10;
+  static constexpr int flag_main_thread  = 0x10;
 
   Thread();
   virtual ~Thread();

--- a/src/torrent/utils/uri_parser.h
+++ b/src/torrent/utils/uri_parser.h
@@ -12,13 +12,11 @@ using uri_resource_list = std::vector<std::string>;
 using uri_query_list    = std::vector<std::string>;
 
 struct uri_base_state {
-  static const int state_empty = 0;
-  static const int state_valid = 1;
-  static const int state_invalid = 2;
+  static constexpr int state_empty = 0;
+  static constexpr int state_valid = 1;
+  static constexpr int state_invalid = 2;
 
-  uri_base_state() : state(state_empty) {}
-
-  int state;
+  int state{state_empty};
 };
 
 struct uri_state : uri_base_state {

--- a/src/tracker/tracker_dht.cc
+++ b/src/tracker/tracker_dht.cc
@@ -18,8 +18,6 @@
 
 namespace torrent {
 
-const char* TrackerDht::states[] = { "Idle", "Searching", "Announcing" };
-
 bool TrackerDht::is_allowed() { return manager->dht_controller()->is_valid(); }
 
 TrackerDht::TrackerDht(const TrackerInfo& info, int flags) :

--- a/src/tracker/tracker_dht.h
+++ b/src/tracker/tracker_dht.h
@@ -1,6 +1,8 @@
 #ifndef LIBTORRENT_TRACKER_TRACKER_DHT_H
 #define LIBTORRENT_TRACKER_TRACKER_DHT_H
 
+#include <array>
+
 #include "net/address_list.h"
 #include "torrent/object.h"
 #include "tracker/tracker_worker.h"
@@ -23,7 +25,7 @@ public:
     state_announcing,
   };
 
-  static const char* states[];
+  static constexpr std::array states{ "Idle", "Searching", "Announcing" };
 
   static bool         is_allowed();
 

--- a/src/tracker/tracker_http.h
+++ b/src/tracker/tracker_http.h
@@ -14,7 +14,7 @@ class Http;
 
 class TrackerHttp : public TrackerWorker {
 public:
-  static const uint32_t http_timeout = 60;
+  static constexpr uint32_t http_timeout = 60;
 
   TrackerHttp(const TrackerInfo& info, int flags = 0);
 

--- a/src/tracker/tracker_udp.h
+++ b/src/tracker/tracker_udp.h
@@ -20,10 +20,10 @@ public:
   using ReadBuffer  = ProtocolBuffer<512>;
   using WriteBuffer = ProtocolBuffer<512>;
 
-  static const uint64_t magic_connection_id = 0x0000041727101980ll;
+  static constexpr uint64_t magic_connection_id = 0x0000041727101980ll;
 
-  static const uint32_t udp_timeout = 30;
-  static const uint32_t udp_tries = 2;
+  static constexpr uint32_t udp_timeout = 30;
+  static constexpr uint32_t udp_tries = 2;
 
   TrackerUdp(const TrackerInfo& info, int flags = 0);
   ~TrackerUdp();


### PR DESCRIPTION
Helps the compiler generate more efficient code.

Surprising that

```
static const
```

and

```
static constexpr
```

differ when normal const variables implicitly promote to constexpr.