### PR TITLE
replace end() inserts with emplace_back

### DIFF
--- a/src/torrent/object.cc
+++ b/src/torrent/object.cc
@@ -218,14 +218,14 @@ Object object_create_normal(const raw_list& obj) {
   raw_list::iterator last = obj.end();
 
   while (first != last) {
-    auto new_entry = result.as_list().insert(result.as_list().end(), Object());
+    auto& new_entry = result.as_list().emplace_back();
 
-    first = object_read_bencode_c(first, last, &*new_entry, 128);
+    first = object_read_bencode_c(first, last, &new_entry, 128);
 
     // The unordered flag is inherited also from list elements who
     // have been marked as unordered, though e.g. unordered strings
     // in the list itself does not cause this flag to be set.
-    if (new_entry->flags() & Object::flag_unordered)
+    if (new_entry.flags() & Object::flag_unordered)
       result.set_internal_flags(Object::flag_unordered);
   }
 

--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -113,13 +113,13 @@ object_read_bencode(std::istream* input, Object* object, uint32_t depth) {
 	return;
       }
 
-      auto itr = object->as_list().insert(object->as_list().end(), Object());
-      object_read_bencode(input, &*itr, depth);
+      auto& obj = object->as_list().emplace_back();
+      object_read_bencode(input, &obj, depth);
 
       // The unordered flag is inherited also from list elements who
       // have been marked as unordered, though e.g. unordered strings
       // in the list itself does not cause this flag to be set.
-      if (itr->flags() & Object::flag_unordered)
+      if (obj.flags() & Object::flag_unordered)
         object->set_internal_flags(Object::flag_unordered);
     }
 
@@ -204,13 +204,13 @@ object_read_bencode_c(const char* first, const char* last, Object* object, uint3
       if (*first == 'e')
 	return first + 1;
 
-      auto itr = object->as_list().insert(object->as_list().end(), Object());
-      first = object_read_bencode_c(first, last, &*itr, depth);
+      auto& obj = object->as_list().emplace_back();
+      first = object_read_bencode_c(first, last, &obj, depth);
 
       // The unordered flag is inherited also from list elements who
       // have been marked as unordered, though e.g. unordered strings
       // in the list itself does not cause this flag to be set.
-      if (itr->flags() & Object::flag_unordered)
+      if (obj.flags() & Object::flag_unordered)
         object->set_internal_flags(Object::flag_unordered);
     }
 

--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -87,10 +87,10 @@ directory_events::notify_on(const std::string& path, [[maybe_unused]] int flags,
   if (result == -1)
     throw input_error("Call to inotify_add_watch(...) failed: " + std::string(rak::error_number::current().c_str()));
 
-  auto itr = m_wd_list.insert(m_wd_list.end(), watch_descriptor());
-  itr->descriptor = result;
-  itr->path = path + (*path.rbegin() != '/' ? "/" : "");
-  itr->slot = slot;
+  auto& wd = m_wd_list.emplace_back();
+  wd.descriptor = result;
+  wd.path = path + (path.back() != '/' ? "/" : "");
+  wd.slot = slot;
 
 #else
   throw input_error("No support for inotify.");


### PR DESCRIPTION
emplace_back returns a reference instead of an iterator. Simpler.

Fixes

```
In file included from ../src/torrent/object.cc:42:
In copy constructor 'torrent::Object::Object(const torrent::Object&)',
    inlined from 'torrent::Object::Object(const torrent::Object&)' at ../src/torrent/object.h:346:1,
    inlined from 'void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = torrent::Object; _Args = {torrent::Object}; _Tp = torrent::Object]' at /home/mangix/devstuff/openwrt/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/mips-openwrt-linux-musl/include/c++/14.3.0/bits/new_allocator.h:191:4,
    inlined from 'static void std::allocator_traits<std::allocator<_Tp1> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = torrent::Object; _Args = {torrent::Object}; _Tp = torrent::Object]' at /home/mangix/devstuff/openwrt/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/mips-openwrt-linux-musl/include/c++/14.3.0/bits/alloc_traits.h:575:17,
    inlined from 'std::vector<_Tp, _Alloc>::iterator std::vector<_Tp, _Alloc>::_M_insert_rval(const_iterator, value_type&&) [with _Tp = torrent::Object; _Alloc = std::allocator<torrent::Object>]' at /home/mangix/devstuff/openwrt/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/mips-openwrt-linux-musl/include/c++/14.3.0/bits/vector.tcc:371:30,
    inlined from 'std::vector<_Tp, _Alloc>::iterator std::vector<_Tp, _Alloc>::insert(const_iterator, value_type&&) [with _Tp = torrent::Object; _Alloc = std::allocator<torrent::Object>]' at /home/mangix/devstuff/openwrt/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/mips-openwrt-linux-musl/include/c++/14.3.0/bits/stl_vector.h:1409:30,
    inlined from 'torrent::Object torrent::object_create_normal(const raw_list&)' at ../src/torrent/object.cc:222:45:
../src/torrent/object.h:355:32: warning: '<unnamed>.torrent::Object::<anonymous>.torrent::Object::<unnamed union>::t_pod' may be used uninitialized [-Wmaybe-uninitialized]
  355 |   case TYPE_VALUE:       t_pod = b.t_pod; break;
      |                          ~~~~~~^~~~~~~~~
../src/torrent/object.cc: In function 'torrent::Object torrent::object_create_normal(const raw_list&)':
../src/torrent/object.cc:222:77: note: '<anonymous>' declared here
  222 |     auto new_entry = result.as_list().insert(result.as_list().end(), Object());
      |                                                                             ^
```

No idea why.