### PR TITLE
Fix crash in DhtRouter::bootstrap

### DIFF
--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -598,10 +598,12 @@ DhtRouter::bootstrap() {
 
   // Contact up to 8 nodes from the contact list (newest first).
   for (int count = 0; count < 8 && !m_contacts->empty(); count++) {
+    int port = m_contacts->back().second;
+
     // Currently discarding SOCK_DGRAM.
-    auto f = [this](const auto& sa, int) {
+    auto f = [this, port](const auto& sa, int) {
       if (sa != nullptr)
-        contact(sa.get(), m_contacts->back().second);
+        contact(sa.get(), port);
     };
 
     this_thread::resolver()->resolve_specific(this, m_contacts->back().first, AF_INET, f);


### PR DESCRIPTION
f is an asyncronous callback, meaning that m_contacts->pop_back() on line 609 will execute prior to f on 602-605. This can result in a scenario where pop_back() has been called on every element in m_cotacts and the deque is empty before the last f executes.

Because f's use of m_contacts->back() on line 604, the now empty deque will throw because we obviously can't go back on an empty deque.

By passing the port into the asynchronous callback, that can keep track of the value as it was before m_contacts was emptied later.