### PR TITLE
define GREP with autotools

### DIFF
--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -23,6 +23,7 @@ AC_DEFUN([TORRENT_WITH_SYSROOT], [
 
 AC_DEFUN([TORRENT_REMOVE_UNWANTED],
 [
+  AC_REQUIRE([AC_PROG_GREP])
   values_to_check=`for i in $2; do echo $i; done`
   unwanted_values=`for i in $3; do echo $i; done`
   if test -z "${unwanted_values}"; then


### PR DESCRIPTION
configure fails with slibtool because it doesn't define GREP