### PR TITLE
scripts/common.m4: Insert spaces in shell lists

### DIFF
--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -30,7 +30,8 @@ AC_DEFUN([TORRENT_REMOVE_UNWANTED],
     $1="$2"
   else
     result=`echo "${values_to_check}" | $GREP -Fvx -- "${unwanted_values}" | $GREP -v '^$'`
-    $1=$(echo "$result" | tr -d '\n')
+    # join with spaces, squeeze repeats, and trim trailing space
+    $1=$(printf '%s\n' "$result" | tr '\n' ' ' | sed 's/  */ /g; s/ *$//')
   fi
 ])
 


### PR DESCRIPTION
$1=$(echo "$result" | tr -d '\n')

removes all newlines without inserting spaces
That usually isn’t what we want for shell lists.
It should typically be space-separated output.

Fixes a bug seen with yocto where compiler is not a single word but a string e.g.

ccache aarch64-yoe-linux-musl-clang++  -mcpu=cortex-a72+crc+nocrypto   --dyld-prefix=/usr -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/mnt/b/yoe/master/build/tmp/work/cortexa72-yoe-linux-musl/libtorrent/0.16.1/recipe-sysroot

It changes it to

ccacheaarch64-yoe-linux-musl-clang++-mcpu=cortex-a72+crc+nocrypto--dyld-prefix=/usr-fstack-protector-strong-O2-D_FORTIFY_SOURCE=2-Wformat-Wformat-security-Werror=format-security--sysroot=/mnt/b/yoe/master/build/tmp/work/cortexa72-yoe-linux-musl/libtorrent/0.16.1/recipe-sysroot

When doing c++17 checks on compiler, resulting in failure