### PR TITLE
Set explicit 8 MB thread stack size when building with musl libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,12 +87,27 @@ fi
 AX_PTHREAD
 CHECK_ATOMIC
 
+AC_ARG_ENABLE([pthread-setstacksize],
+  [AS_HELP_STRING([--enable-pthread-setstacksize], [explicitly set pthread stack size (auto-enabled for musl)])],
+  [enable_pthread_setstacksize=$enableval],
+  [enable_pthread_setstacksize=auto])
+
 AC_CANONICAL_HOST
-case "$host" in
-  *-musl*)
-    AC_DEFINE([USE_MUSL_LIBC], [1], [Building with musl libc])
-    ;;
-esac
+if test "x$enable_pthread_setstacksize" = "xauto"; then
+  case "$host" in
+    *-musl*)
+      enable_pthread_setstacksize=yes
+      ;;
+    *)
+      enable_pthread_setstacksize=no
+      ;;
+  esac
+fi
+
+if test "x$enable_pthread_setstacksize" = "xyes"; then
+  AC_DEFINE([USE_PTHREAD_SETSTACKSIZE], [1], [Use explicit pthread stack size])
+  AC_DEFINE([DEFAULT_PTHREAD_STACKSIZE], [(8 * 1024 * 1024)], [Default pthread stack size in bytes])
+fi
 
 PKG_CHECK_MODULES([LIBCURL], [libcurl],, [LIBCURL_CHECK_CONFIG])
 PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,13 @@ fi
 AX_PTHREAD
 CHECK_ATOMIC
 
+AC_CANONICAL_HOST
+case "$host" in
+  *-musl*)
+    AC_DEFINE([USE_MUSL_LIBC], [1], [Building with musl libc])
+    ;;
+esac
+
 PKG_CHECK_MODULES([LIBCURL], [libcurl],, [LIBCURL_CHECK_CONFIG])
 PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])
 PKG_CHECK_MODULES([ZLIB], [zlib])

--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -53,8 +53,21 @@ Thread::start_thread() {
 
   init_thread_pre_start();
 
+#ifdef USE_MUSL_LIBC
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+
+  if (pthread_create(&m_thread, &attr, &Thread::enter_event_loop, this)) {
+    pthread_attr_destroy(&attr);
+    throw internal_error("Failed to create thread.");
+  }
+
+  pthread_attr_destroy(&attr);
+#else
   if (pthread_create(&m_thread, nullptr, &Thread::enter_event_loop, this))
     throw internal_error("Failed to create thread.");
+#endif
 
   while (m_state != STATE_ACTIVE)
     usleep(100);

--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -53,10 +53,10 @@ Thread::start_thread() {
 
   init_thread_pre_start();
 
-#ifdef USE_MUSL_LIBC
+#ifdef USE_PTHREAD_SETSTACKSIZE
   pthread_attr_t attr;
   pthread_attr_init(&attr);
-  pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+  pthread_attr_setstacksize(&attr, DEFAULT_PTHREAD_STACKSIZE);
 
   if (pthread_create(&m_thread, &attr, &Thread::enter_event_loop, this)) {
     pthread_attr_destroy(&attr);


### PR DESCRIPTION
Worker threads are created with pthread_create using a NULL attribute, which inherits the platform's default stack size. On glibc this is 8 MB, but on musl libc it is only 128 KB, and other C libraries (uclibc, bionic) also use smaller defaults.

128 KB is insufficient for libtorrent's worker threads, which use deep call stacks in the DHT, peer connection, and curl integration paths. This causes stack overflows and crashes when running on musl-based systems (Alpine Linux, static musl builds, etc.).

When the build host triplet contains "musl", configure now defines USE_MUSL_LIBC. When this macro is set, pthread_create uses an explicit pthread_attr_t with an 8 MB stack size, matching the glibc default that existing users have always relied on. On glibc and other C libraries the behavior is unchanged.

The pthread_attr_t is properly destroyed in both the success and error paths to avoid resource leaks.