### PR TITLE
get rid of various accessor typedefs

### DIFF
--- a/src/dht/dht_hash_map.h
+++ b/src/dht/dht_hash_map.h
@@ -120,19 +120,6 @@ public:
 };
 
 class DhtTrackerList : public std::unordered_map<HashString, DhtTracker*, hashstring_hash> {
-public:
-  using base_type = std::unordered_map<HashString, DhtTracker*, hashstring_hash>;
-
-  template<typename T>
-  struct accessor_wrapper : public T {
-    accessor_wrapper(const T& itr) : T(itr) { }
-
-    const HashString&    id() const       { return (**this).first; }
-    DhtTracker*          tracker() const  { return (**this).second; }
-  };
-
-  using const_accessor = accessor_wrapper<const_iterator>;
-  using accessor       = accessor_wrapper<iterator>;
 };
 
 inline

--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -66,11 +66,11 @@ DhtRouter::DhtRouter(const Object& cache, const rak::socket_address* sa) :
 
     LT_LOG_THIS("adding nodes (size:%zu)", nodes.size());
 
-    for (const auto& node : nodes) {
-      if (node.first.length() != HashString::size_data)
+    for (const auto& [id, node] : nodes) {
+      if (id.length() != HashString::size_data)
         throw bencode_error("Loading cache: Invalid node hash.");
 
-      add_node_to_bucket(m_nodes.add_node(new DhtNode(node.first, node.second)));
+      add_node_to_bucket(m_nodes.add_node(new DhtNode(id, node)));
     }
   }
 
@@ -136,20 +136,20 @@ DhtRouter::cancel_announce(const HashString* info_hash, const TrackerDht* tracke
 
 DhtTracker*
 DhtRouter::get_tracker(const HashString& hash, bool create) {
-  DhtTrackerList::accessor itr = m_trackers.find(hash);
+  auto itr = m_trackers.find(hash);
 
   if (itr != m_trackers.end())
-    return itr.tracker();
+    return itr->second;
 
   if (!create)
     return NULL;
 
-  std::pair<DhtTrackerList::accessor, bool> res = m_trackers.emplace(hash, new DhtTracker());
+  auto [tr, ins] = m_trackers.emplace(hash, new DhtTracker());
 
-  if (!res.second)
+  if (!ins)
     throw internal_error("DhtRouter::get_tracker did not actually insert tracker.");
 
-  return res.first.tracker();
+  return tr->second;
 }
 
 bool
@@ -318,9 +318,9 @@ DhtRouter::store_cache(Object* container) const {
 
   // Insert all nodes.
   Object& nodes = container->insert_key("nodes", Object::create_map());
-  for (DhtNodeList::const_accessor itr = m_nodes.begin(); itr != m_nodes.end(); ++itr) {
-    if (!itr.node()->is_bad())
-      itr.node()->store_cache(&nodes.insert_key(itr.id().str(), Object::create_map()));
+  for (const auto& [id, node] : m_nodes) {
+    if (!node->is_bad())
+      node->store_cache(&nodes.insert_key(id->str(), Object::create_map()));
   }
 
   // Insert contacts, if we have any.
@@ -361,8 +361,8 @@ DhtRouter::get_statistics() const {
   stats.max_peers        = 0;
   stats.num_trackers     = m_trackers.size();
 
-  for (DhtTrackerList::const_accessor itr = m_trackers.begin(); itr != m_trackers.end(); ++itr) {
-    unsigned int peers = itr.tracker()->size();
+  for (const auto& [_, tracker] : m_trackers) {
+    unsigned int peers = tracker->size();
     stats.num_peers += peers;
     stats.max_peers = std::max(peers, stats.max_peers);
   }
@@ -418,18 +418,18 @@ DhtRouter::receive_timeout() {
   // bad nodes.
 
   // Update nodes.
-  for (DhtNodeList::accessor itr = m_nodes.begin(); itr != m_nodes.end(); ++itr) {
-    if (!itr.node()->bucket())
+  for (const auto& [id, node] : m_nodes) {
+    if (!node->bucket())
       throw internal_error("DhtRouter::receive_timeout has node without bucket.");
 
-    itr.node()->update();
+    node->update();
 
     // Try contacting nodes we haven't received anything from for a while.
     // Don't contact repeatedly unresponsive nodes; we keep them in case they
     // do send a query, until we find a better node. However, give it a last
     // chance just before deleting it.
-    if (itr.node()->is_questionable() && (!itr.node()->is_bad() || itr.node()->age() >= timeout_remove_node))
-      m_server.ping(itr.node()->id(), itr.node()->address());
+    if (node->is_questionable() && (!node->is_bad() || node->age() >= timeout_remove_node))
+      m_server.ping(node->id(), node->address());
   }
 
   // If bucket isn't full yet or hasn't received replies/queries from
@@ -442,16 +442,16 @@ DhtRouter::receive_timeout() {
   }
 
   // Remove old peers and empty torrents from the tracker.
-  for (DhtTrackerList::accessor itr = m_trackers.begin(); itr != m_trackers.end(); ) {
-    itr.tracker()->prune(timeout_peer_announce);
+  for (auto itr = m_trackers.begin(); itr != m_trackers.end();) {
+    auto tracker = itr->second;
+    tracker->prune(timeout_peer_announce);
 
-    if (itr.tracker()->empty()) {
-      delete itr.tracker();
-      m_trackers.erase(itr++);
-
-    } else {
-      ++itr;
+    if (tracker->empty()) {
+      delete tracker;
+      itr = m_trackers.erase(itr);
+      continue;
     }
+    ++itr;
   }
 
   m_server.update();
@@ -491,11 +491,11 @@ DhtRouter::token_valid(raw_string token, const rak::socket_address* sa) {
 
 DhtNode*
 DhtRouter::find_node(const rak::socket_address* sa) {
-  for (DhtNodeList::accessor itr = m_nodes.begin(); itr != m_nodes.end(); ++itr)
-    if (itr.node()->address()->sa_inet()->address_n() == sa->sa_inet()->address_n())
-      return itr.node();
+  for (const auto& [id, node] : m_nodes)
+    if (node->address()->sa_inet()->address_n() == sa->sa_inet()->address_n())
+      return node;
 
-  return NULL;
+  return nullptr;
 }
 
 DhtRouter::DhtBucketList::iterator

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -184,9 +184,11 @@ void
 DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
   auto search = new DhtSearch(target, contacts);
 
-  DhtSearch::const_accessor n;
-  while ((n = search->get_contact()) != search->end())
+  auto n = search->get_contact();
+  while (n != search->end()) {
     add_transaction(new DhtTransactionFindNode(n), packet_prio_low);
+    n = search->get_contact();
+  }
 
   // This shouldn't happen, it means we had no contactable nodes at all.
   if (!search->start())
@@ -196,10 +198,12 @@ DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
 void
 DhtServer::announce(const DhtBucket& contacts, const HashString& infoHash, TrackerDht* tracker) {
   auto announce = new DhtAnnounce(infoHash, tracker, contacts);
+  auto n        = announce->get_contact();
 
-  DhtSearch::const_accessor n;
-  while ((n = announce->get_contact()) != announce->end())
+  while (n != announce->end()) {
     add_transaction(new DhtTransactionFindNode(n), packet_prio_high);
+    n = announce->get_contact();
+  }
 
   // This can only happen if all nodes we know are bad.
   if (!announce->start())
@@ -445,9 +449,11 @@ DhtServer::find_node_next(DhtTransactionSearch* transaction) {
   if (transaction->search()->is_announce())
     priority = packet_prio_high;
 
-  DhtSearch::const_accessor node;
-  while ((node = transaction->search()->get_contact()) != transaction->search()->end())
+  auto node = transaction->search()->get_contact();
+  while (node != transaction->search()->end()) {
     add_transaction(new DhtTransactionFindNode(node), priority);
+    node = transaction->search()->get_contact();
+  }
 
   if (!transaction->search()->is_announce())
     return;

--- a/src/dht/dht_transaction.cc
+++ b/src/dht/dht_transaction.cc
@@ -26,8 +26,8 @@ DhtSearch::~DhtSearch() {
   assert(!m_pending && "DhtSearch::~DhtSearch called with pending transactions.");
   assert(m_concurrency == 3 && "DhtSearch::~DhtSearch called with invalid concurrency limit.");
 
-  for (accessor itr = begin(); itr != end(); ++itr)
-    delete itr.node();
+  for (auto& [node, _] : *this)
+    delete node;
 }
 
 bool


### PR DESCRIPTION
These were useful with pre C++17. But now there's auto and structured bindings.