### PR TITLE
Fix crash on double scrape request

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -140,7 +140,7 @@ TrackerHttp::send_scrape() {
   }
 
   LT_LOG("scrape requested : url:%s", info().url.c_str());
-  this_thread::scheduler()->wait_for_ceil_seconds(&m_delay_scrape, 10s);
+  this_thread::scheduler()->update_wait_for_ceil_seconds(&m_delay_scrape, 10s);
 }
 
 void
@@ -329,7 +329,7 @@ TrackerHttp::receive_done() {
   process_success(b);
 
   if (m_requested_scrape && !is_busy())
-    this_thread::scheduler()->wait_for_ceil_seconds(&m_delay_scrape, 10s);
+    this_thread::scheduler()->update_wait_for_ceil_seconds(&m_delay_scrape, 10s);
 }
 
 void


### PR DESCRIPTION
Replaces wait_for_ceil_seconds by the idempotent update_wait_For_ceil_seconds to fix crashes on startup when a send_scrape and receive_done event are called within 10s of eachother, triggering a "Scheduler::wait_until(...) called on an already scheduled entry." error and crash.