### PR TITLE
Unlock when calling the callback to prevent lock inversion

### DIFF
--- a/src/torrent/runtime/network_manager.cc
+++ b/src/torrent/runtime/network_manager.cc
@@ -151,13 +151,20 @@ NetworkManager::restart_listen() {
 
 bool
 NetworkManager::listen_open_unsafe(uint16_t begin, uint16_t end) {
-  auto config_guard = runtime::network_config()->lock_guard();
-  auto backlog      = runtime::network_config()->listen_backlog_unsafe();
+  int backlog = 0;
+  NetworkConfig::listen_addresses listen_addresses = {};
 
   if (m_listen_inet->is_open() || m_listen_inet6->is_open())
     throw internal_error("NetworkManager::open_listen(): Tried to open listen socket when one is already open.");
 
-  auto [inet_address, inet6_address, block_ipv4in6] = runtime::network_config()->listen_addresses_unsafe();
+  {
+    auto config_guard = runtime::network_config()->lock_guard();
+    backlog           = runtime::network_config()->listen_backlog_unsafe();
+
+    listen_addresses = runtime::network_config()->listen_addresses_unsafe();
+  }
+
+  auto& [inet_address, inet6_address, block_ipv4in6] = listen_addresses;
 
   if (inet_address == nullptr && inet6_address == nullptr)
     throw input_error("Neither IPv4 nor IPv6 listen address are suitable for opening listen sockets, check block_ipv4 and block_ipv6 settings.");


### PR DESCRIPTION
Avoids lock order inversion between SocketManager and NetworkConfig.

Reported by ThreadSanitizer:

```
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=28914)
  Cycle in lock order graph: M0 (0x722800000140) => M1 (0x7218000001e0) => M0

  Mutex M1 acquired here while holding mutex M0 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #4 torrent::runtime::SocketManager::lock_guard() ../torrent/runtime/socket_manager.h:73 (rtorrent+0x414ad1) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #5 torrent::runtime::SocketManager::register_event_or_throw(torrent::Event*, std::function<void ()>) runtime/socket_manager.cc:143 (rtorrent+0x412261) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #6 torrent::Listen::open_done(int, unsigned short, int) net/listen.cc:194 (rtorrent+0x4d596b) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #7 torrent::Listen::open_single(torrent::Listen*, sockaddr const*, unsigned short, unsigned short, int, bool) net/listen.cc:110 (rtorrent+0x4d4b4f) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #8 torrent::runtime::NetworkManager::listen_open_unsafe(unsigned short, unsigned short) runtime/network_manager.cc:189 (rtorrent+0x3bd83a) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #9 torrent::runtime::NetworkManager::listen_open(unsigned short, unsigned short) runtime/network_manager.cc:78 (rtorrent+0x3bcdcd) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #10 core::Manager::listen_open() core/manager.cc:191 (rtorrent+0x52df5) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #11 Control::initialize() rtorrent/src/control.cc:71 (rtorrent+0x1d82cf) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #12 main rtorrent/src/main.cc:430 (rtorrent+0x2d55e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)

  Mutex M0 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #4 torrent::runtime::NetworkConfig::lock_guard() const ../torrent/runtime/network_config.h:122 (rtorrent+0x3bafd7) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #5 torrent::runtime::NetworkManager::listen_open_unsafe(unsigned short, unsigned short) runtime/network_manager.cc:160 (rtorrent+0x3bd476) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #6 torrent::runtime::NetworkManager::listen_open(unsigned short, unsigned short) runtime/network_manager.cc:78 (rtorrent+0x3bcdcd) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #7 core::Manager::listen_open() core/manager.cc:191 (rtorrent+0x52df5) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #8 Control::initialize() rtorrent/src/control.cc:71 (rtorrent+0x1d82cf) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #9 main rtorrent/src/main.cc:430 (rtorrent+0x2d55e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)

  Mutex M0 acquired here while holding mutex M1 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #4 torrent::runtime::NetworkConfig::lock_guard() const ../torrent/runtime/network_config.h:122 (rtorrent+0x3bafd7) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #5 torrent::runtime::NetworkConfig::is_block_ipv4() const runtime/network_config.cc:34 (rtorrent+0x3b6c1f) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #6 torrent::ConnectionManager::filter(sockaddr const*) libtorrent/src/torrent/connection_manager.cc:22 (rtorrent+0x548169) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #7 torrent::HandshakeManager::add_incoming(std::unique_ptr<torrent::Handshake, std::default_delete<torrent::Handshake> >&, int, sockaddr const*) protocol/handshake_manager.cc:95 (rtorrent+0x57b492) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #8 operator()<std::unique_ptr<torrent::Handshake>, int, const sockaddr*> libtorrent/src/manager.cc:68 (rtorrent+0x53a32a) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #9 __invoke_impl<void, torrent::Manager::Manager()::<lambda(auto:8&, auto:9, auto:10)>&, std::unique_ptr<torrent::Handshake, std::default_delete<torrent::Handshake> >&, int, const sockaddr*> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x53e524) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #10 __invoke_r<void, torrent::Manager::Manager()::<lambda(auto:8&, auto:9, auto:10)>&, std::unique_ptr<torrent::Handshake, std::default_delete<torrent::Handshake> >&, int, const sockaddr*> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x53db6d) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #11 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x53c95c) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #12 std::function<void (std::unique_ptr<torrent::Handshake, std::default_delete<torrent::Handshake> >&, int, sockaddr const*)>::operator()(std::unique_ptr<torrent::Handshake, std::default_delete<torrent::Handshake> >&, int, sockaddr const*) const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x4d850c) (BuildId: 598f92a08cd357bf3e55dd
    #13 operator() net/listen.cc:244 (rtorrent+0x4d5e39) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #14 __invoke_impl<void, torrent::Listen::event_read()::<lambda()>&> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x4d781b) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #15 __invoke_r<void, torrent::Listen::event_read()::<lambda()>&> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x4d726e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #16 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x4d6ad2) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #17 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70130) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #18 torrent::runtime::SocketManager::open_event_or_cleanup(torrent::Event*, std::function<void ()>, std::function<void ()>) runtime/socket_manager.cc:68 (rtorrent+0x4114db) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #19 torrent::Listen::event_read() net/listen.cc:254 (rtorrent+0x4d60b5) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #20 torrent::net::Poll::process() net/poll_epoll.cc:239 (rtorrent+0x3d501d) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #21 torrent::net::Poll::do_poll(long) net/poll_epoll.cc:182 (rtorrent+0x3d4ada) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #22 torrent::system::Thread::event_loop() system/thread.cc:204 (rtorrent+0x419c2c) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #23 main rtorrent/src/main.cc:448 (rtorrent+0x2d744) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)

  Mutex M1 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #4 torrent::runtime::SocketManager::lock_guard() ../torrent/runtime/socket_manager.h:73 (rtorrent+0x414ad1) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #5 torrent::runtime::SocketManager::open_event_or_cleanup(torrent::Event*, std::function<void ()>, std::function<void ()>) runtime/socket_manager.cc:63 (rtorrent+0x411481) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #6 torrent::Listen::event_read() net/listen.cc:254 (rtorrent+0x4d60b5) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #7 torrent::net::Poll::process() net/poll_epoll.cc:239 (rtorrent+0x3d501d) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #8 torrent::net::Poll::do_poll(long) net/poll_epoll.cc:182 (rtorrent+0x3d4ada) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #9 torrent::system::Thread::event_loop() system/thread.cc:204 (rtorrent+0x419c2c) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
    #10 main rtorrent/src/main.cc:448 (rtorrent+0x2d744) (BuildId: 598f92a08cd357bf3e55dd2fbab2fbd65686478e)
```