### PR TITLE
remove some delete calls

### DIFF
--- a/src/data/hash_chunk.h
+++ b/src/data/hash_chunk.h
@@ -36,9 +36,6 @@ public:
   uint32_t            remaining();
 
 private:
-  HashChunk(const HashChunk&) = delete;
-  HashChunk& operator=(const HashChunk&) = delete;
-
   inline uint32_t     remaining_part(Chunk::iterator itr, uint32_t pos);
   uint32_t            perform_part(Chunk::iterator itr, uint32_t length);
 

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -265,9 +265,6 @@ public:
   DhtTransaction*             transaction()             { return m_transaction; }
 
 private:
-  DhtTransactionPacket(const DhtTransactionPacket&) = delete;
-  DhtTransactionPacket& operator=(const DhtTransactionPacket&) = delete;
-
   void                        build_buffer(const DhtMessage& data);
 
   rak::socket_address         m_sa;

--- a/src/download/download_wrapper.h
+++ b/src/download/download_wrapper.h
@@ -21,8 +21,6 @@ class DownloadWrapper {
 public:
   DownloadWrapper();
   ~DownloadWrapper();
-  DownloadWrapper(const DownloadWrapper&) = delete;
-  DownloadWrapper& operator=(const DownloadWrapper&) = delete;
 
   DownloadInfo*       info()                                  { return m_main->info(); }
   download_data*      data()                                  { return m_main->file_list()->mutable_data(); }

--- a/src/protocol/handshake.h
+++ b/src/protocol/handshake.h
@@ -62,8 +62,6 @@ public:
 
   Handshake(SocketFd fd, HandshakeManager* m, int encryption_options);
   ~Handshake() override;
-  Handshake(const Handshake&) = delete;
-  Handshake& operator=(const Handshake&) = delete;
 
   const char*         type_name() const override    { return "handshake"; }
 

--- a/src/protocol/initial_seed.h
+++ b/src/protocol/initial_seed.h
@@ -61,9 +61,6 @@ public:
   bool                should_upload(uint32_t index);
 
 private:
-  InitialSeeding(const InitialSeeding&) = delete;
-  InitialSeeding& operator=(const InitialSeeding&) = delete;
-
   static PeerInfo* const chunk_unsent;  // Chunk never sent to anyone.
   static PeerInfo* const chunk_unknown; // Peer has chunk, we don't know who we sent it to.
   static PeerInfo* const chunk_done;    // Chunk properly distributed by peer.

--- a/src/torrent/peer/peer_list.h
+++ b/src/torrent/peer/peer_list.h
@@ -52,8 +52,6 @@ public:
 
   PeerList();
   ~PeerList();
-  PeerList(const PeerList&) = delete;
-  PeerList& operator=(const PeerList&) = delete;
 
   PeerInfo*           insert_address(const sockaddr* address, int flags);
 

--- a/src/torrent/poll.h
+++ b/src/torrent/poll.h
@@ -57,9 +57,6 @@ public:
 private:
   Poll() = default;
 
-  Poll(const Poll&) = delete;
-  Poll& operator=(const Poll&) = delete;
-
   int                 poll(int msec);
   unsigned int        process();
 

--- a/src/torrent/tracker/manager.h
+++ b/src/torrent/tracker/manager.h
@@ -47,9 +47,6 @@ protected:
   void                remove_events(torrent::TrackerWorker* tracker_worker);
 
 private:
-  Manager(const Manager&) = delete;
-  Manager& operator=(const Manager&) = delete;
-
   utils::Thread*      m_main_thread{nullptr};
   utils::Thread*      m_tracker_thread{nullptr};
   unsigned int        m_signal_process_events{~0u};

--- a/src/tracker/tracker_worker.h
+++ b/src/tracker/tracker_worker.h
@@ -97,9 +97,6 @@ protected:
   std::function<TrackerParameters()> m_slot_parameters;
 
 private:
-  TrackerWorker(const TrackerWorker&) = delete;
-  TrackerWorker& operator=(const TrackerWorker&) = delete;
-
   mutable std::mutex    m_mutex;
 
   TrackerInfo           m_info;

--- a/src/utils/diffie_hellman.h
+++ b/src/utils/diffie_hellman.h
@@ -16,8 +16,6 @@ public:
   DiffieHellman(const unsigned char prime[], int primeLength,
                 const unsigned char generator[], int generatorLength);
   ~DiffieHellman() = default;
-  DiffieHellman(const DiffieHellman&) = delete;
-  DiffieHellman& operator=(const DiffieHellman&) = delete;
 
   bool         is_valid() const;
 

--- a/src/utils/signal_interrupt.h
+++ b/src/utils/signal_interrupt.h
@@ -25,7 +25,8 @@ public:
   void                event_error();
 
 private:
-  SignalInterrupt() = delete;
+  SignalInterrupt(const SignalInterrupt&) = delete;
+  SignalInterrupt& operator=(const SignalInterrupt&) = delete;
   SignalInterrupt(int fd);
 
   SignalInterrupt*    m_other;

--- a/test/helpers/progress_listener.h
+++ b/test/helpers/progress_listener.h
@@ -17,7 +17,8 @@ typedef std::vector<failure_type> failure_list_type;
 
 class progress_listener : public CppUnit::TestListener {
 public:
-  progress_listener() : m_last_test_failed(false) {}
+  progress_listener() = default;
+  ~progress_listener() override = default;
 
   void startTest(CppUnit::Test *test) override;
   void addFailure(const CppUnit::TestFailure &failure) override;
@@ -36,12 +37,12 @@ public:
   failure_list_type&& move_failures() { return std::move(m_failures); }
 
 private:
-  progress_listener(const progress_listener& rhs) = delete;
-  void operator =(const progress_listener& rhs) = delete;
+  progress_listener(const progress_listener&) = delete;
+  progress_listener& operator=(const progress_listener&) = delete;
 
   test_list_type    m_test_path;
   failure_list_type m_failures;
-  bool              m_last_test_failed;
+  bool              m_last_test_failed{};
 
   torrent::log_buffer_ptr m_current_log_buffer;
 };

--- a/test/protocol/test_request_list.cc
+++ b/test/protocol/test_request_list.cc
@@ -43,6 +43,9 @@ struct RequestListGuard {
     request_list->delegator()->transfer_list()->clear();
   }
 
+  RequestListGuard(const RequestListGuard&) = delete;
+  RequestListGuard& operator=(const RequestListGuard&) = delete;
+
   bool                  completed{false};
   torrent::RequestList* request_list;
 };


### PR DESCRIPTION
unique_ptr being a member of a class effectively deletes its copy operations.