### PR TITLE
resolver: some cleanups

### DIFF
--- a/src/torrent/net/resolver.cc
+++ b/src/torrent/net/resolver.cc
@@ -21,9 +21,9 @@ Resolver::init() {
 
 void
 Resolver::resolve_both(void* requester, const std::string& hostname, int family, both_callback&& callback) {
-  auto cb = [this, requester, hostname, family, callback = std::move(callback)] {
-    auto fn = [this, requester, callback = std::move(callback)](sin_shared_ptr sin, sin6_shared_ptr sin6, int err) {
-      m_thread->callback(requester, std::bind(std::move(callback), sin, sin6, err));
+  auto cb = [this, requester, hostname, family, callback = std::move(callback)]() mutable {
+    auto fn = [this, requester, callback = std::move(callback)](sin_shared_ptr sin, sin6_shared_ptr sin6, int err) mutable {
+      m_thread->callback(requester, std::bind(std::move(callback), std::move(sin), std::move(sin6), err));
     };
 
     ThreadNet::thread_net()->udns()->resolve(requester, hostname, family, std::move(fn));
@@ -37,8 +37,8 @@ Resolver::resolve_preferred(void* requester, const std::string& hostname, int fa
   if (preferred != AF_INET && preferred != AF_INET6)
     throw internal_error("Invalid preferred family.");
 
-  auto cb = [this, requester, hostname, family, preferred, callback = std::move(callback)] {
-    auto fn = [this, requester, preferred, callback = std::move(callback)](sin_shared_ptr sin, sin6_shared_ptr sin6, int err) {
+  auto cb = [this, requester, hostname, family, preferred, callback = std::move(callback)] () mutable {
+    auto fn = [this, requester, preferred, callback = std::move(callback)](const auto& sin, const auto& sin6, int err) mutable {
       sa_shared_ptr result(nullptr, sa_free);
 
       if (err == 0) {
@@ -56,7 +56,7 @@ Resolver::resolve_preferred(void* requester, const std::string& hostname, int fa
         }
       }
 
-      m_thread->callback(requester, std::bind(std::move(callback), result, err));
+      m_thread->callback(requester, std::bind(std::move(callback), std::move(result), err));
     };
 
     ThreadNet::thread_net()->udns()->resolve(requester, hostname, family, std::move(fn));
@@ -67,8 +67,8 @@ Resolver::resolve_preferred(void* requester, const std::string& hostname, int fa
 
 void
 Resolver::resolve_specific(void* requester, const std::string& hostname, int family, single_callback&& callback) {
-  auto cb = [this, requester, hostname, family, callback = std::move(callback)]() {
-    auto fn = [this, requester, family, callback = std::move(callback)](sin_shared_ptr sin, sin6_shared_ptr sin6, int err) {
+  auto cb = [this, requester, hostname, family, callback = std::move(callback)]() mutable {
+    auto fn = [this, requester, family, callback = std::move(callback)](const auto& sin, const auto& sin6, int err) mutable {
       sa_shared_ptr result(nullptr, sa_free);
 
       if (err == 0) {


### PR DESCRIPTION
I've mostly been trying to fix some memory leaks flagged by GCC's -fanalyzer. This only partially succeeds. There's still something still triggering on shared_ptr.