### PR TITLE
clang: fix more weak vtables warnings

### DIFF
--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -22,6 +22,23 @@
 #define LT_LOG_THIS(log_fmt, ...)                                       \
   lt_log_print_subsystem(torrent::LOG_DHT_SERVER, "dht_server", log_fmt, __VA_ARGS__);
 
+namespace {
+// Error in DHT protocol, avoids std::string ctor from communication_error
+class dht_error : public torrent::network_error {
+public:
+  dht_error(int code, const char* message) :
+      m_message(message), m_code(code) {}
+
+  int         code() const noexcept { return m_code; }
+  const char* what() const noexcept override { return m_message; }
+
+private:
+  const char* m_message;
+  int         m_code;
+};
+
+} // namespace
+
 namespace torrent {
 
 // List of all possible keys we need/support in a DHT message.
@@ -48,19 +65,6 @@ const DhtMessage::key_list_type DhtMessage::base_type::keys = {
   { key_t,          "t*S" },
   { key_v,          "v*" },
   { key_y,          "y*S" },
-};
-
-// Error in DHT protocol, avoids std::string ctor from communication_error
-class dht_error : public network_error {
-public:
-  dht_error(int code, const char* message) : m_message(message), m_code(code) {}
-
-  int          code() const noexcept { return m_code; }
-  const char*  what() const noexcept override { return m_message; }
-
-private:
-  const char*  m_message;
-  int          m_code;
 };
 
 DhtServer::DhtServer(DhtRouter* router) :

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -34,11 +34,8 @@
 namespace {
 class handshake_succeeded : public torrent::network_error {
 };
-}  // namespace
 
-namespace torrent {
-
-class handshake_error : public network_error {
+class handshake_error : public torrent::network_error {
 public:
   handshake_error(int type, int error) : m_type(type), m_error(error) {}
 
@@ -51,6 +48,9 @@ private:
   int     m_error;
 };
 
+} // namespace
+
+namespace torrent {
 Handshake::Handshake(SocketFd fd, HandshakeManager* m, int encryptionOptions) :
   m_manager(m),
 

--- a/src/torrent/exceptions.cc
+++ b/src/torrent/exceptions.cc
@@ -22,6 +22,31 @@ void resource_error::initialize(const std::string& msg) { m_msg = msg; }
 void input_error::initialize(const std::string& msg) { m_msg = msg; }
 
 const char*
+internal_error::what() const noexcept {
+  return m_msg.c_str();
+}
+
+const char*
+input_error::what() const noexcept {
+  return m_msg.c_str();
+}
+
+const char*
+resource_error::what() const noexcept {
+  return m_msg.c_str();
+}
+
+const char*
+storage_error::what() const noexcept {
+  return m_msg.c_str();
+}
+
+const char*
+communication_error::what() const noexcept {
+  return m_msg.c_str();
+}
+
+const char*
 connection_error::what() const noexcept {
   return std::strerror(m_errno);
 }

--- a/src/torrent/exceptions.h
+++ b/src/torrent/exceptions.h
@@ -30,7 +30,7 @@ public:
     initialize(std::string(msg) + " [#" + hash_string_to_hex_str(hash) + "]"); }
   internal_error(const std::string& msg) { initialize(msg); }
 
-  const char*        what() const noexcept override { return m_msg.c_str(); }
+  const char*        what() const noexcept override;
   const std::string& backtrace() const noexcept { return m_backtrace; }
 
 private:
@@ -51,7 +51,7 @@ public:
   communication_error(const char* msg)        { initialize(msg); }
   communication_error(const std::string& msg) { initialize(msg); }
 
-  const char* what() const noexcept override { return m_msg.c_str(); }
+  const char* what() const noexcept override;
 
 private:
   // Use this function for breaking on throws.
@@ -99,7 +99,7 @@ public:
   storage_error(const char* msg)       { initialize(msg); }
   storage_error(const std::string& msg) { initialize(msg); }
 
-  const char* what() const noexcept override { return m_msg.c_str(); }
+  const char* what() const noexcept override;
 
 private:
   // Use this function for breaking on throws.
@@ -113,7 +113,7 @@ public:
   resource_error(const char* msg) { initialize(msg); }
   resource_error(const std::string& msg) { initialize(msg); }
 
-  const char* what() const noexcept override { return m_msg.c_str(); }
+  const char* what() const noexcept override;
 
 private:
   // Use this function for breaking on throws.
@@ -127,7 +127,7 @@ public:
   input_error(const char* msg) { initialize(msg); }
   input_error(const std::string& msg) { initialize(msg); }
 
-  const char* what() const noexcept override { return m_msg.c_str(); }
+  const char* what() const noexcept override;
 
 private:
   // Use this function for breaking on throws.
@@ -138,8 +138,7 @@ private:
 
 class LIBTORRENT_EXPORT bencode_error : public input_error {
 public:
-  bencode_error(const char* msg) : input_error(msg) {}
-  bencode_error(const std::string& msg) : input_error(msg) {}
+  using input_error::input_error;
 };
 
 class LIBTORRENT_EXPORT shutdown_exception : public base_error {


### PR DESCRIPTION
Also move a bunch of static functions to anonymous namespaces.

basically ones found with

```
rg Wweak v | grep -v exceptions\\\.h  | grep -v test/
```

test/ probably doesn't matter and exceptions.h is...interesting. Can't tell if the comment in exceptions.cc is relevant:

```
// Use actual functions, instead of inlined, for the ctor of
// exceptions. This allows us to create breakpoints at throws. This is
// limited to rarely thrown exceptions.
```