### PR TITLE
Fix stack-use-after-free in DHT

### DIFF
--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -651,16 +651,15 @@ DhtRouter::bootstrap_bucket(const DhtBucket* bucket) {
   // own when bootstrapping our own bucket. We don't search for
   // our own exact ID to avoid receiving only our own node info
   // instead of closest nodes, from nodes that know us already.
-  HashString contactId;
 
   if (bucket == this->bucket()) {
-    contactId = id();
-    contactId[torrent::HashString::size() - 1] ^= 1;
+    m_contactId = id();
+    m_contactId[torrent::HashString::size() - 1] ^= 1;
   } else {
-    bucket->get_random_id(&contactId);
+    bucket->get_random_id(&m_contactId);
   }
 
-  m_server.find_node(*bucket, contactId);
+  m_server.find_node(*bucket, m_contactId);
 }
 
 } // namespace torrent

--- a/src/dht/dht_router.h
+++ b/src/dht/dht_router.h
@@ -126,6 +126,7 @@ private:
   DhtNodeList         m_nodes;
   DhtBucketList       m_routingTable;
   DhtTrackerList      m_trackers;
+  HashString          m_contactId;
 
   std::optional<std::deque<contact_t>> m_contacts;
 

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -687,13 +687,14 @@ DhtServer::event_read() {
     Object request;
     int type = '?';
     DhtMessage message;
+    raw_string nodeIdStr;
     const HashString* nodeId = NULL;
+    char buffer[2048];
 
     sockaddr_in6 sa_raw{};
     sockaddr* sa = reinterpret_cast<sockaddr*>(&sa_raw);
 
     try {
-      char buffer[2048];
       int32_t read = read_datagram_sa(buffer, sizeof(buffer), sa, sizeof(sa_raw));
 
       if (read < 0)
@@ -738,7 +739,7 @@ DhtServer::event_read() {
         if (!message[type == 'q' ? key_a_id : key_r_id].is_raw_string())
           throw dht_error(dht_error_protocol, "Invalid `id' value");
 
-        raw_string nodeIdStr = message[type == 'q' ? key_a_id : key_r_id].as_raw_string();
+        nodeIdStr = message[type == 'q' ? key_a_id : key_r_id].as_raw_string();
 
         if (nodeIdStr.size() < HashString::size_data)
           throw dht_error(dht_error_protocol, "`id' value too short");


### PR DESCRIPTION
- keep contactId as a member variable (DhtSearch keeps a reference)

- move nodeIdStr and buffer a level up (used later in catch())