### PR TITLE
clang-tidy: test: use static

### DIFF
--- a/test/data/test_chunk_list.h
+++ b/test/data/test_chunk_list.h
@@ -10,9 +10,9 @@ class test_chunk_list : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_get_release();
-  void test_blocking();
+  static void test_basic();
+  static void test_get_release();
+  static void test_blocking();
 };
 
 #include "data/chunk_list.h"

--- a/test/data/test_hash_check_queue.h
+++ b/test/data/test_hash_check_queue.h
@@ -24,11 +24,11 @@ public:
   void setUp();
   void tearDown();
 
-  void test_single();
-  void test_multiple();
-  void test_erase();
+  static void test_single();
+  static void test_multiple();
+  static void test_erase();
 
-  void test_thread_interrupt();
+  static void test_thread_interrupt();
 };
 
 typedef std::map<int, torrent::HashString> done_chunks_type;

--- a/test/data/test_hash_queue.h
+++ b/test/data/test_hash_queue.h
@@ -14,9 +14,9 @@ public:
   void setUp();
   void tearDown();
 
-  void test_single();
-  void test_multiple();
-  void test_erase();
-  void test_erase_stress();
+  static void test_single();
+  static void test_multiple();
+  static void test_erase();
+  static void test_erase_stress();
 };
 

--- a/test/net/test_socket_listen.h
+++ b/test/net/test_socket_listen.h
@@ -24,21 +24,21 @@ class test_socket_listen : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
+  static void test_basic();
 
-  void test_open_error();
-  void test_open_sap();
-  void test_open_sap_error();
-  void test_open_flags();
-  void test_open_flags_error();
+  static void test_open_error();
+  static void test_open_sap();
+  static void test_open_sap_error();
+  static void test_open_flags();
+  static void test_open_flags_error();
 
-  void test_open_port_single();
-  void test_open_port_single_error();
-  void test_open_port_range();
-  void test_open_port_range_error();
+  static void test_open_port_single();
+  static void test_open_port_single_error();
+  static void test_open_port_range();
+  static void test_open_port_range_error();
 
-  void test_open_sequential();
-  void test_open_randomize();
+  static void test_open_sequential();
+  static void test_open_randomize();
 
-  void test_accept();
+  static void test_accept();
 };

--- a/test/protocol/test_request_list.h
+++ b/test/protocol/test_request_list.h
@@ -18,12 +18,12 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_basic();
+  static void test_basic();
 
-  void test_single_request();
-  void test_single_canceled();
+  static void test_single_request();
+  static void test_single_canceled();
 
-  void test_choke_normal();
-  void test_choke_unchoke_discard();
-  void test_choke_unchoke_transfer();
+  static void test_choke_normal();
+  static void test_choke_unchoke_discard();
+  static void test_choke_unchoke_transfer();
 };

--- a/test/rak/allocators_test.h
+++ b/test/rak/allocators_test.h
@@ -15,5 +15,5 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void testAlignment();
+  static void testAlignment();
 };

--- a/test/rak/ranges_test.h
+++ b/test/rak/ranges_test.h
@@ -15,8 +15,8 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_basic();
-  void test_intersect();
+  static void test_basic();
+  static void test_intersect();
 
-  void test_create_union();
+  static void test_create_union();
 };

--- a/test/torrent/net/test_address_info.h
+++ b/test/torrent/net/test_address_info.h
@@ -13,7 +13,7 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_basic();
-  void test_numericserv();
-  void test_helpers();
+  static void test_basic();
+  static void test_numericserv();
+  static void test_helpers();
 };

--- a/test/torrent/net/test_fd.h
+++ b/test/torrent/net/test_fd.h
@@ -8,5 +8,5 @@ class test_fd : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_valid_flags();
+  static void test_valid_flags();
 };

--- a/test/torrent/net/test_socket_address.h
+++ b/test/torrent/net/test_socket_address.h
@@ -25,19 +25,19 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_sa_is_any();
-  void test_sa_is_broadcast();
+  static void test_sa_is_any();
+  static void test_sa_is_broadcast();
 
-  void test_make();
+  static void test_make();
 
-  void test_sin_from_sa();
-  void test_sin6_from_sa();
+  static void test_sin_from_sa();
+  static void test_sin6_from_sa();
 
-  void test_sa_equal();
-  void test_sa_equal_addr();
-  void test_sa_copy();
-  void test_sa_copy_addr();
+  static void test_sa_equal();
+  static void test_sa_equal_addr();
+  static void test_sa_copy();
+  static void test_sa_copy_addr();
 
-  void test_sa_from_v4mapped();
-  void test_sa_to_v4mapped();
+  static void test_sa_from_v4mapped();
+  static void test_sa_to_v4mapped();
 };

--- a/test/torrent/object_static_map_test.h
+++ b/test/torrent/object_static_map_test.h
@@ -25,23 +25,23 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_basics();
-  void test_write();
+  static void test_basics();
+  static void test_write();
 
-  void test_read();
+  static void test_read();
 
-  void test_read_extensions();
+  static void test_read_extensions();
 
   // Proper unit tests:
-  void test_read_empty();
-  void test_read_single();
-  void test_read_single_raw();
-  void test_read_raw_types();
-  void test_read_multiple();
-  void test_read_dict();
+  static void test_read_empty();
+  static void test_read_single();
+  static void test_read_single_raw();
+  static void test_read_raw_types();
+  static void test_read_multiple();
+  static void test_read_dict();
 
-  void test_write_empty();
-  void test_write_single();
-  void test_write_multiple();
+  static void test_write_empty();
+  static void test_write_single();
+  static void test_write_multiple();
 };
 

--- a/test/torrent/object_stream_test.h
+++ b/test/torrent/object_stream_test.h
@@ -19,16 +19,16 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void testInputOrdered();
-  void testInputNullKey();
-  void testOutputMask();
-  void testBuffer();
+  static void testInputOrdered();
+  static void testInputNullKey();
+  static void testOutputMask();
+  static void testBuffer();
 
-  void testReadBencodeC();
+  static void testReadBencodeC();
 
-  void test_read_skip();
-  void test_read_skip_invalid();
+  static void test_read_skip();
+  static void test_read_skip_invalid();
 
-  void test_write();
+  static void test_write();
 };
 

--- a/test/torrent/object_test.h
+++ b/test/torrent/object_test.h
@@ -15,12 +15,12 @@ public:
   void setUp() {}
   void tearDown() {}
 
-  void test_basic();
-  void test_flags();
-  void test_merge();
+  static void test_basic();
+  static void test_flags();
+  static void test_merge();
 
-  void test_swap_and_move();
+  static void test_swap_and_move();
 
-  void test_create_normal();
+  static void test_create_normal();
 };
 

--- a/test/torrent/test_http.h
+++ b/test/torrent/test_http.h
@@ -13,11 +13,11 @@ class test_http : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_done();
-  void test_failure();
+  static void test_basic();
+  static void test_done();
+  static void test_failure();
 
-  void test_delete_on_done();
-  void test_delete_on_failure();
+  static void test_delete_on_done();
+  static void test_delete_on_failure();
 };
 

--- a/test/torrent/test_tracker_controller.h
+++ b/test/torrent/test_tracker_controller.h
@@ -38,34 +38,34 @@ public:
   void setUp();
   void tearDown();
 
-  void test_basic();
-  void test_enable();
-  void test_disable();
-  void test_requesting();
-  void test_timeout();
+  static void test_basic();
+  static void test_enable();
+  static void test_disable();
+  static void test_requesting();
+  static void test_timeout();
 
-  void test_single_success();
-  void test_single_failure();
-  void test_single_disable();
+  static void test_single_success();
+  static void test_single_failure();
+  static void test_single_disable();
 
-  void test_send_start();
-  void test_send_stop_normal();
-  void test_send_completed_normal();
-  void test_send_update_normal();
-  void test_send_update_failure();
-  void test_send_task_timeout();
-  void test_send_close_on_enable();
+  static void test_send_start();
+  static void test_send_stop_normal();
+  static void test_send_completed_normal();
+  static void test_send_update_normal();
+  static void test_send_update_failure();
+  static void test_send_task_timeout();
+  static void test_send_close_on_enable();
 
-  void test_multiple_success();
-  void test_multiple_failure();
-  void test_multiple_cycle();
-  void test_multiple_cycle_second_group();
-  void test_multiple_send_stop();
-  void test_multiple_send_update();
+  static void test_multiple_success();
+  static void test_multiple_failure();
+  static void test_multiple_cycle();
+  static void test_multiple_cycle_second_group();
+  static void test_multiple_send_stop();
+  static void test_multiple_send_update();
 
-  void test_timeout_lacking_usable();
-  void test_disable_tracker();
-  void test_new_peers();
+  static void test_timeout_lacking_usable();
+  static void test_disable_tracker();
+  static void test_new_peers();
 };
 
 #define TRACKER_CONTROLLER_SETUP()                                      \

--- a/test/torrent/test_tracker_controller_features.h
+++ b/test/torrent/test_tracker_controller_features.h
@@ -21,14 +21,14 @@ public:
   void setUp();
   void tearDown();
 
-  void test_requesting_basic();
-  void test_requesting_timeout();
-  void test_promiscious_timeout();
-  void test_promiscious_failed();
+  static void test_requesting_basic();
+  static void test_requesting_timeout();
+  static void test_promiscious_timeout();
+  static void test_promiscious_failed();
 
-  void test_scrape_basic();
-  void test_scrape_priority();
+  static void test_scrape_basic();
+  static void test_scrape_priority();
 
-  void test_groups_requesting();
-  void test_groups_scrape();
+  static void test_groups_requesting();
+  static void test_groups_scrape();
 };

--- a/test/torrent/test_tracker_controller_requesting.h
+++ b/test/torrent/test_tracker_controller_requesting.h
@@ -25,20 +25,20 @@ public:
   void setUp();
   void tearDown();
 
-  void test_hammering_basic_success();
-  void test_hammering_basic_success_long_timeout();
-  void test_hammering_basic_success_short_timeout();
-  void test_hammering_basic_failure();
-  void test_hammering_basic_failure_long_timeout();
-  void test_hammering_basic_failure_short_timeout();
+  static void test_hammering_basic_success();
+  static void test_hammering_basic_success_long_timeout();
+  static void test_hammering_basic_success_short_timeout();
+  static void test_hammering_basic_failure();
+  static void test_hammering_basic_failure_long_timeout();
+  static void test_hammering_basic_failure_short_timeout();
 
-  void test_hammering_multi_success();
-  void test_hammering_multi_success_long_timeout();
-  void test_hammering_multi_success_short_timeout();
-  void test_hammering_multi_failure();
-  void test_hammering_multi_failure_long_timeout();
-  void test_hammering_multi_failure_short_timeout();
+  static void test_hammering_multi_success();
+  static void test_hammering_multi_success_long_timeout();
+  static void test_hammering_multi_success_short_timeout();
+  static void test_hammering_multi_failure();
+  static void test_hammering_multi_failure_long_timeout();
+  static void test_hammering_multi_failure_short_timeout();
 
-  void do_test_hammering_basic(bool success1, bool success2, bool success3, uint32_t min_interval = 0);
-  void do_test_hammering_multi3(bool success1, bool success2, bool success3, uint32_t min_interval = 0);
+  static void do_test_hammering_basic(bool success1, bool success2, bool success3, uint32_t min_interval = 0);
+  static void do_test_hammering_multi3(bool success1, bool success2, bool success3, uint32_t min_interval = 0);
 };

--- a/test/torrent/test_tracker_list.h
+++ b/test/torrent/test_tracker_list.h
@@ -30,24 +30,24 @@ public:
   void setUp() {}
   void tearDown();
 
-  void test_basic();
-  void test_enable();
-  void test_close();
+  static void test_basic();
+  static void test_enable();
+  static void test_close();
 
-  void test_tracker_flags();
-  void test_find_url();
-  void test_can_scrape();
+  static void test_tracker_flags();
+  static void test_find_url();
+  static void test_can_scrape();
 
-  void test_single_success();
-  void test_single_failure();
-  void test_single_closing();
+  static void test_single_success();
+  static void test_single_failure();
+  static void test_single_closing();
 
-  void test_multiple_success();
+  static void test_multiple_success();
 
-  void test_scrape_success();
-  void test_scrape_failure();
+  static void test_scrape_success();
+  static void test_scrape_failure();
 
-  void test_has_active();
+  static void test_has_active();
 };
 
 bool check_has_active_in_group(const torrent::TrackerList* tracker_list, const char* states, bool scrape);

--- a/test/torrent/test_tracker_list_features.h
+++ b/test/torrent/test_tracker_list_features.h
@@ -17,11 +17,11 @@ public:
   void setUp();
   void tearDown();
 
-  void test_new_peers();
-  void test_has_active();
-  void test_find_next_to_request();
-  void test_find_next_to_request_groups();
-  void test_count_active();
+  static void test_new_peers();
+  static void test_has_active();
+  static void test_find_next_to_request();
+  static void test_find_next_to_request_groups();
+  static void test_count_active();
 
-  void test_request_safeguard();
+  static void test_request_safeguard();
 };

--- a/test/torrent/test_tracker_timeout.h
+++ b/test/torrent/test_tracker_timeout.h
@@ -13,9 +13,9 @@ class test_tracker_timeout : public test_fixture {
 public:
   void setUp();
 
-  void test_set_timeout();
+  static void test_set_timeout();
 
-  void test_timeout_tracker();
-  void test_timeout_update();
-  void test_timeout_requesting();
+  static void test_timeout_tracker();
+  static void test_timeout_update();
+  static void test_timeout_requesting();
 };

--- a/test/torrent/utils/test_extents.h
+++ b/test/torrent/utils/test_extents.h
@@ -6,5 +6,5 @@ class test_extents : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
+  static void test_basic();
 };

--- a/test/torrent/utils/test_log.h
+++ b/test/torrent/utils/test_log.h
@@ -15,11 +15,11 @@ public:
   void setUp();
   void tearDown();
 
-  void test_basic();
-  void test_output_open();
+  static void test_basic();
+  static void test_output_open();
 
-  void test_print();
-  void test_children();
-  void test_file_output();
-  void test_file_output_append();
+  static void test_print();
+  static void test_children();
+  static void test_file_output();
+  static void test_file_output_append();
 };

--- a/test/torrent/utils/test_log_buffer.h
+++ b/test/torrent/utils/test_log_buffer.h
@@ -7,6 +7,6 @@ class test_log_buffer : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_timestamps();
+  static void test_basic();
+  static void test_timestamps();
 };

--- a/test/torrent/utils/test_option_strings.h
+++ b/test/torrent/utils/test_option_strings.h
@@ -6,5 +6,5 @@ class test_option_strings : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_entries();
+  static void test_entries();
 };

--- a/test/torrent/utils/test_queue_buckets.h
+++ b/test/torrent/utils/test_queue_buckets.h
@@ -13,10 +13,10 @@ class test_queue_buckets : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_erase();
-  void test_find();
+  static void test_basic();
+  static void test_erase();
+  static void test_find();
 
-  void test_destroy_range();
-  void test_move_range();
+  static void test_destroy_range();
+  static void test_move_range();
 };

--- a/test/torrent/utils/test_signal_bitfield.h
+++ b/test/torrent/utils/test_signal_bitfield.h
@@ -12,9 +12,9 @@ class test_signal_bitfield : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_single();
-  void test_multiple();
+  static void test_basic();
+  static void test_single();
+  static void test_multiple();
 
-  void test_threaded();
+  static void test_threaded();
 };

--- a/test/torrent/utils/test_signal_interrupt.h
+++ b/test/torrent/utils/test_signal_interrupt.h
@@ -14,10 +14,10 @@ class TestSignalInterrupt : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_thread_interrupt();
-  void test_latency();
-  void test_hammer();
+  static void test_basic();
+  static void test_thread_interrupt();
+  static void test_latency();
+  static void test_hammer();
 };
 
 #endif // TEST_TORRENT_UTILS_SIGNAL_INTERRUPT_H

--- a/test/torrent/utils/test_thread_base.h
+++ b/test/torrent/utils/test_thread_base.h
@@ -12,10 +12,10 @@ class test_thread_base : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_lifecycle();
+  static void test_basic();
+  static void test_lifecycle();
 
-  void test_interrupt();
-  void test_interrupt_legacy();
-  void test_stop();
+  static void test_interrupt();
+  static void test_interrupt_legacy();
+  static void test_stop();
 };

--- a/test/torrent/utils/test_uri_parser.h
+++ b/test/torrent/utils/test_uri_parser.h
@@ -10,7 +10,7 @@ class test_uri_parser : public test_fixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void test_basic();
-  void test_basic_magnet();
-  void test_query_magnet();
+  static void test_basic();
+  static void test_basic_magnet();
+  static void test_query_magnet();
 };


### PR DESCRIPTION
Found with readability-convert-member-functions-to-static