### PR TITLE
fix compilation with g++7

### DIFF
--- a/test/helpers/tracker_test.cc
+++ b/test/helpers/tracker_test.cc
@@ -18,9 +18,9 @@ TrackerTest::new_tracker([[maybe_unused]] torrent::TrackerList* parent, const st
     // .info_hash = m_info->hash(),
     // .obfuscated_hash = m_info->hash_obfuscated(),
     // .local_id = m_info->local_id(),
-    .url = url,
     // .key = m_key
   };
+  tracker_info.url = url;
 
   return torrent::tracker::Tracker(std::make_shared<TrackerTest>(tracker_info, flags));
 }


### PR DESCRIPTION
Designated initializers are a feature of C++20, not 17. Also fixes such warnings on Clang.

Current CI tests a minimum of GCC 8, which supports C++20 (7 does not). GCC 8 also supports designated initializers.