### PR TITLE
Mention OpenBSD in mincore error msg

### DIFF
--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -89,7 +89,7 @@ AC_DEFUN([TORRENT_MINCORE_SIGNEDNESS], [
           AC_MSG_RESULT(signed)
         ],
         [
-          AC_MSG_ERROR([failed, do *not* attempt fix this with --disable-mincore unless you are running Win32.])
+          AC_MSG_ERROR([failed, do *not* attempt fix this with --disable-mincore unless you are running Win32 or OpenBSD.])
       ])
   ])
 


### PR DESCRIPTION
No mincore on OpenBSD since 6.5. 

`--disable-mincore` is used on the OpenBSD ports Makefile: https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/net/libtorrent/Makefile?rev=1.70&content-type=text/plain