### PR TITLE
Fix use-after-free in dht_compare_closer

### DIFF
--- a/src/dht/transactions/dht_search.h
+++ b/src/dht/transactions/dht_search.h
@@ -40,7 +40,7 @@ struct dht_compare_closer {
   bool operator () (const std::unique_ptr<DhtNode>& one, const std::unique_ptr<DhtNode>& two) const;
 
 private:
-  const HashString&   m_target;
+  const HashString    m_target;
 };
 
 // Use std::enable_shared_from_this as a temporary hack.


### PR DESCRIPTION
const HashString& info_hash copy is created in the lambda capture in DhtController::announce

then, the reference to captured value is passed through

DhtRouter::announce
DhtServer::announce
DhtAnnounce::DhtAnnounce
DhtSearch::DhtSearch

The refeenced HashString is then destroyed at the end of callback with the DhtSearch reference outliving it.

Capture the HashString reference instead so DhtSearch still references the value in TrackerWorker::TrackerInfo .