### PR TITLE
Handle EBADF and ENOENT gracefully in epoll_ctl MOD/DEL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,14 @@ TORRENT_WITH_SYSROOT
 dnl TORRENT_WITH_XFS
 TORRENT_WITHOUT_KQUEUE
 TORRENT_WITHOUT_EPOLL
+
+AC_ARG_ENABLE(epoll-safe-close,
+  AS_HELP_STRING([--enable-epoll-safe-close],[handle EBADF/ENOENT gracefully in epoll_ctl for externally managed sockets [[default=disable]]]),
+  [
+    if test "$enableval" = "yes"; then
+      AC_DEFINE([EPOLL_SAFE_CLOSE], [1], [Handle EBADF/ENOENT in epoll_ctl MOD/DEL instead of aborting])
+    fi
+  ],[])
 TORRENT_CHECK_FALLOCATE
 TORRENT_WITH_POSIX_FALLOCATE
 TORRENT_WITH_ADDRESS_SPACE

--- a/src/torrent/net/poll_epoll.cc
+++ b/src/torrent/net/poll_epoll.cc
@@ -106,18 +106,29 @@ PollInternal::modify(Event* event, unsigned short op, uint32_t mask, uint32_t ol
       throw internal_error("PollInternal::modify(): epoll_ctl(ADD) error for event: " + event->print_name_fd_str() + " : " + std::string(std::strerror(errno)));
 
     case EPOLL_CTL_MOD:
+#ifdef EPOLL_SAFE_CLOSE
+      if (errno == EBADF) {
+        LT_LOG_EVENT("modify event EPOLL_CTL_MOD failed with EBADF, clearing event", 0);
+        set_event_mask(event, 0);
+        return;
+      }
+#endif
+
       if (errno == ENOENT) {
         LT_LOG_EVENT("modify event EPOLL_CTL_MOD failed with ENOENT", 0);
-        // TODO: We might be getting removed because EPOLLERR is not considered being in the poll?
-        //
-        // We still seem to be getting error events (verify with libcurl idle poll).
-        //
-        // Add a test here to see if we're moving from no events to some events, and only retry in that case.
 
+#ifdef EPOLL_SAFE_CLOSE
+        if (old_mask & (EPOLLIN | EPOLLOUT)) {
+          LT_LOG_EVENT("modify event EPOLL_CTL_MOD ENOENT with old read/write mask, clearing event", 0);
+          set_event_mask(event, 0);
+          return;
+        }
+#else
         if (old_mask & (EPOLLIN | EPOLLOUT)) {
           LT_LOG_EVENT("modify event EPOLL_CTL_MOD cannot retry as old mask had read/write", 0);
           throw internal_error("PollInternal::modify(): epoll_ctl(MOD) error for event: " + event->print_name_fd_str() + " : in read/write but got ENOENT");
         }
+#endif
 
         if (epoll_ctl(m_fd, EPOLL_CTL_ADD, event->file_descriptor(), &e) == 0) {
           LT_LOG_EVENT("modify event EPOLL_CTL_ADD retry after ENOENT succeeded", 0);
@@ -129,6 +140,14 @@ PollInternal::modify(Event* event, unsigned short op, uint32_t mask, uint32_t ol
       throw internal_error("PollInternal::modify(): epoll_ctl(MOD) error for event: " + event->print_name_fd_str() + " : " + std::string(std::strerror(errno)));
 
     case EPOLL_CTL_DEL:
+#ifdef EPOLL_SAFE_CLOSE
+      if (errno == EBADF || errno == ENOENT) {
+        LT_LOG_EVENT("modify event EPOLL_CTL_DEL failed with %s, ignoring", std::strerror(errno));
+        set_event_mask(event, 0);
+        return;
+      }
+#endif
+
       LT_LOG_EVENT("modify event EPOLL_CTL_DEL failed: %s", std::strerror(errno));
       throw internal_error("PollInternal::modify(): epoll_ctl(DEL) error for event: " + event->print_name_fd_str() + " : " + std::string(std::strerror(errno)));
 


### PR DESCRIPTION
Add --enable-epoll-safe-close configure option (disabled by default). When enabled, epoll_ctl errors for MOD and DEL operations are handled gracefully instead of throwing internal_error and aborting the process.

When libcurl manages sockets internally (connection reuse, timeouts, redirects), it may close a file descriptor before libtorrent's poll loop has finished modifying or removing the epoll registration. This race condition manifests as two distinct epoll_ctl errors:

EBADF: curl closed the socket and the fd is now invalid. The kernel has already removed it from all epoll sets automatically.

ENOENT: curl closed the socket and the kernel reassigned the same fd number to a new socket. The new fd is valid but was never added to the epoll set, so EPOLL_CTL_MOD fails because there is nothing to modify.

Previously, both cases threw internal_error which propagated as an uncaught exception in the worker thread, calling std::terminate and aborting the process with messages such as:

  epoll_ctl(MOD) error: name:curl_socket fd:N : Bad file descriptor
  epoll_ctl(MOD) error: name:curl_socket fd:N : in read/write but got ENOENT

The existing ENOENT handling for EPOLL_CTL_MOD attempted a retry via EPOLL_CTL_ADD, but only when the old event mask had no EPOLLIN/EPOLLOUT flags. For curl sockets that were actively reading or writing (the common case), it threw instead of recovering.

With --enable-epoll-safe-close:

  EPOLL_CTL_MOD + EBADF: clear event mask and return (fd is gone,
  kernel already cleaned up).

  EPOLL_CTL_MOD + ENOENT with active read/write mask: clear event mask
  and return instead of throwing (the old socket is gone, curl will
  re-register the new socket through its own callback).

  EPOLL_CTL_MOD + ENOENT without read/write mask: retain the existing
  retry-via-ADD behavior.

  EPOLL_CTL_DEL + EBADF/ENOENT: clear event mask and return (deleting
  an already-gone fd is a no-op).

Without --enable-epoll-safe-close the behavior is unchanged from the current code.

This is consistent with how other event loop implementations (libevent, libev) handle stale file descriptors. This race is more likely to trigger under musl libc but is possible under glibc as well.