### PR TITLE
Disable stream buffering for plaintext logs

### DIFF
--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -357,7 +357,7 @@ log_gz_file_write(const std::shared_ptr<log_gz_output>& outfile, const char* dat
 }
 
 void
-log_open_file_output(const char* name, const char* filename, bool append) {
+log_open_file_output(const char* name, const char* filename, bool append, bool flush) {
   std::ios_base::openmode mode = std::ofstream::out;
   if (append)
     mode |= std::ofstream::app;
@@ -366,9 +366,10 @@ log_open_file_output(const char* name, const char* filename, bool append) {
   if (!outfile->good())
     throw input_error("Could not open log file '" + std::string(filename) + "'.");
 
-  outfile->setf(std::ios::unitbuf);
-
-  log_open_output(name, [outfile](auto d, auto l, auto g) { log_file_write(outfile, d, l, g); });
+  if (flush)
+    log_open_output(name, [outfile](auto d, auto l, auto g) { log_file_write(outfile, d, l, g); outfile->flush(); });
+  else
+    log_open_output(name, [outfile](auto d, auto l, auto g) { log_file_write(outfile, d, l, g); });
 }
 
 void

--- a/src/torrent/utils/log.h
+++ b/src/torrent/utils/log.h
@@ -207,7 +207,7 @@ void log_remove_group_output(int group, const char* name) LIBTORRENT_EXPORT;
 void log_add_child(int group, int child) LIBTORRENT_EXPORT;
 void log_remove_child(int group, int child) LIBTORRENT_EXPORT;
 
-void log_open_file_output(const char* name, const char* filename, bool append = false) LIBTORRENT_EXPORT;
+void log_open_file_output(const char* name, const char* filename, bool append = false, bool flush = false) LIBTORRENT_EXPORT;
 void log_open_gz_file_output(const char* name, const char* filename, bool append = false) LIBTORRENT_EXPORT;
 
 //


### PR DESCRIPTION
rtorrent log files are buffered, which means log lines may be extremely delayed.

this is particularly noticeable when running with system.daemon.set=true, where startup log messages will only show up when there's enough data to cause a flush (or rtorrent exits)

this change will cause the stream to flush on each call, and logs to appear immediately, but I'm not sure this is the right solution.