### PR TITLE
clean up valgrind error

### DIFF
--- a/src/utils/partial_queue.h
+++ b/src/utils/partial_queue.h
@@ -65,7 +65,7 @@ private:
 
   static size_type    ceiling(size_type layer)                { return (2 << layer) - 1; }
 
-  std::unique_ptr<mapped_type> m_data;
+  std::unique_ptr<mapped_type[]> m_data;
 
   size_type           m_max_layer_size{};
   size_type           m_index{};


### PR DESCRIPTION
This ensures that the `new[]` call here:

https://github.com/rakshasa/libtorrent/blob/aa363d84e869b5dc654b5198ff71887ca719eb7c/src/utils/partial_queue.h#L82

is paired with a `delete[]` call instead of a `delete` call, fixing this class of Valgrind errors:

```
==1324887== Mismatched new/delete size value: 4
==1324887==    at 0x484A5B9: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1324887==    by 0x49C0307: operator() (unique_ptr.h:99)
==1324887==    by 0x49C0307: ~unique_ptr (unique_ptr.h:404)
==1324887==    by 0x49C0307: ~PartialQueue (partial_queue.h:28)
==1324887==    by 0x49C0307: ~ChunkSelector (chunk_selector.h:24)
==1324887==    by 0x49C0307: torrent::DownloadMain::~DownloadMain() (download_main.cc:88)
==1324887==    by 0x49C4210: operator() (unique_ptr.h:99)
==1324887==    by 0x49C4210: operator() (unique_ptr.h:93)
==1324887==    by 0x49C4210: ~unique_ptr (unique_ptr.h:404)
==1324887==    by 0x49C4210: torrent::DownloadWrapper::~DownloadWrapper() (download_wrapper.cc:63)
==1324887==    by 0x495233C: torrent::DownloadManager::erase(torrent::DownloadWrapper*) (download_manager.cc:62)
==1324887==    by 0x166950: core::DownloadList::erase(std::_List_iterator<core::Download*>) (download_list.cc:211)
==1324887==    by 0x1691B7: erase_ptr (download_list.cc:190)
==1324887==    by 0x1691B7: core::DownloadList::process_meta_download(core::Download*) (download_list.cc:709)
==1324887==    by 0x4985005: operator() (std_function.h:591)
==1324887==    by 0x4985005: torrent::utils::Scheduler::perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) (scheduler.cc:171)
==1324887==    by 0x4987C37: torrent::utils::Thread::event_loop() (thread.cc:188)
==1324887==    by 0x15B825: main (main.cc:441)
==1324887==  Address 0x6460160 is 0 bytes inside a block of size 1,024 alloc'd
==1324887==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1324887==    by 0x49B7533: enable (partial_queue.h:82)
==1324887==    by 0x49B7533: torrent::ChunkSelector::initialize(torrent::ChunkStatistics*) (chunk_selector.cc:28)
==1324887==    by 0x49C47A5: torrent::DownloadWrapper::receive_initial_hash() (download_wrapper.cc:140)
==1324887==    by 0x4985005: operator() (std_function.h:591)
==1324887==    by 0x4985005: torrent::utils::Scheduler::perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) (scheduler.cc:171)
==1324887==    by 0x4987C37: torrent::utils::Thread::event_loop() (thread.cc:188)
==1324887==    by 0x15B825: main (main.cc:441)
```

There should be no functional change. On the plus side, with this patch, I no longer see any errors in valgrind, including the DHT errors from #166.