### PR TITLE
Include netinet/in.h before ip.h for portability

### DIFF
--- a/src/torrent/net/network_config.h
+++ b/src/torrent/net/network_config.h
@@ -2,6 +2,7 @@
 #define LIBTORRENT_TORRENT_NET_NETWORK_CONFIG_H
 
 #include <mutex>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <torrent/net/types.h>
 


### PR DESCRIPTION
Similar to d9e8f3efac3fbedbb38aeb5c4b56adf21bcfc4cd

Current head of master fails to build on OpenBSD, this fixes it on my machine. 