### PR TITLE
pkgconfig: fix static linking

### DIFF
--- a/libtorrent.pc.in
+++ b/libtorrent.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: libtorrent
 Description: A BitTorrent library
 Version: @VERSION@
+Requires.private: zlib, libcrypto
 Libs: -L${libdir} -ltorrent
-Libs.Private: -lz
+Libs.private: -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
A link to libcrypto and pthread are missing, which shows up when trying to link a static libtorrent with rtorrent. The latter being an issue with older platforms that don't have pthread stuff in libc.

Annoyingly this is not a full fix. It works correct if rtorrent calls

```
PKG_CHECK_MODULES_STATIC
```

but if libtorrent is built with --disable-shared --enable-static and rtorrent calls

```
PKG_CHECK_MODULES
```

it still fails.

meson handles this difference but not sure how to do so in autotools.

meson -Ddefault_library=static:

```
prefix=/usr/local
includedir=${prefix}/include
libdir=${prefix}/lib64

Name: libtorrent
Description: A BitTorrent client
Version: 0.15.3
Requires: zlib, libcrypto
Libs: -L${libdir} -ltorrent -pthread
Cflags: -I${includedir} -pthread
```

meson -Ddefault_library=shared:

```
prefix=/usr/local
includedir=${prefix}/include
libdir=${prefix}/lib64

Name: libtorrent
Description: A BitTorrent client
Version: 0.15.3
Requires.private: zlib, libcrypto
Libs: -L${libdir} -ltorrent
Libs.private: -pthread
Cflags: -I${includedir}
```