### PR TITLE
Fix use after free in UdnsResolver::try_resolve_numeric

### DIFF
--- a/src/net/udns_resolver.cc
+++ b/src/net/udns_resolver.cc
@@ -233,10 +233,10 @@ UdnsResolver::try_resolve_numeric(std::unique_ptr<UdnsQuery>& query) {
     throw internal_error("getaddrinfo returned unsupported family");
   }
 
-  ::freeaddrinfo(result);
-
   if (query->family != AF_UNSPEC && query->family != result->ai_family)
     throw internal_error("getaddrinfo returned address with unexpected family");
+
+  ::freeaddrinfo(result);
 
   {
     auto lock = std::lock_guard(m_mutex);


### PR DESCRIPTION
::freeaddrinfo() on 236 frees result but we were using it later on line 238.

Move the free after the integrity check to resolve some infrequent crashes.

Because internal_errors are never handled, since they're used for integrity checks, we don't need ::freeaddrinfo() in the throw conditions because rtorrent will be shutting down immediately.