### PR TITLE
CurlStack: Guard the vector during iteration and removal

### DIFF
--- a/src/net/curl_stack.cc
+++ b/src/net/curl_stack.cc
@@ -128,6 +128,7 @@ CurlStack::start_get(const std::shared_ptr<CurlGet>& curl_get) {
     curl_easy_setopt(curl_get->handle_unsafe(), CURLOPT_DNS_CACHE_TIMEOUT, m_dns_timeout);
 
     base_type::push_back(curl_get);
+    m_size = base_type::size();
 
     // Calling curl_multi_add_handle() can result in CurlSocket::receive_socket() being called,
     // which calls CurlStack::is_running().
@@ -150,6 +151,7 @@ CurlStack::close_get(const std::shared_ptr<CurlGet>& curl_get) {
         throw torrent::internal_error("CurlStack::close_get() called on a CurlGet that is not in the stack.");
 
       base_type::erase(itr);
+      m_size = base_type::size();
     }
 
     curl_get->cleanup_unsafe();

--- a/src/net/curl_stack.h
+++ b/src/net/curl_stack.h
@@ -1,6 +1,7 @@
 #ifndef LIBTORRENT_NET_CURL_STACK_H
 #define LIBTORRENT_NET_CURL_STACK_H
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -97,6 +98,9 @@ private:
 
   mutable std::mutex  m_mutex;
 
+  // Mirrors base::size()
+  std::atomic_size_t  m_size{0};
+
   // Use lock guard when accessing these members, and when modifying the underlying vector.
   bool                m_running{true};
 
@@ -122,8 +126,7 @@ CurlStack::is_running() const {
 
 inline unsigned int
 CurlStack::size() const {
-  auto guard = lock_guard();
-  return base_type::size();
+  return m_size;
 }
 
 inline unsigned int


### PR DESCRIPTION
Fixes race between CurlStack::size() and CurlStack::close_get()

WARNING: ThreadSanitizer: data race (pid=25077)
  Read of size 8 at 0x724800000308 by main thread (mutexes: write M0):
    #0 std::vector<std::shared_ptr<torrent::net::CurlGet>, std::allocator<std::shared_ptr<torrent::net::CurlGet> > >::size() const /usr/include/c++/15/bits/stl_vector.h:1119 (rtorrent+0x39f790) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #1 torrent::net::CurlStack::size() const ../net/curl_stack.h:126 (rtorrent+0x39ee1d) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 torrent::net::HttpStack::size() const net/http_stack.cc:79 (rtorrent+0x39e640) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #3 display::print_status_extra(char*, char*) display/utils.cc:425 (rtorrent+0x20f55a) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 display::WindowStatusbar::redraw() display/window_statusbar.cc:30 (rtorrent+0x217be4) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 operator() display/window.cc:28 (rtorrent+0x2110d8) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #6 __invoke_impl<void, display::Window::Window(display::Canvas*, int, extent_type, extent_type, extent_type, extent_type)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x211b27) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #7 __invoke_r<void, display::Window::Window(display::Canvas*, int, extent_type, extent_type, extent_type, extent_type)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x21198a) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #8 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x2117b2) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #9 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70140) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #10 torrent::utils::Scheduler::perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) utils/scheduler.cc:171 (rtorrent+0x404725) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #11 torrent::utils::ExternalScheduler::external_perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) include/torrent/utils/scheduler.h:87 (rtorrent+0x7f0e3) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #12 display::Manager::receive_update() display/manager.cc:67 (rtorrent+0x7ea60) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #13 void std::__invoke_impl<void, void (display::Manager::*&)(), display::Manager*&>(std::__invoke_memfun_deref, void (display::Manager::*&)(), display::Manager*&) /usr/include/c++/15/bits/invoke.h:76 (rtorrent+0x3e167) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #14 std::__invoke_result<void (display::Manager::*&)(), display::Manager*&>::type std::__invoke<void (display::Manager::*&)(), display::Manager*&>(void (display::Manager::*&)(), display::Manager*&) /usr/include/c++/15/bits/invoke.h:98 (rtorrent+0x3dae7) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #15 void std::_Bind<void (display::Manager::*(display::Manager*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/15/functional:515 (rtorrent+0x3d428) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #16 void std::_Bind<void (display::Manager::*(display::Manager*))()>::operator()<, void>() /usr/include/c++/15/functional:600 (rtorrent+0x3cb30) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #17 void std::__invoke_impl<void, std::_Bind<void (display::Manager::*(display::Manager*))()>&>(std::__invoke_other, std::_Bind<void (display::Manager::*(display::Manager*))()>&) /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x3b7c5) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #18 std::enable_if<is_invocable_r_v<void, std::_Bind<void (display::Manager::*(display::Manager*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (display::Manager::*(display::Manager*))()>&>(std::_Bind<void (display::Manager::*(display::Manager*))()>&) /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x3a2c8) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #19 std::_Function_handler<void (), std::_Bind<void (display::Manager::*(display::Manager*))()> >::_M_invoke(std::_Any_data const&) /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x3838f) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #20 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70140) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #21 torrent::utils::Scheduler::perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) utils/scheduler.cc:171 (rtorrent+0x404725) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #22 torrent::system::Thread::process_events() system/thread.cc:285 (rtorrent+0x41a5c7) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #23 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419bda) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #24 main rtorrent/src/main.cc:448 (rtorrent+0x2d754) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Previous write of size 8 at 0x724800000308 by thread T2 (mutexes: write M1, write M2):
    #0 std::vector<std::shared_ptr<torrent::net::CurlGet>, std::allocator<std::shared_ptr<torrent::net::CurlGet> > >::_M_erase(__gnu_cxx::__normal_iterator<std::shared_ptr<torrent::net::CurlGet>*, std::vector<std::shared_ptr<torrent::net::CurlGet>, std::allocator<std::shared_ptr<torrent::net::CurlGet> > > >) /usr/include/c++/15/bits/vector.tcc:186 (rtorrent+0x44f083) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #1 std::vector<std::shared_ptr<torrent::net::CurlGet>, std::allocator<std::shared_ptr<torrent::net::CurlGet> > >::erase(__gnu_cxx::__normal_iterator<std::shared_ptr<torrent::net::CurlGet> const*, std::vector<std::shared_ptr<torrent::net::CurlGet>, std::allocator<std::shared_ptr<torrent::net::CurlGet> > > >) /usr/include/c++/15/bits/stl_vector.h:1793 (rtorrent+0x44e3c3) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 torrent::net::CurlStack::close_get(std::shared_ptr<torrent::net::CurlGet> const&) net/curl_stack.cc:152 (rtorrent+0x44c6b0) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #3 operator() net/curl_get.cc:181 (rtorrent+0x446e18) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 __invoke_impl<void, torrent::net::CurlGet::close(const std::shared_ptr<torrent::net::CurlGet>&, torrent::system::Thread*, bool)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x44963f) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 __invoke_r<void, torrent::net::CurlGet::close(const std::shared_ptr<torrent::net::CurlGet>&, torrent::system::Thread*, bool)::<lambda()>&> /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x449359) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #6 _M_invoke /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x448e41) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #7 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70140) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #8 torrent::system::Thread::process_callbacks(bool) system/thread.cc:323 (rtorrent+0x41a8d2) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #9 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7c1e) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #10 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a572) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #11 torrent::system::Thread::event_loop() system/thread.cc:194 (rtorrent+0x419c01) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #12 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x419788) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Location is heap block of size 384 at 0x724800000300 allocated by main thread:
    #0 operator new(unsigned long, std::align_val_t) ../../../../src/libsanitizer/tsan/tsan_new_delete.cpp:88 (libtsan.so.2+0xa325b) (BuildId: 23ea634af55c5ef94cda6211eb5e19855c8e9596)
    #1 torrent::net::HttpStack::HttpStack(torrent::system::Thread*) net/http_stack.cc:59 (rtorrent+0x39e431) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 std::__detail::_MakeUniq<torrent::net::HttpStack>::__single_object std::make_unique<torrent::net::HttpStack, torrent::ThreadNet*&>(torrent::ThreadNet*&) /usr/include/c++/15/bits/unique_ptr.h:1084 (rtorrent+0x4f8631) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #3 torrent::ThreadNet::create_thread() net/thread_net.cc:46 (rtorrent+0x4f77e2) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 torrent::initialize() libtorrent/src/torrent/torrent.cc:249 (rtorrent+0x423484) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 main rtorrent/src/main.cc:162 (rtorrent+0x2a77c) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Mutex M0 (0x724800000388) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: 23ea634af55c5ef94cda6211eb5e19855c8e9596)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b94) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b94)
    #3 std::scoped_lock<std::mutex>::scoped_lock(std::mutex&) /usr/include/c++/15/mutex:789 (rtorrent+0x39f70a) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 torrent::net::CurlStack::lock_guard() const net/curl_stack.h:77 (rtorrent+0x39edc0) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 torrent::net::CurlStack::set_max_host_connections(unsigned int) net/curl_stack.cc:54 (rtorrent+0x44bc5d) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #6 torrent::net::HttpStack::set_max_host_connections(unsigned int) net/http_stack.cc:104 (rtorrent+0x39e7eb) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #7 torrent::initialize() libtorrent/src/torrent/torrent.cc:261 (rtorrent+0x423530) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #8 main rtorrent/src/main.cc:162 (rtorrent+0x2a77c) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Mutex M1 (0x726800001700) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: 23ea634af55c5ef94cda6211eb5e19855c8e9596)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b94) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b94)
    #3 torrent::system::Thread::process_callbacks(bool) system/thread.cc:307 (rtorrent+0x41a6ee) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 torrent::ThreadNet::call_events() net/thread_net.cc:99 (rtorrent+0x4f7c1e) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 torrent::system::Thread::process_events() system/thread.cc:280 (rtorrent+0x41a572) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #6 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419bda) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #7 torrent::system::Thread::enter_event_loop(void*) system/thread.cc:168 (rtorrent+0x419788) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Mutex M2 (0x724000001f10) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1424 (libtsan.so.2+0x5824a) (BuildId: 23ea634af55c5ef94cda6211eb5e19855c8e9596)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/x86_64-linux-gnu/c++/15/bits/gthr-default.h:795 (rtorrent+0xa8b94) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 std::mutex::lock() /usr/include/c++/15/bits/std_mutex.h:115 (rtorrent+0xa8b94)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15/bits/std_mutex.h:252 (rtorrent+0x268838) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #4 torrent::net::CurlGet::lock_guard() const net/curl_get.h:81 (rtorrent+0x39ccab) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #5 torrent::net::CurlGet::reset(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<std::ostream>) net/curl_get.cc:60 (rtorrent+0x4464a7) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #6 torrent::net::HttpGet::reset(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<std::ostream>) net/http_get.cc:63 (rtorrent+0x39a1e5) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #7 torrent::TrackerHttp::TrackerHttp(torrent::TrackerInfo const&, int) tracker/tracker_http.cc:37 (rtorrent+0x594da4) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #8 void std::_Construct<torrent::TrackerHttp, torrent::TrackerInfo&, int&>(torrent::TrackerHttp*, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/stl_construct.h:133 (rtorrent+0x51d4b6) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #9 void std::allocator_traits<std::allocator<void> >::construct<torrent::TrackerHttp, torrent::TrackerInfo&, int&>(std::allocator<void>&, torrent::TrackerHttp*, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/alloc_traits.h:805 (rtorrent+0x51c4c2) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #10 std::_Sp_counted_ptr_inplace<torrent::TrackerHttp, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<torrent::TrackerInfo&, int&>(std::allocator<void>, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/shared_ptr_base.h:606 (rtorrent+0x51c4c2)
    #11 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<torrent::TrackerHttp, std::allocator<void>, torrent::TrackerInfo&, int&>(torrent::TrackerHttp*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/shared_ptr_base.h:969 (rtorrent+0x51bab0) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #12 std::__shared_ptr<torrent::TrackerHttp, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, torrent::TrackerInfo&, int&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/shared_ptr_base.h:1719 (rtorrent+0x51aef8) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #13 std::shared_ptr<torrent::TrackerHttp>::shared_ptr<std::allocator<void>, torrent::TrackerInfo&, int&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/shared_ptr.h:463 (rtorrent+0x51961c) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #14 std::shared_ptr<std::enable_if<!std::is_array<torrent::TrackerHttp>::value, torrent::TrackerHttp>::type> std::make_shared<torrent::TrackerHttp, torrent::TrackerInfo&, int&>(torrent::TrackerInfo&, int&) /usr/include/c++/15/bits/shared_ptr.h:1008 (rtorrent+0x517771) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #15 torrent::TrackerList::insert_url(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) tracker/tracker_list.cc:292 (rtorrent+0x50bb95) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #16 torrent::DownloadConstructor::add_tracker_single(torrent::Object const&, int) download/download_constructor.cc:179 (rtorrent+0x4993ad) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #17 torrent::DownloadConstructor::add_tracker_group(torrent::Object const&) download/download_constructor.cc:170 (rtorrent+0x499247) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #18 torrent::DownloadConstructor::parse_tracker(torrent::Object const&) download/download_constructor.cc:144 (rtorrent+0x498e6c) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #19 torrent::download_add(torrent::Object*, unsigned int) libtorrent/src/torrent/torrent.cc:376 (rtorrent+0x4240fe) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #20 core::DownloadList::create(torrent::Object*, unsigned int, bool) core/download_list.cc:109 (rtorrent+0x46d76) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #21 core::DownloadFactory::receive_success() core/download_factory.cc:173 (rtorrent+0x1f60b3) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #22 core::DownloadFactory::receive_loaded() core/download_factory.cc:148 (rtorrent+0x1f5ce2) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #23 core::DownloadFactory::receive_load() core/download_factory.cc:139 (rtorrent+0x1f5ace) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #24 void std::__invoke_impl<void, void (core::DownloadFactory::*&)(), core::DownloadFactory*&>(std::__invoke_memfun_deref, void (core::DownloadFactory::*&)(), core::DownloadFactory*&) /usr/include/c++/15/bits/invoke.h:76 (rtorrent+0x1fe15f) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #25 std::__invoke_result<void (core::DownloadFactory::*&)(), core::DownloadFactory*&>::type std::__invoke<void (core::DownloadFactory::*&)(), core::DownloadFactory*&>(void (core::DownloadFactory::*&)(), core::DownloadFactory*&) /usr/include/c++/15/bits/invoke.h:98 (rtorrent+0x1fe073) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #26 void std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/include/c++/15/functional:515 (rtorrent+0x1fdfbc) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #27 void std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>::operator()<, void>() /usr/include/c++/15/functional:600 (rtorrent+0x1fde64) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #28 void std::__invoke_impl<void, std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>&>(std::__invoke_other, std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>&) /usr/include/c++/15/bits/invoke.h:63 (rtorrent+0x1fdc7f) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #29 std::enable_if<is_invocable_r_v<void, std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>&>(std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()>&) /usr/include/c++/15/bits/invoke.h:113 (rtorrent+0x1fd8a0) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #30 std::_Function_handler<void (), std::_Bind<void (core::DownloadFactory::*(core::DownloadFactory*))()> >::_M_invoke(std::_Any_data const&) /usr/include/c++/15/bits/std_function.h:292 (rtorrent+0x1fd3cc) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #31 std::function<void ()>::operator()() const /usr/include/c++/15/bits/std_function.h:593 (rtorrent+0x70140) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #32 torrent::utils::Scheduler::perform(std::chrono::duration<long, std::ratio<1l, 1000000l> >) utils/scheduler.cc:171 (rtorrent+0x404725) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #33 torrent::system::Thread::process_events() system/thread.cc:285 (rtorrent+0x41a5c7) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #34 torrent::system::Thread::event_loop() system/thread.cc:188 (rtorrent+0x419bda) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #35 main rtorrent/src/main.cc:448 (rtorrent+0x2d754) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)

  Thread T2 'rtorrent-net' (tid=25080, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1078 (libtsan.so.2+0x58c4f) (BuildId: 23ea634af55c5ef94cda6211eb5e19855c8e9596)
    #1 torrent::system::Thread::start_thread() system/thread.cc:56 (rtorrent+0x418e8f) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #2 torrent::initialize() libtorrent/src/torrent/torrent.cc:269 (rtorrent+0x4235e0) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)
    #3 main rtorrent/src/main.cc:162 (rtorrent+0x2a77c) (BuildId: 4e56967a3fe5a338cfd89d6aa6b314dcceb5b6c1)