### PR TITLE
tracker_test: change constructor to match base

### DIFF
--- a/test/helpers/tracker_test.cc
+++ b/test/helpers/tracker_test.cc
@@ -22,7 +22,7 @@ TrackerTest::new_tracker([[maybe_unused]] torrent::TrackerList* parent, const st
   };
   tracker_info.url = url;
 
-  return torrent::tracker::Tracker(std::make_shared<TrackerTest>(tracker_info, flags));
+  return torrent::tracker::Tracker(std::make_shared<TrackerTest>(std::move(tracker_info), flags));
 }
 
 void

--- a/test/helpers/tracker_test.h
+++ b/test/helpers/tracker_test.h
@@ -10,7 +10,7 @@ public:
   static const int flag_scrape_on_success = 0x20;
 
   // TODO: Clean up tracker related enums.
-  TrackerTest(const torrent::TrackerInfo& info, int flags = torrent::tracker::TrackerState::flag_enabled);
+  TrackerTest(torrent::TrackerInfo info, int flags = torrent::tracker::TrackerState::flag_enabled);
 
   bool                is_busy() const override { return m_busy; }
   bool                is_open() const          { return m_open; }
@@ -60,8 +60,8 @@ private:
 };
 
 inline
-TrackerTest::TrackerTest(const torrent::TrackerInfo& info, int flags) :
-  torrent::TrackerWorker(info, flags) {
+TrackerTest::TrackerTest(torrent::TrackerInfo info, int flags) :
+  torrent::TrackerWorker(std::move(info), flags) {
 
   state().m_flags |= flag_close_on_done;
 }


### PR DESCRIPTION
Allows using std::move.