### PR TITLE
pkgconfig: add libcurl to Requires.private for static linking

### DIFF
--- a/libtorrent.pc.in
+++ b/libtorrent.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libtorrent
 Description: A BitTorrent library
 Version: @VERSION@
-Requires.private: zlib, libcrypto
+Requires.private: zlib, libcrypto, libcurl
 Libs: -L${libdir} -ltorrent
-Libs.private: @PTHREAD_LIBS@ @ATOMIC_LIBS@
+Libs.private: @PTHREAD_LIBS@ @ATOMIC_LIBS@ @LIBCURL_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
libtorrent was updated to detect and link against libcurl via `PKG_CHECK_MODULES([LIBCURL], ...)` in configure.ac (commit 20b92330), but `libtorrent.pc.in` was not updated to declare the dependency.

This causes static linking failures for downstream consumers (like rtorrent) that rely on `pkg-config --static --libs libtorrent` to resolve transitive dependencies. Without `libcurl` in `Requires.private`, the generated `libtorrent.pc` is missing curl's link flags, leading to undefined `curl_easy_*` / `curl_multi_*` symbols at the final link step.

**Changes:**
- `libtorrent.pc.in`: added `libcurl` to `Requires.private`
- `libtorrent.pc.in`: added `@LIBCURL_LIBS@` to `Libs.private`