### PR TITLE
Flip the lock order to prevent lock order inversion

### DIFF
--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -301,6 +301,11 @@ Thread::process_callbacks(bool only_interrupt) {
   while (true) {
     std::function<void ()> callback;
 
+    // The 'm_callbacks_processing_lock' is used by 'cancel_callback_and_wait' as a way to wait
+    // for the processing of the callbacks to finish.
+    auto processing_lock = std::lock_guard(m_callbacks_processing_lock);
+    m_callbacks_processing = true;
+
     {
       auto lock = std::lock_guard(m_callbacks_lock);
 
@@ -308,19 +313,15 @@ Thread::process_callbacks(bool only_interrupt) {
         callback = m_interrupt_callbacks.extract(m_interrupt_callbacks.begin()).mapped();
       else if (!only_interrupt && !m_callbacks.empty())
         callback = m_callbacks.extract(m_callbacks.begin()).mapped();
-      else
+      else {
+        m_callbacks_processing = false;
         break;
-
-      // The 'm_callbacks_processing_lock' is used by 'cancel_callback_and_wait' as a way to wait
-      // for the processing of the callbacks to finish.
-      m_callbacks_processing_lock.lock();
-      m_callbacks_processing = true;
+      }
     }
 
     callback();
 
     m_callbacks_processing = false;
-    m_callbacks_processing_lock.unlock();
   }
 }
 


### PR DESCRIPTION
Reported by ThreadSanitizer:

```
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=29744)
  Cycle in lock order graph: M0 (0x726800001670) => M1 (0x726800001700) => M2 (0x724000000170) => M0

  Mutex M1 acquired here while holding mutex M0 in thread T2:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 torrent::system::Thread::process_callbacks(bool) system/thread.cc:316 (rtorrent+0x41a793) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7bae) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a4a2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419b0a) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Mutex M0 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::system::Thread::process_callbacks(bool) system/thread.cc:305 (rtorrent+0x41a626) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7bae) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a4a2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419b0a) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #8 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Mutex M2 acquired here while holding mutex M1 in thread T2:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::net::UdnsResolver::resolve(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int)>&&) net/udns_resolver.cc:209 (rtorrent+0x5264a5) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 torrent::net::DnsBuffer::activate_and_resolve_query(torrent::net::DnsBufferQuery) net/dns_buffer.cc:189 (rtorrent+0x482cf4) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 torrent::net::DnsBuffer::resolve(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int)>&&) net/dns_buffer.cc:90 (rtorrent+0x481d7e) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 torrent::net::DnsCache::resolve(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::function<void (std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int)>&&) net/dns_cache.cc:68 (rtorrent+0x48d8dd) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #8 operator() net/resolver.cc:65 (rtorrent+0x3df00d) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #9 __invoke_impl<void, torrent::net::Resolver::resolve_both(void*, const std::string&, int, both_callback&&)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x3e436d) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #10 __invoke_r<void, torrent::net::Resolver::resolve_both(void*, const std::string&, int, both_callback&&)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x3e2b4f) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #11 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x3e18bb) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #12 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70130) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #13 torrent::system::Thread::process_callbacks(bool) system/thread.cc:320 (rtorrent+0x41a7d3) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #14 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7bae) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #15 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a4a2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #16 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419b0a) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #17 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Mutex M1 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 torrent::system::Thread::process_callbacks(bool) system/thread.cc:316 (rtorrent+0x41a793) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7bae) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a4a2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419b0a) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Mutex M0 acquired here while holding mutex M2 in thread T2:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::system::Thread::callback(void*, std::function<void ()>&&) system/thread.cc:76 (rtorrent+0x418f66) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 torrent::system::ThreadInternal::callback(void*, std::function<void ()>&&) ../utils/thread_internal.h:17 (rtorrent+0x41ce01) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 torrent::this_thread::callback(void*, std::function<void ()>&&) system/thread.cc:343 (rtorrent+0x41a9e9) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 operator() net/dns_buffer.cc:181 (rtorrent+0x48294b) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #8 __invoke_impl<void, torrent::net::DnsBuffer::activate_and_resolve_query(torrent::net::DnsBufferQuery)::<lambda(torrent::sin_shared_ptr, int, torrent::sin6_shared_ptr, int)>&, std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x485004) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #9 __invoke_r<void, torrent::net::DnsBuffer::activate_and_resolve_query(torrent::net::DnsBufferQuery)::<lambda(torrent::sin_shared_ptr, int, torrent::sin6_shared_ptr, int)>&, std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x484c92) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #10 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x484364) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #11 std::function<void (std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int)>::operator()(std::shared_ptr<sockaddr_in>, int, std::shared_ptr<sockaddr_in6>, int) const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x486d53) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #12 torrent::net::UdnsResolver::process_final_result_unsafe(std::unique_ptr<torrent::net::UdnsQuery, std::default_delete<torrent::net::UdnsQuery> >&&) net/udns_resolver.cc:516 (rtorrent+0x528ea3) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #13 torrent::net::UdnsResolver::process_partial_result_unsafe(std::_Rb_tree_iterator<std::pair<void* const, std::unique_ptr<torrent::net::UdnsQuery, std::default_delete<torrent::net::UdnsQuery> > > >) net/udns_resolver.cc:498 (rtorrent+0x528afe) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #14 torrent::net::UdnsResolverInternal::a4_callback_wrapper(dns_ctx*, dns_rr_a4*, void*) net/udns_resolver.cc:393 (rtorrent+0x527ca0) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #15 dns_end_query net/udns/udns_resolver.c:623 (rtorrent+0x5a40c2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #16 dns_ioevent net/udns/udns_resolver.c:1120 (rtorrent+0x5a60c3) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #17 torrent::net::UdnsResolver::event_read() net/udns_resolver.cc:310 (rtorrent+0x5272b9) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #18 torrent::net::Poll::process() net/poll_epoll.cc:239 (rtorrent+0x3d4fc7) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #19 torrent::net::Poll::do_poll(long) net/poll_epoll.cc:182 (rtorrent+0x3d4a84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #20 torrent::system::Thread::event_loop() system/thread.cc:204 (rtorrent+0x419cb8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #21 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Mutex M2 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b84)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268e0e) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #4 torrent::net::UdnsResolverInternal::a4_callback_wrapper(dns_ctx*, dns_rr_a4*, void*) net/udns_resolver.cc:367 (rtorrent+0x5278f3) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #5 dns_end_query net/udns/udns_resolver.c:623 (rtorrent+0x5a40c2) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #6 dns_ioevent net/udns/udns_resolver.c:1120 (rtorrent+0x5a60c3) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #7 torrent::net::UdnsResolver::event_read() net/udns_resolver.cc:310 (rtorrent+0x5272b9) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #8 torrent::net::Poll::process() net/poll_epoll.cc:239 (rtorrent+0x3d4fc7) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #9 torrent::net::Poll::do_poll(long) net/poll_epoll.cc:182 (rtorrent+0x3d4a84) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #10 torrent::system::Thread::event_loop() system/thread.cc:204 (rtorrent+0x419cb8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #11 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x4196b8) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)

  Thread T2 'rtorrent-net' (tid=29747, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1078 (libtsan.so.2+0x58c4f) (BuildId: bd04c412d2d38b7c7fa3b7853f33d38688c5dcbb)
    #1 torrent::system::Thread::start_thread() system/thread.cc:56 (rtorrent+0x418dbf) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #2 torrent::initialize() libtorrent/src/torrent/torrent.cc:268 (rtorrent+0x4234f9) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    #3 main rtorrent/src/main.cc:162 (rtorrent+0x2a76c) (BuildId: 763618c6534d16f6215015fd016d44c7505682a6)
    ```