### PR TITLE
Fix use-after-free in DhtSearch

### DIFF
--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -181,7 +181,7 @@ DhtServer::ping(const HashString& id, const sockaddr* sa) {
 // Contact nodes in given bucket and ask for their nodes closest to target.
 void
 DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
-  auto search = new DhtSearch(target, contacts);
+  auto search = std::make_shared<DhtSearch>(target, contacts);
 
   auto n = search->get_contact();
   while (n != search->end()) {
@@ -189,14 +189,12 @@ DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
     n = search->get_contact();
   }
 
-  // This shouldn't happen, it means we had no contactable nodes at all.
-  if (!search->start())
-    delete search;
+  search->start();
 }
 
 void
 DhtServer::announce(const DhtBucket& contacts, const HashString& infoHash, TrackerDht* tracker) {
-  auto announce = new DhtAnnounce(infoHash, tracker, contacts);
+  auto announce = std::make_shared<DhtAnnounce>(infoHash, tracker, contacts);
   auto n        = announce->get_contact();
 
   while (n != announce->end()) {
@@ -204,10 +202,7 @@ DhtServer::announce(const DhtBucket& contacts, const HashString& infoHash, Track
     n = announce->get_contact();
   }
 
-  // This can only happen if all nodes we know are bad.
-  if (!announce->start())
-    delete announce;
-  else
+  if (announce->start())
     announce->update_status();
 }
 

--- a/src/dht/dht_transaction.cc
+++ b/src/dht/dht_transaction.cc
@@ -283,7 +283,7 @@ DhtTransactionSearch::complete(bool success) {
   if (m_node == m_search->end())
     throw internal_error("DhtTransactionSearch::complete() called multiple times.");
 
-  if (m_node.search() != m_search)
+  if (m_node.search() != m_search.get())
     throw internal_error("DhtTransactionSearch::complete() called for node from wrong search.");
 
   if (!m_hasQuickTimeout)
@@ -296,9 +296,6 @@ DhtTransactionSearch::complete(bool success) {
 DhtTransactionSearch::~DhtTransactionSearch() {
   if (m_node != m_search->end())
     complete(false);
-
-  if (m_search->complete())
-    delete m_search;
 }
 
 DhtTransaction::transaction_type

--- a/src/dht/dht_transaction.h
+++ b/src/dht/dht_transaction.h
@@ -51,7 +51,8 @@ struct dht_compare_closer {
 // and returns what nodes to contact with up to three concurrent transactions pending.
 // The map element is the DhtSearch object itself to allow the returned accessors
 // to know which search a given node belongs to.
-class DhtSearch : protected std::map<std::unique_ptr<DhtNode>, DhtSearch*, dht_compare_closer> {
+class DhtSearch : public std::enable_shared_from_this<DhtSearch>,
+                  protected std::map<std::unique_ptr<DhtNode>, DhtSearch*, dht_compare_closer> {
   friend class DhtTransactionSearch;
 
 public:
@@ -304,7 +305,7 @@ public:
   bool                       is_search() override         { return true; }
 
   DhtSearch::const_accessor  node()                       { return m_node; }
-  DhtSearch*                 search()                     { return m_search; }
+  DhtSearch*                 search()                     { return m_search.get(); }
 
   void                       set_stalled();
 
@@ -314,11 +315,11 @@ protected:
   DhtTransactionSearch(int quick_timeout, int timeout, DhtSearch::const_accessor& node)
     : DhtTransaction(quick_timeout, timeout, node.node()->id(), node.node()->address()),
       m_node(node),
-      m_search(node.search()) { if (!m_hasQuickTimeout) m_search->m_concurrency++; }
+      m_search(node.search()->shared_from_this()) { if (!m_hasQuickTimeout) m_search->m_concurrency++; }
 
 private:
-  DhtSearch::const_accessor  m_node;
-  DhtSearch*                 m_search;
+  DhtSearch::const_accessor    m_node;
+  std::shared_ptr<DhtSearch>   m_search;
 };
 
 // Actual transaction classes.


### PR DESCRIPTION
This is a two patch series fixing infrequent crashes in DhtSearch

The first crash and patch patch I successfully traced to precisely what was happening in the code, documented in the commit message.

The second crash, I wasn't able to identify the code path to blame, but I did confirm that converting to shared_ptr (which has some precedence in the codebase) successfully resolves it. I don't think further time spent on it is getting me any closer to finding the lines to blame.