### PR TITLE
Add ready directory event support

### DIFF
--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -3,6 +3,8 @@
 #include "directory_events.h"
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <unistd.h>
 
@@ -15,6 +17,37 @@
 #include "torrent/net/poll.h"
 
 namespace torrent {
+
+namespace {
+
+std::string
+normalize_directory_event_path(const std::string& path) {
+  char* resolved = ::realpath(path.c_str(), nullptr);
+
+  if (resolved == nullptr)
+    throw input_error("Could not resolve watch directory '" + path + "': " + std::string(std::strerror(errno)));
+
+  std::string normalized(resolved);
+  std::free(resolved);
+
+  while (normalized.size() > 1 && normalized.back() == '/')
+    normalized.pop_back();
+
+  return normalized;
+}
+
+bool
+directory_event_flags_include_added_mode(int flags) {
+  return flags & directory_events::flag_on_added;
+}
+
+bool
+directory_event_flags_conflict(int lhs, int rhs) {
+  return ((lhs & directory_events::flag_on_ready) && directory_event_flags_include_added_mode(rhs)) ||
+         ((rhs & directory_events::flag_on_ready) && directory_event_flags_include_added_mode(lhs));
+}
+
+} // namespace
 
 bool
 directory_events::open() {
@@ -63,6 +96,14 @@ directory_events::notify_on(const std::string& path, [[maybe_unused]] int flags,
     throw input_error("Cannot add notification event for empty paths.");
 
 #ifdef USE_INOTIFY
+  std::string normalized_path = normalize_directory_event_path(path);
+
+  for (const auto& wd : m_wd_list) {
+    if (directory_event_flags_conflict(wd.flags, flags) &&
+        wd.canonical_path == normalized_path)
+      throw input_error("Conflicting directory watch modes for watch directories: " + wd.canonical_path + " and " + normalized_path);
+  }
+
   int in_flags = IN_MASK_ADD;
 
 #ifdef IN_EXCL_UNLINK
@@ -79,18 +120,23 @@ directory_events::notify_on(const std::string& path, [[maybe_unused]] int flags,
   if ((flags & flag_on_updated))
     in_flags |= IN_CLOSE_WRITE;
 
+  if ((flags & flag_on_ready))
+    in_flags |= (IN_MOVED_TO | IN_CLOSE_WRITE);
+
   if ((flags & flag_on_removed))
     in_flags |= (IN_DELETE | IN_MOVED_FROM);
 
-  int result = inotify_add_watch(m_fileDesc, path.c_str(), in_flags);
+  int result = inotify_add_watch(m_fileDesc, normalized_path.c_str(), in_flags);
 
   if (result == -1)
     throw input_error("Call to inotify_add_watch(...) failed: " + std::string(std::strerror(errno)));
 
-  auto& wd = m_wd_list.emplace_back();
-  wd.descriptor = result;
-  wd.path = path + (path.back() != '/' ? "/" : "");
-  wd.slot = slot;
+  auto& wd          = m_wd_list.emplace_back();
+  wd.descriptor     = result;
+  wd.flags          = flags;
+  wd.canonical_path = normalized_path;
+  wd.path           = path + (path.back() != '/' ? "/" : "");
+  wd.slot           = slot;
 
 #else
   throw input_error("No support for inotify.");
@@ -100,7 +146,7 @@ directory_events::notify_on(const std::string& path, [[maybe_unused]] int flags,
 void
 directory_events::event_read() {
 #ifdef USE_INOTIFY
-  char buffer[2048];
+  char    buffer[2048];
   ssize_t result = ::read(m_fileDesc, buffer, 2048);
 
   if (result < static_cast<ssize_t>(sizeof(struct inotify_event)))

--- a/src/torrent/utils/directory_events.h
+++ b/src/torrent/utils/directory_events.h
@@ -12,9 +12,11 @@ namespace torrent {
 struct watch_descriptor {
   using slot_string = std::function<void(const std::string&)>;
 
-  bool compare_desc(int desc) const { return desc == descriptor; }
+  bool        compare_desc(int desc) const { return desc == descriptor; }
 
   int         descriptor;
+  int         flags;
+  std::string canonical_path;
   std::string path;
   slot_string slot;
 };
@@ -27,23 +29,24 @@ public:
   static constexpr int flag_on_added   = 0x1;
   static constexpr int flag_on_removed = 0x2;
   static constexpr int flag_on_updated = 0x3;
+  static constexpr int flag_on_ready   = 0x4;
 
   directory_events() { m_fileDesc = -1; }
   ~directory_events() override = default;
 
-  bool                open();
-  void                close();
+  bool        open();
+  void        close();
 
-  void                notify_on(const std::string& path, int flags, const slot_string& slot);
+  void        notify_on(const std::string& path, int flags, const slot_string& slot);
 
-  void                event_read() override;
-  void                event_write() override;
-  void                event_error() override;
+  void        event_read() override;
+  void        event_write() override;
+  void        event_error() override;
 
-  const char*         type_name() const override { return "directory_events"; }
+  const char* type_name() const override { return "directory_events"; }
 
 private:
-  wd_list             m_wd_list;
+  wd_list m_wd_list;
 };
 
 } // namespace torrent

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -63,6 +63,8 @@ LibTorrent_Test_Torrent_Utils_SOURCES = $(LibTorrent_Test_Common) \
 	torrent/utils/test_log.h \
 	torrent/utils/test_log_buffer.cc \
 	torrent/utils/test_log_buffer.h \
+	torrent/utils/directory_events_test.cc \
+	torrent/utils/directory_events_test.h \
 	torrent/utils/test_option_strings.cc \
 	torrent/utils/test_option_strings.h \
 	torrent/utils/test_queue_buckets.cc \

--- a/test/torrent/utils/directory_events_test.cc
+++ b/test/torrent/utils/directory_events_test.cc
@@ -1,21 +1,170 @@
 #include "config.h"
 
-#include <functional>
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <vector>
+
 #include <torrent/exceptions.h>
 #include <torrent/utils/directory_events.h>
 
 #include "directory_events_test.h"
 
-CPPUNIT_TEST_SUITE_REGISTRATION(utils_directory_events_test);
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(utils_directory_events_test, "torrent/utils");
+
+namespace {
+
+constexpr int added_flags = torrent::directory_events::flag_on_added |
+                            torrent::directory_events::flag_on_updated;
+
+torrent::directory_events::slot_string
+noop_slot() {
+  return [](const std::string&) {};
+}
+
+void
+assert_mkdir(const std::string& path) {
+  CPPUNIT_ASSERT_MESSAGE(("Could not create test directory: " + path).c_str(), ::mkdir(path.c_str(), 0700) == 0);
+}
+
+void
+assert_write_file(const std::string& path) {
+  int fd = ::open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0600);
+  CPPUNIT_ASSERT_MESSAGE(("Could not create test file: " + path).c_str(), fd != -1);
+  CPPUNIT_ASSERT(::write(fd, "x", 1) == 1);
+  CPPUNIT_ASSERT(::close(fd) == 0);
+}
+
+void
+assert_conflicting_watch(torrent::directory_events* events, const std::string& path, int flags) {
+  try {
+    events->notify_on(path, flags, noop_slot());
+    CPPUNIT_ASSERT_MESSAGE(("Expected conflicting watch for: " + path).c_str(), false);
+  } catch (const torrent::input_error&) {
+  }
+}
+
+} // namespace
 
 void
 utils_directory_events_test::setUp() {
+  TestFixtureWithMainThread::setUp();
+
+  char  path_template[] = "/tmp/libtorrent-directory-events.XXXXXX";
+  char* path            = ::mkdtemp(path_template);
+
+  CPPUNIT_ASSERT(path != nullptr);
+
+  m_root = path;
+  m_link = m_root + "-link";
+  assert_mkdir(m_root + "/child");
+  assert_mkdir(m_root + "/other");
+  CPPUNIT_ASSERT_MESSAGE(("Could not create test symlink: " + m_link).c_str(), ::symlink(m_root.c_str(), m_link.c_str()) == 0);
 }
 
 void
 utils_directory_events_test::tearDown() {
+  if (!m_root.empty()) {
+    ::unlink((m_root + "/symlink-callback.torrent").c_str());
+    ::unlink(m_link.c_str());
+    ::rmdir((m_root + "/child").c_str());
+    ::rmdir((m_root + "/other").c_str());
+    ::rmdir(m_root.c_str());
+    m_link.clear();
+    m_root.clear();
+  }
+
+  TestFixtureWithMainThread::tearDown();
 }
 
 void
-utils_directory_events_test::test_basic() {
+utils_directory_events_test::test_ready_conflicts_with_added_same_directory() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_root, torrent::directory_events::flag_on_ready, noop_slot());
+  assert_conflicting_watch(&events, m_root + "/.", added_flags);
+
+  events.close();
+#endif
+}
+
+void
+utils_directory_events_test::test_symlink_watch_uses_configured_callback_path() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  std::vector<std::string> paths;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_link, added_flags, [&paths](const std::string& path) {
+    paths.push_back(path);
+  });
+
+  assert_write_file(m_link + "/symlink-callback.torrent");
+
+  for (int i = 0; i < 100 && paths.empty(); i++) {
+    events.event_read();
+    ::usleep(1000);
+  }
+
+  CPPUNIT_ASSERT(!paths.empty());
+  CPPUNIT_ASSERT_EQUAL(m_link + "/symlink-callback.torrent", paths.front());
+
+  events.close();
+#endif
+}
+
+void
+utils_directory_events_test::test_added_conflicts_with_ready_same_directory_normalized() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_root + "/child/..", added_flags, noop_slot());
+  assert_conflicting_watch(&events, m_root, torrent::directory_events::flag_on_ready);
+
+  events.close();
+#endif
+}
+
+void
+utils_directory_events_test::test_ready_allows_added_child() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_root, torrent::directory_events::flag_on_ready, noop_slot());
+  events.notify_on(m_root + "/child", added_flags, noop_slot());
+
+  events.close();
+#endif
+}
+
+void
+utils_directory_events_test::test_added_allows_ready_parent() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_root + "/child", added_flags, noop_slot());
+  events.notify_on(m_root, torrent::directory_events::flag_on_ready, noop_slot());
+
+  events.close();
+#endif
+}
+
+void
+utils_directory_events_test::test_ready_allows_added_sibling() {
+#ifdef USE_INOTIFY
+  torrent::directory_events events;
+  CPPUNIT_ASSERT(events.open());
+
+  events.notify_on(m_root + "/child", torrent::directory_events::flag_on_ready, noop_slot());
+  events.notify_on(m_root + "/other", added_flags, noop_slot());
+
+  events.close();
+#endif
 }

--- a/test/torrent/utils/directory_events_test.h
+++ b/test/torrent/utils/directory_events_test.h
@@ -1,15 +1,35 @@
-#include <cppunit/extensions/HelperMacros.h>
+#ifndef LIBTORRENT_TEST_DIRECTORY_EVENTS_TEST_H
+#define LIBTORRENT_TEST_DIRECTORY_EVENTS_TEST_H
 
+#include <string>
+
+#include "test/helpers/test_main_thread.h"
 #include "torrent/utils/directory_events.h"
 
-class utils_directory_events_test : public CppUnit::TestFixture {
+class utils_directory_events_test : public TestFixtureWithMainThread {
   CPPUNIT_TEST_SUITE(utils_directory_events_test);
-  CPPUNIT_TEST(test_basic);
+  CPPUNIT_TEST(test_ready_conflicts_with_added_same_directory);
+  CPPUNIT_TEST(test_added_conflicts_with_ready_same_directory_normalized);
+  CPPUNIT_TEST(test_ready_allows_added_child);
+  CPPUNIT_TEST(test_added_allows_ready_parent);
+  CPPUNIT_TEST(test_ready_allows_added_sibling);
+  CPPUNIT_TEST(test_symlink_watch_uses_configured_callback_path);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void setUp();
   void tearDown();
 
-  void test_basic();
+  void test_ready_conflicts_with_added_same_directory();
+  void test_added_conflicts_with_ready_same_directory_normalized();
+  void test_ready_allows_added_child();
+  void test_added_allows_ready_parent();
+  void test_ready_allows_added_sibling();
+  void test_symlink_watch_uses_configured_callback_path();
+
+private:
+  std::string m_link;
+  std::string m_root;
 };
+
+#endif


### PR DESCRIPTION
## Summary

Add internal ready-directory event support for rTorrent watch folders.

This supports the rTorrent-side `directory.watch.ready` command for normal file-copy workflows where a writer either:

- writes to a temporary name and renames the completed file into place; or
- creates the final filename, writes data, and closes it.

## Changes

- Add `torrent::directory_events::flag_on_ready`.
- Map the ready flag to `IN_MOVED_TO | IN_CLOSE_WRITE` on Linux/inotify.
- Keep existing `flag_on_added`, `flag_on_removed`, and `flag_on_updated` behavior unchanged.
- Normalize watch directories for inotify registration and same-directory collision checks.
- Reject mixed `ready` / `added` watches only for the same canonical watch directory.
- Allow parent/child and sibling watches, since inotify directory watches are not recursive.
- Preserve callback paths based on the configured watch path, including symlinked watch directories.
- Add directory-event unit tests for same-directory conflicts, normalized-path conflicts, parent/child allowance, sibling allowance, and symlink callback paths.

## Rationale

Current rTorrent `directory.watch.added` can load on `IN_CREATE`, which is too early for writers that create the final filename before contents are complete. This happens with normal macOS Finder copies into a Samba share, and can also happen with `cp`, direct `scp`/SFTP, and cross-filesystem moves.

Using `IN_MOVED_TO | IN_CLOSE_WRITE` captures the two common candidate-ready cases without exposing inotify-specific commands to rTorrent users:

- `IN_MOVED_TO`: complete file moved/renamed into the watch directory.
- `IN_CLOSE_WRITE`: final-name writer closed the file after writing.

The rTorrent PR layers a small readiness queue on top of these candidate-ready events before calling the configured load command.

Related rTorrent issue: rakshasa/rtorrent#1757.
Stacked rTorrent PR: rakshasa/rtorrent#1758.

## Verification

- `make check`
