### PR TITLE
fix compilation with llvm's libc++

### DIFF
--- a/src/utils/signal_interrupt.cc
+++ b/src/utils/signal_interrupt.cc
@@ -2,6 +2,8 @@
 
 #include "utils/signal_interrupt.h"
 
+#include <cerrno>
+
 #include <fcntl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Missing header for errno.