### PR TITLE
socket_manager: add per-category allocation limits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 BasedOnStyle: LLVM
-Standard: c++14
+Standard: c++17
 
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
@@ -10,11 +10,15 @@ BinPackParameters: false
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: false
 ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
 IndentCaseLabels: false
 IndentWidth: 2
+PackConstructorInitializers: Never
 PenaltyReturnTypeOnItsOwnLine: 130
 PointerAlignment: Left
+SpacesInContainerLiterals: true
 
 AlignEscapedNewlines: Right
 AlignConsecutiveDeclarations:

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 BasedOnStyle: LLVM
-Standard: c++17
+Standard: c++20
 
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -5,25 +5,25 @@
 #include <algorithm>
 #include <cstdio>
 
-#include "manager.h"
 #include "dht/dht_bucket.h"
 #include "dht/dht_router.h"
 #include "dht/dht_transaction.h"
 #include "dht/transactions/dht_announce.h"
+#include "manager.h"
 #include "torrent/exceptions.h"
-#include "torrent/object.h"
-#include "torrent/object_static_map.h"
-#include "torrent/object_stream.h"
 #include "torrent/net/fd.h"
 #include "torrent/net/poll.h"
 #include "torrent/net/socket_address.h"
+#include "torrent/object.h"
+#include "torrent/object_static_map.h"
+#include "torrent/object_stream.h"
 #include "torrent/runtime/network_config.h"
 #include "torrent/runtime/runtime.h"
 #include "torrent/runtime/socket_manager.h"
 #include "torrent/utils/log.h"
 #include "tracker/tracker_dht.h"
 
-#define LT_LOG_THIS(log_fmt, ...)                                       \
+#define LT_LOG_THIS(log_fmt, ...) \
   lt_log_print_subsystem(torrent::LOG_DHT_SERVER, "dht_server", log_fmt, __VA_ARGS__);
 
 namespace {
@@ -51,29 +51,31 @@ namespace torrent {
 // See torrent/object_static_map.h for how this works.
 template <>
 const DhtMessage::key_list_type DhtMessage::base_type::keys = {
-  { key_a_id,       "a::id*S" },
-  { key_a_infoHash, "a::info_hash*S" },
-  { key_a_port,     "a::port", },
-  { key_a_target,   "a::target*S" },
-  { key_a_token,    "a::token*S" },
+  {key_a_id, "a::id*S"},
+  {key_a_infoHash, "a::info_hash*S"},
+  {
+    key_a_port,
+    "a::port",
+  },
+  {key_a_target, "a::target*S"},
+  {key_a_token, "a::token*S"},
 
-  { key_e_0,        "e[]*" },
-  { key_e_1,        "e[]*" },
+  {key_e_0, "e[]*"},
+  {key_e_1, "e[]*"},
 
-  { key_q,          "q*S" },
+  {key_q, "q*S"},
 
-  { key_r_id,       "r::id*S" },
-  { key_r_nodes,    "r::nodes*S" },
-  { key_r_token,    "r::token*S" },
-  { key_r_values,   "r::values*L" },
+  {key_r_id, "r::id*S"},
+  {key_r_nodes, "r::nodes*S"},
+  {key_r_token, "r::token*S"},
+  {key_r_values, "r::values*L"},
 
-  { key_t,          "t*S" },
-  { key_v,          "v*" },
-  { key_y,          "y*S" },
+  {key_t, "t*S"},
+  {key_v, "v*"},
+  {key_y, "y*S"},
 };
 
-DhtServer::DhtServer(DhtRouter* router)
-  : m_router(router) {
+DhtServer::DhtServer(DhtRouter* router) : m_router(router) {
 
   m_fileDesc = -1;
   reset_statistics();
@@ -136,8 +138,7 @@ DhtServer::start(int port) {
   runtime::socket_manager()->register_event_or_throw(this, [this]() {
       this_thread::poll()->open(this);
       this_thread::poll()->insert_read(this);
-      this_thread::poll()->insert_error(this);
-    });
+      this_thread::poll()->insert_error(this); }, runtime::SocketManager::category_dht);
 }
 
 void
@@ -154,11 +155,11 @@ DhtServer::stop() {
   this_thread::scheduler()->erase(&m_task_timeout);
 
   runtime::socket_manager()->close_event_or_throw(this, [this]() {
-      this_thread::poll()->remove_and_close(this);
+    this_thread::poll()->remove_and_close(this);
 
-      fd_close(file_descriptor());
-      set_file_descriptor(-1);
-    });
+    fd_close(file_descriptor());
+    set_file_descriptor(-1);
+  });
 
   m_networkUp = false;
 }
@@ -166,10 +167,10 @@ DhtServer::stop() {
 void
 DhtServer::reset_statistics() {
   m_queriesReceived = 0;
-  m_queriesSent = 0;
+  m_queriesSent     = 0;
   m_repliesReceived = 0;
-  m_errorsReceived = 0;
-  m_errorsCaught = 0;
+  m_errorsReceived  = 0;
+  m_errorsCaught    = 0;
 }
 
 // Ping a node whose ID we know.
@@ -198,7 +199,7 @@ DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
   // This shouldn't happen, it means we had no contactable nodes at all.
   if (!search->start())
     return;
-    // throw internal_error("DhtServer::find_node search start failed, no contactable nodes.");  ///////////////// TMP
+  // throw internal_error("DhtServer::find_node search start failed, no contactable nodes.");  ///////////////// TMP
 
   m_searches.insert(search);
 }
@@ -218,7 +219,7 @@ DhtServer::announce(const DhtBucket& contacts, const HashString& infoHash, std::
   // This can only happen if all nodes we know are bad.
   if (!announce->start())
     return;
-    // throw internal_error("DhtServer::announce search start failed, no contactable nodes.");  ///////////////// TMP
+  // throw internal_error("DhtServer::announce search start failed, no contactable nodes.");  ///////////////// TMP
 
   m_searches.insert(announce);
   announce->update_status();
@@ -343,7 +344,7 @@ DhtServer::create_get_peers_response(const DhtMessage& req, const sockaddr* sa, 
 
   const HashString* info_hash = HashString::cast_from(info_hash_str.data());
 
-  DhtTracker* tracker = m_router->get_tracker(*info_hash, false);
+  DhtTracker*       tracker = m_router->get_tracker(*info_hash, false);
 
   // If we're not tracking or have no peers, send closest nodes.
   if (!tracker || tracker->empty()) {
@@ -380,7 +381,7 @@ DhtServer::create_announce_peer_response(const DhtMessage& req, const sockaddr* 
 void
 DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtMessage& response) {
   int  transactionId = static_cast<unsigned char>(response[key_t].as_raw_string().data()[0]);
-  auto itr = m_transactions.find(DhtTransaction::key(sa, transactionId));
+  auto itr           = m_transactions.find(DhtTransaction::key(sa, transactionId));
 
   // Response to a transaction we don't have in our table. At this point it's
   // impossible to tell whether it used to be a valid transaction but timed out
@@ -408,17 +409,17 @@ DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtM
       return;
 
     switch (transaction->type()) {
-      case DhtTransaction::DHT_FIND_NODE:
-        parse_find_node_reply(transaction->as_find_node(), response[key_r_nodes].as_raw_string());
-        break;
+    case DhtTransaction::DHT_FIND_NODE:
+      parse_find_node_reply(transaction->as_find_node(), response[key_r_nodes].as_raw_string());
+      break;
 
-      case DhtTransaction::DHT_GET_PEERS:
-        parse_get_peers_reply(transaction->as_get_peers(), response);
-        break;
+    case DhtTransaction::DHT_GET_PEERS:
+      parse_get_peers_reply(transaction->as_get_peers(), response);
+      break;
 
-      // Nothing to do for DHT_PING and DHT_ANNOUNCE_PEER
-      default:
-        break;
+    // Nothing to do for DHT_PING and DHT_ANNOUNCE_PEER
+    default:
+      break;
     }
 
     // Mark node responsive only if all processing was successful, without errors.
@@ -439,7 +440,7 @@ DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtM
 void
 DhtServer::process_error(const sockaddr* sa, const DhtMessage& error) {
   int  transactionId = static_cast<unsigned char>(error[key_t].as_raw_string().data()[0]);
-  auto itr = m_transactions.find(DhtTransaction::key(sa, transactionId));
+  auto itr           = m_transactions.find(DhtTransaction::key(sa, transactionId));
 
   if (itr == m_transactions.end())
     return;
@@ -533,26 +534,26 @@ DhtServer::find_node_next(DhtTransactionSearch* transaction) {
 void
 DhtServer::add_packet(std::shared_ptr<DhtTransactionPacket> packet, int priority) {
   switch (priority) {
-    // High priority packets are for important queries, and quite small.
-    // They're added to front of high priority queue and thus will be the
-    // next packets sent.
-    case packet_prio_high:
-      m_highQueue.push_front(std::move(packet));
-      break;
+  // High priority packets are for important queries, and quite small.
+  // They're added to front of high priority queue and thus will be the
+  // next packets sent.
+  case packet_prio_high:
+    m_highQueue.push_front(std::move(packet));
+    break;
 
-    // Low priority query packets are added to the back of the high priority
-    // queue and will be sent when all high priority packets have been transmitted.
-    case packet_prio_low:
-      m_highQueue.push_back(std::move(packet));
-      break;
+  // Low priority query packets are added to the back of the high priority
+  // queue and will be sent when all high priority packets have been transmitted.
+  case packet_prio_low:
+    m_highQueue.push_back(std::move(packet));
+    break;
 
-    // Reply packets will be processed after all of our own packets have been send.
-    case packet_prio_reply:
-      m_lowQueue.push_back(std::move(packet));
-      break;
+  // Reply packets will be processed after all of our own packets have been send.
+  case packet_prio_reply:
+    m_lowQueue.push_back(std::move(packet));
+    break;
 
-    default:
-      throw internal_error("DhtServer::add_packet called with invalid priority.");
+  default:
+    throw internal_error("DhtServer::add_packet called with invalid priority.");
   }
 }
 
@@ -575,36 +576,36 @@ DhtServer::create_query(transaction_itr itr, int tID, [[maybe_unused]] const soc
   DhtMessage query;
 
   // Transaction ID is a bencode string.
-  query[key_t] = raw_bencode(query.data_end, 3);
+  query[key_t]      = raw_bencode(query.data_end, 3);
   *query.data_end++ = '1';
   *query.data_end++ = ':';
   *query.data_end++ = tID;
 
   auto& transaction = itr->second;
 
-  query[key_q] = raw_string::from_c_str(queries[transaction->type()]);
-  query[key_y] = raw_bencode::from_c_str("1:q");
-  query[key_v] = raw_bencode("4:" PEER_VERSION, 6);
+  query[key_q]    = raw_string::from_c_str(queries[transaction->type()]);
+  query[key_y]    = raw_bencode::from_c_str("1:q");
+  query[key_v]    = raw_bencode("4:" PEER_VERSION, 6);
   query[key_a_id] = m_router->id_raw_string();
 
   switch (transaction->type()) {
-    case DhtTransaction::DHT_PING:
-      // nothing to do
-      break;
+  case DhtTransaction::DHT_PING:
+    // nothing to do
+    break;
 
-    case DhtTransaction::DHT_FIND_NODE:
-      query[key_a_target] = transaction->as_find_node()->search()->target_raw_string();
-      break;
+  case DhtTransaction::DHT_FIND_NODE:
+    query[key_a_target] = transaction->as_find_node()->search()->target_raw_string();
+    break;
 
-    case DhtTransaction::DHT_GET_PEERS:
-      query[key_a_infoHash] = transaction->as_get_peers()->search()->target_raw_string();
-      break;
+  case DhtTransaction::DHT_GET_PEERS:
+    query[key_a_infoHash] = transaction->as_get_peers()->search()->target_raw_string();
+    break;
 
-    case DhtTransaction::DHT_ANNOUNCE_PEER:
-      query[key_a_infoHash] = transaction->as_announce_peer()->info_hash_raw_string();
-      query[key_a_token]    = transaction->as_announce_peer()->token();
-      query[key_a_port]     = runtime::listen_port();
-      break;
+  case DhtTransaction::DHT_ANNOUNCE_PEER:
+    query[key_a_infoHash] = transaction->as_announce_peer()->info_hash_raw_string();
+    query[key_a_token]    = transaction->as_announce_peer()->token();
+    query[key_a_port]     = runtime::listen_port();
+    break;
   }
 
   auto packet = std::make_shared<DhtTransactionPacket>(transaction->address(), query, tID, transaction);
@@ -618,9 +619,9 @@ DhtServer::create_query(transaction_itr itr, int tID, [[maybe_unused]] const soc
 void
 DhtServer::create_response(const DhtMessage& req, const sockaddr* sa, DhtMessage& reply) {
   reply[key_r_id] = m_router->id_raw_string();
-  reply[key_t] = req[key_t];
-  reply[key_y] = raw_bencode::from_c_str("1:r");
-  reply[key_v] = raw_bencode("4:" PEER_VERSION, 6);
+  reply[key_t]    = req[key_t];
+  reply[key_y]    = raw_bencode::from_c_str("1:r");
+  reply[key_v]    = raw_bencode("4:" PEER_VERSION, 6);
 
   add_packet(std::make_shared<DhtTransactionPacket>(sa, reply), packet_prio_reply);
 }
@@ -632,8 +633,8 @@ DhtServer::create_error(const DhtMessage& req, const sockaddr* sa, int num, cons
   if (req[key_t].is_raw_string() && req[key_t].as_raw_string().size() < 67)
     error[key_t] = req[key_t];
 
-  error[key_y] = raw_bencode::from_c_str("1:e");
-  error[key_v] = raw_bencode("4:" PEER_VERSION, 6);
+  error[key_y]   = raw_bencode::from_c_str("1:e");
+  error[key_v]   = raw_bencode("4:" PEER_VERSION, 6);
   error[key_e_0] = num;
   error[key_e_1] = raw_string::from_c_str(msg);
 
@@ -652,9 +653,9 @@ DhtServer::add_transaction(std::shared_ptr<DhtTransaction> transaction, int prio
   // node, a collision is extremely unlikely, and a linear search for the first
   // open one is the most efficient.
   unsigned int rnd = static_cast<uint8_t>(random());
-  unsigned int id = rnd;
+  unsigned int id  = rnd;
 
-  auto insertItr = m_transactions.lower_bound(transaction->key(rnd));
+  auto         insertItr = m_transactions.lower_bound(transaction->key(rnd));
 
   // If key matches, keep trying successive IDs.
   while (insertItr != m_transactions.end() && insertItr->first == transaction->key(id)) {
@@ -734,15 +735,15 @@ DhtServer::clear_transactions() {
 void
 DhtServer::event_read() {
   while (true) {
-    Object request;
-    int type = '?';
-    DhtMessage message;
-    raw_string nodeIdStr;
+    Object            request;
+    int               type = '?';
+    DhtMessage        message;
+    raw_string        nodeIdStr;
     const HashString* nodeId = NULL;
-    char buffer[2048];
+    char              buffer[2048];
 
-    sockaddr_in6 sa_raw{};
-    sockaddr* sa = reinterpret_cast<sockaddr*>(&sa_raw);
+    sockaddr_in6      sa_raw{};
+    sockaddr*         sa = reinterpret_cast<sockaddr*>(&sa_raw);
 
     try {
       int32_t read = read_datagram_sa(buffer, sizeof(buffer), sa, sizeof(sa_raw));
@@ -753,7 +754,7 @@ DhtServer::event_read() {
       // We can currently only process mapped-IPv4 addresses, not real IPv6.
       // Translate them to an af_inet socket_address.
       if (sa_is_v4mapped(sa)) {
-        auto sa_unmapped = sin_from_v4mapped_in6(&sa_raw);
+        auto sa_unmapped                         = sin_from_v4mapped_in6(&sa_raw);
         *reinterpret_cast<sockaddr_in*>(&sa_raw) = *sa_unmapped.get();
       }
 
@@ -772,8 +773,8 @@ DhtServer::event_read() {
         throw dht_error(dht_error_protocol, "No transaction ID");
 
       // Restrict the length of Transaction IDs. We echo them in our replies.
-      if(message[key_t].as_raw_string().size() > 20) {
-		  throw dht_error(dht_error_protocol, "Transaction ID length too long");
+      if (message[key_t].as_raw_string().size() > 20) {
+        throw dht_error(dht_error_protocol, "Transaction ID length too long");
       }
 
       if (!message[key_y].is_raw_string())
@@ -807,25 +808,25 @@ DhtServer::event_read() {
         throw dht_error(dht_error_protocol, "Send your own ID, not mine");
 
       switch (type) {
-        case 'q':
-          process_query(*nodeId, sa, message);
-          break;
+      case 'q':
+        process_query(*nodeId, sa, message);
+        break;
 
-        case 'r':
-          process_response(*nodeId, sa, message);
-          break;
+      case 'r':
+        process_response(*nodeId, sa, message);
+        break;
 
-        case 'e':
-          process_error(sa, message);
-          break;
+      case 'e':
+        process_error(sa, message);
+        break;
 
-        default:
-          throw dht_error(dht_error_bad_method, "Unknown message type.");
+      default:
+        throw dht_error(dht_error_bad_method, "Unknown message type.");
       }
 
-    // If node was querying us, reply with error packet, otherwise mark the node as "query failed",
-    // so that if it repeatedly sends malformed replies we will drop it instead of propagating it
-    // to other nodes.
+      // If node was querying us, reply with error packet, otherwise mark the node as "query failed",
+      // so that if it repeatedly sends malformed replies we will drop it instead of propagating it
+      // to other nodes.
     } catch (const bencode_error& e) {
       if ((type == 'r' || type == 'e') && nodeId != NULL) {
         m_router->node_inactive(*nodeId, sa);
@@ -851,10 +852,10 @@ DhtServer::event_read() {
 void
 DhtServer::process_queue(packet_queue& queue) {
   while (!queue.empty()) {
-    auto packet = queue.front();
+    auto                     packet         = queue.front();
     DhtTransaction::key_type transactionKey = 0;
 
-    if(packet->has_transaction())
+    if (packet->has_transaction())
       transactionKey = packet->transaction()->key(packet->id());
 
     // Make sure its transaction hasn't timed out yet, if it has/had one

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -5,25 +5,25 @@
 #include <algorithm>
 #include <cstdio>
 
+#include "manager.h"
 #include "dht/dht_bucket.h"
 #include "dht/dht_router.h"
 #include "dht/dht_transaction.h"
 #include "dht/transactions/dht_announce.h"
-#include "manager.h"
 #include "torrent/exceptions.h"
-#include "torrent/net/fd.h"
-#include "torrent/net/poll.h"
-#include "torrent/net/socket_address.h"
 #include "torrent/object.h"
 #include "torrent/object_static_map.h"
 #include "torrent/object_stream.h"
+#include "torrent/net/fd.h"
+#include "torrent/net/poll.h"
+#include "torrent/net/socket_address.h"
 #include "torrent/runtime/network_config.h"
 #include "torrent/runtime/runtime.h"
 #include "torrent/runtime/socket_manager.h"
 #include "torrent/utils/log.h"
 #include "tracker/tracker_dht.h"
 
-#define LT_LOG_THIS(log_fmt, ...) \
+#define LT_LOG_THIS(log_fmt, ...)                                       \
   lt_log_print_subsystem(torrent::LOG_DHT_SERVER, "dht_server", log_fmt, __VA_ARGS__);
 
 namespace {
@@ -51,31 +51,29 @@ namespace torrent {
 // See torrent/object_static_map.h for how this works.
 template <>
 const DhtMessage::key_list_type DhtMessage::base_type::keys = {
-  {key_a_id, "a::id*S"},
-  {key_a_infoHash, "a::info_hash*S"},
-  {
-    key_a_port,
-    "a::port",
-  },
-  {key_a_target, "a::target*S"},
-  {key_a_token, "a::token*S"},
+  { key_a_id,       "a::id*S" },
+  { key_a_infoHash, "a::info_hash*S" },
+  { key_a_port,     "a::port", },
+  { key_a_target,   "a::target*S" },
+  { key_a_token,    "a::token*S" },
 
-  {key_e_0, "e[]*"},
-  {key_e_1, "e[]*"},
+  { key_e_0,        "e[]*" },
+  { key_e_1,        "e[]*" },
 
-  {key_q, "q*S"},
+  { key_q,          "q*S" },
 
-  {key_r_id, "r::id*S"},
-  {key_r_nodes, "r::nodes*S"},
-  {key_r_token, "r::token*S"},
-  {key_r_values, "r::values*L"},
+  { key_r_id,       "r::id*S" },
+  { key_r_nodes,    "r::nodes*S" },
+  { key_r_token,    "r::token*S" },
+  { key_r_values,   "r::values*L" },
 
-  {key_t, "t*S"},
-  {key_v, "v*"},
-  {key_y, "y*S"},
+  { key_t,          "t*S" },
+  { key_v,          "v*" },
+  { key_y,          "y*S" },
 };
 
-DhtServer::DhtServer(DhtRouter* router) : m_router(router) {
+DhtServer::DhtServer(DhtRouter* router)
+  : m_router(router) {
 
   m_fileDesc = -1;
   reset_statistics();
@@ -135,10 +133,11 @@ DhtServer::start(int port) {
   set_file_descriptor(fd);
 
   // TODO: This throws internal_error on failure.
-  runtime::socket_manager()->register_event_or_throw(this, [this]() {
+  runtime::socket_manager()->register_event_or_throw(this, runtime::SocketManager::category_internal, [this]() {
       this_thread::poll()->open(this);
       this_thread::poll()->insert_read(this);
-      this_thread::poll()->insert_error(this); }, runtime::SocketManager::category_dht);
+      this_thread::poll()->insert_error(this);
+    });
 }
 
 void
@@ -155,11 +154,11 @@ DhtServer::stop() {
   this_thread::scheduler()->erase(&m_task_timeout);
 
   runtime::socket_manager()->close_event_or_throw(this, [this]() {
-    this_thread::poll()->remove_and_close(this);
+      this_thread::poll()->remove_and_close(this);
 
-    fd_close(file_descriptor());
-    set_file_descriptor(-1);
-  });
+      fd_close(file_descriptor());
+      set_file_descriptor(-1);
+    });
 
   m_networkUp = false;
 }
@@ -167,10 +166,10 @@ DhtServer::stop() {
 void
 DhtServer::reset_statistics() {
   m_queriesReceived = 0;
-  m_queriesSent     = 0;
+  m_queriesSent = 0;
   m_repliesReceived = 0;
-  m_errorsReceived  = 0;
-  m_errorsCaught    = 0;
+  m_errorsReceived = 0;
+  m_errorsCaught = 0;
 }
 
 // Ping a node whose ID we know.
@@ -199,7 +198,7 @@ DhtServer::find_node(const DhtBucket& contacts, const HashString& target) {
   // This shouldn't happen, it means we had no contactable nodes at all.
   if (!search->start())
     return;
-  // throw internal_error("DhtServer::find_node search start failed, no contactable nodes.");  ///////////////// TMP
+    // throw internal_error("DhtServer::find_node search start failed, no contactable nodes.");  ///////////////// TMP
 
   m_searches.insert(search);
 }
@@ -219,7 +218,7 @@ DhtServer::announce(const DhtBucket& contacts, const HashString& infoHash, std::
   // This can only happen if all nodes we know are bad.
   if (!announce->start())
     return;
-  // throw internal_error("DhtServer::announce search start failed, no contactable nodes.");  ///////////////// TMP
+    // throw internal_error("DhtServer::announce search start failed, no contactable nodes.");  ///////////////// TMP
 
   m_searches.insert(announce);
   announce->update_status();
@@ -344,7 +343,7 @@ DhtServer::create_get_peers_response(const DhtMessage& req, const sockaddr* sa, 
 
   const HashString* info_hash = HashString::cast_from(info_hash_str.data());
 
-  DhtTracker*       tracker = m_router->get_tracker(*info_hash, false);
+  DhtTracker* tracker = m_router->get_tracker(*info_hash, false);
 
   // If we're not tracking or have no peers, send closest nodes.
   if (!tracker || tracker->empty()) {
@@ -381,7 +380,7 @@ DhtServer::create_announce_peer_response(const DhtMessage& req, const sockaddr* 
 void
 DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtMessage& response) {
   int  transactionId = static_cast<unsigned char>(response[key_t].as_raw_string().data()[0]);
-  auto itr           = m_transactions.find(DhtTransaction::key(sa, transactionId));
+  auto itr = m_transactions.find(DhtTransaction::key(sa, transactionId));
 
   // Response to a transaction we don't have in our table. At this point it's
   // impossible to tell whether it used to be a valid transaction but timed out
@@ -409,17 +408,17 @@ DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtM
       return;
 
     switch (transaction->type()) {
-    case DhtTransaction::DHT_FIND_NODE:
-      parse_find_node_reply(transaction->as_find_node(), response[key_r_nodes].as_raw_string());
-      break;
+      case DhtTransaction::DHT_FIND_NODE:
+        parse_find_node_reply(transaction->as_find_node(), response[key_r_nodes].as_raw_string());
+        break;
 
-    case DhtTransaction::DHT_GET_PEERS:
-      parse_get_peers_reply(transaction->as_get_peers(), response);
-      break;
+      case DhtTransaction::DHT_GET_PEERS:
+        parse_get_peers_reply(transaction->as_get_peers(), response);
+        break;
 
-    // Nothing to do for DHT_PING and DHT_ANNOUNCE_PEER
-    default:
-      break;
+      // Nothing to do for DHT_PING and DHT_ANNOUNCE_PEER
+      default:
+        break;
     }
 
     // Mark node responsive only if all processing was successful, without errors.
@@ -440,7 +439,7 @@ DhtServer::process_response(const HashString& id, const sockaddr* sa, const DhtM
 void
 DhtServer::process_error(const sockaddr* sa, const DhtMessage& error) {
   int  transactionId = static_cast<unsigned char>(error[key_t].as_raw_string().data()[0]);
-  auto itr           = m_transactions.find(DhtTransaction::key(sa, transactionId));
+  auto itr = m_transactions.find(DhtTransaction::key(sa, transactionId));
 
   if (itr == m_transactions.end())
     return;
@@ -534,26 +533,26 @@ DhtServer::find_node_next(DhtTransactionSearch* transaction) {
 void
 DhtServer::add_packet(std::shared_ptr<DhtTransactionPacket> packet, int priority) {
   switch (priority) {
-  // High priority packets are for important queries, and quite small.
-  // They're added to front of high priority queue and thus will be the
-  // next packets sent.
-  case packet_prio_high:
-    m_highQueue.push_front(std::move(packet));
-    break;
+    // High priority packets are for important queries, and quite small.
+    // They're added to front of high priority queue and thus will be the
+    // next packets sent.
+    case packet_prio_high:
+      m_highQueue.push_front(std::move(packet));
+      break;
 
-  // Low priority query packets are added to the back of the high priority
-  // queue and will be sent when all high priority packets have been transmitted.
-  case packet_prio_low:
-    m_highQueue.push_back(std::move(packet));
-    break;
+    // Low priority query packets are added to the back of the high priority
+    // queue and will be sent when all high priority packets have been transmitted.
+    case packet_prio_low:
+      m_highQueue.push_back(std::move(packet));
+      break;
 
-  // Reply packets will be processed after all of our own packets have been send.
-  case packet_prio_reply:
-    m_lowQueue.push_back(std::move(packet));
-    break;
+    // Reply packets will be processed after all of our own packets have been send.
+    case packet_prio_reply:
+      m_lowQueue.push_back(std::move(packet));
+      break;
 
-  default:
-    throw internal_error("DhtServer::add_packet called with invalid priority.");
+    default:
+      throw internal_error("DhtServer::add_packet called with invalid priority.");
   }
 }
 
@@ -576,36 +575,36 @@ DhtServer::create_query(transaction_itr itr, int tID, [[maybe_unused]] const soc
   DhtMessage query;
 
   // Transaction ID is a bencode string.
-  query[key_t]      = raw_bencode(query.data_end, 3);
+  query[key_t] = raw_bencode(query.data_end, 3);
   *query.data_end++ = '1';
   *query.data_end++ = ':';
   *query.data_end++ = tID;
 
   auto& transaction = itr->second;
 
-  query[key_q]    = raw_string::from_c_str(queries[transaction->type()]);
-  query[key_y]    = raw_bencode::from_c_str("1:q");
-  query[key_v]    = raw_bencode("4:" PEER_VERSION, 6);
+  query[key_q] = raw_string::from_c_str(queries[transaction->type()]);
+  query[key_y] = raw_bencode::from_c_str("1:q");
+  query[key_v] = raw_bencode("4:" PEER_VERSION, 6);
   query[key_a_id] = m_router->id_raw_string();
 
   switch (transaction->type()) {
-  case DhtTransaction::DHT_PING:
-    // nothing to do
-    break;
+    case DhtTransaction::DHT_PING:
+      // nothing to do
+      break;
 
-  case DhtTransaction::DHT_FIND_NODE:
-    query[key_a_target] = transaction->as_find_node()->search()->target_raw_string();
-    break;
+    case DhtTransaction::DHT_FIND_NODE:
+      query[key_a_target] = transaction->as_find_node()->search()->target_raw_string();
+      break;
 
-  case DhtTransaction::DHT_GET_PEERS:
-    query[key_a_infoHash] = transaction->as_get_peers()->search()->target_raw_string();
-    break;
+    case DhtTransaction::DHT_GET_PEERS:
+      query[key_a_infoHash] = transaction->as_get_peers()->search()->target_raw_string();
+      break;
 
-  case DhtTransaction::DHT_ANNOUNCE_PEER:
-    query[key_a_infoHash] = transaction->as_announce_peer()->info_hash_raw_string();
-    query[key_a_token]    = transaction->as_announce_peer()->token();
-    query[key_a_port]     = runtime::listen_port();
-    break;
+    case DhtTransaction::DHT_ANNOUNCE_PEER:
+      query[key_a_infoHash] = transaction->as_announce_peer()->info_hash_raw_string();
+      query[key_a_token]    = transaction->as_announce_peer()->token();
+      query[key_a_port]     = runtime::listen_port();
+      break;
   }
 
   auto packet = std::make_shared<DhtTransactionPacket>(transaction->address(), query, tID, transaction);
@@ -619,9 +618,9 @@ DhtServer::create_query(transaction_itr itr, int tID, [[maybe_unused]] const soc
 void
 DhtServer::create_response(const DhtMessage& req, const sockaddr* sa, DhtMessage& reply) {
   reply[key_r_id] = m_router->id_raw_string();
-  reply[key_t]    = req[key_t];
-  reply[key_y]    = raw_bencode::from_c_str("1:r");
-  reply[key_v]    = raw_bencode("4:" PEER_VERSION, 6);
+  reply[key_t] = req[key_t];
+  reply[key_y] = raw_bencode::from_c_str("1:r");
+  reply[key_v] = raw_bencode("4:" PEER_VERSION, 6);
 
   add_packet(std::make_shared<DhtTransactionPacket>(sa, reply), packet_prio_reply);
 }
@@ -633,8 +632,8 @@ DhtServer::create_error(const DhtMessage& req, const sockaddr* sa, int num, cons
   if (req[key_t].is_raw_string() && req[key_t].as_raw_string().size() < 67)
     error[key_t] = req[key_t];
 
-  error[key_y]   = raw_bencode::from_c_str("1:e");
-  error[key_v]   = raw_bencode("4:" PEER_VERSION, 6);
+  error[key_y] = raw_bencode::from_c_str("1:e");
+  error[key_v] = raw_bencode("4:" PEER_VERSION, 6);
   error[key_e_0] = num;
   error[key_e_1] = raw_string::from_c_str(msg);
 
@@ -653,9 +652,9 @@ DhtServer::add_transaction(std::shared_ptr<DhtTransaction> transaction, int prio
   // node, a collision is extremely unlikely, and a linear search for the first
   // open one is the most efficient.
   unsigned int rnd = static_cast<uint8_t>(random());
-  unsigned int id  = rnd;
+  unsigned int id = rnd;
 
-  auto         insertItr = m_transactions.lower_bound(transaction->key(rnd));
+  auto insertItr = m_transactions.lower_bound(transaction->key(rnd));
 
   // If key matches, keep trying successive IDs.
   while (insertItr != m_transactions.end() && insertItr->first == transaction->key(id)) {
@@ -735,15 +734,15 @@ DhtServer::clear_transactions() {
 void
 DhtServer::event_read() {
   while (true) {
-    Object            request;
-    int               type = '?';
-    DhtMessage        message;
-    raw_string        nodeIdStr;
+    Object request;
+    int type = '?';
+    DhtMessage message;
+    raw_string nodeIdStr;
     const HashString* nodeId = NULL;
-    char              buffer[2048];
+    char buffer[2048];
 
-    sockaddr_in6      sa_raw{};
-    sockaddr*         sa = reinterpret_cast<sockaddr*>(&sa_raw);
+    sockaddr_in6 sa_raw{};
+    sockaddr* sa = reinterpret_cast<sockaddr*>(&sa_raw);
 
     try {
       int32_t read = read_datagram_sa(buffer, sizeof(buffer), sa, sizeof(sa_raw));
@@ -754,7 +753,7 @@ DhtServer::event_read() {
       // We can currently only process mapped-IPv4 addresses, not real IPv6.
       // Translate them to an af_inet socket_address.
       if (sa_is_v4mapped(sa)) {
-        auto sa_unmapped                         = sin_from_v4mapped_in6(&sa_raw);
+        auto sa_unmapped = sin_from_v4mapped_in6(&sa_raw);
         *reinterpret_cast<sockaddr_in*>(&sa_raw) = *sa_unmapped.get();
       }
 
@@ -773,8 +772,8 @@ DhtServer::event_read() {
         throw dht_error(dht_error_protocol, "No transaction ID");
 
       // Restrict the length of Transaction IDs. We echo them in our replies.
-      if (message[key_t].as_raw_string().size() > 20) {
-        throw dht_error(dht_error_protocol, "Transaction ID length too long");
+      if(message[key_t].as_raw_string().size() > 20) {
+		  throw dht_error(dht_error_protocol, "Transaction ID length too long");
       }
 
       if (!message[key_y].is_raw_string())
@@ -808,25 +807,25 @@ DhtServer::event_read() {
         throw dht_error(dht_error_protocol, "Send your own ID, not mine");
 
       switch (type) {
-      case 'q':
-        process_query(*nodeId, sa, message);
-        break;
+        case 'q':
+          process_query(*nodeId, sa, message);
+          break;
 
-      case 'r':
-        process_response(*nodeId, sa, message);
-        break;
+        case 'r':
+          process_response(*nodeId, sa, message);
+          break;
 
-      case 'e':
-        process_error(sa, message);
-        break;
+        case 'e':
+          process_error(sa, message);
+          break;
 
-      default:
-        throw dht_error(dht_error_bad_method, "Unknown message type.");
+        default:
+          throw dht_error(dht_error_bad_method, "Unknown message type.");
       }
 
-      // If node was querying us, reply with error packet, otherwise mark the node as "query failed",
-      // so that if it repeatedly sends malformed replies we will drop it instead of propagating it
-      // to other nodes.
+    // If node was querying us, reply with error packet, otherwise mark the node as "query failed",
+    // so that if it repeatedly sends malformed replies we will drop it instead of propagating it
+    // to other nodes.
     } catch (const bencode_error& e) {
       if ((type == 'r' || type == 'e') && nodeId != NULL) {
         m_router->node_inactive(*nodeId, sa);
@@ -852,10 +851,10 @@ DhtServer::event_read() {
 void
 DhtServer::process_queue(packet_queue& queue) {
   while (!queue.empty()) {
-    auto                     packet         = queue.front();
+    auto packet = queue.front();
     DhtTransaction::key_type transactionKey = 0;
 
-    if (packet->has_transaction())
+    if(packet->has_transaction())
       transactionKey = packet->transaction()->key(packet->id());
 
     // Make sure its transaction hasn't timed out yet, if it has/had one

--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -323,7 +323,7 @@ DownloadMain::receive_connect_peers() {
     if (connection_list()->size() + m_slot_count_handshakes(this) >= connection_list()->max_size())
       break;
 
-    if (!runtime::socket_manager()->can_open_socket())
+    if (!runtime::socket_manager()->can_open_socket(runtime::SocketManager::category_generic))
       break;
 
     auto sa = peer_list()->available_list()->pop_random();

--- a/src/net/curl_socket.cc
+++ b/src/net/curl_socket.cc
@@ -3,8 +3,8 @@
 #include "curl_socket.h"
 
 #include <cassert>
-#include <curl/multi.h>
 #include <unistd.h>
+#include <curl/multi.h>
 
 #include "net/curl_stack.h"
 #include "torrent/exceptions.h"
@@ -23,15 +23,15 @@
 
 #else
 
-#define LT_LOG_DEBUG(log_fmt, ...) \
+#define LT_LOG_DEBUG(log_fmt, ...)                                      \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket: " log_fmt, __VA_ARGS__)
-#define LT_LOG_DEBUG_THIS(log_fmt, ...) \
+#define LT_LOG_DEBUG_THIS(log_fmt, ...)                                 \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): " log_fmt, this, this->m_fileDesc, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET(log_fmt, ...) \
+#define LT_LOG_DEBUG_SOCKET(log_fmt, ...)                               \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET_FD(log_fmt, ...) \
+#define LT_LOG_DEBUG_SOCKET_FD(log_fmt, ...)                            \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): fd:%i : " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, fd, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET_FD_HANDLE(log_fmt, ...) \
+#define LT_LOG_DEBUG_SOCKET_FD_HANDLE(log_fmt, ...)                            \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): fd:%i easy_handle:%p : " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, fd, easy_handle, __VA_ARGS__)
 
 #endif
@@ -41,13 +41,15 @@
 
 namespace torrent::net {
 
-CurlSocket::CurlSocket(int fd, CurlStack* stack, CURL* easy_handle) : m_stack(stack),
-                                                                      m_easy_handle(easy_handle) {
+CurlSocket::CurlSocket(int fd, CurlStack* stack, CURL* easy_handle)
+  : m_stack(stack),
+    m_easy_handle(easy_handle) {
 
   set_file_descriptor(fd);
 }
 
-CurlSocket::CurlSocket(CurlStack* stack) : m_stack(stack) {
+CurlSocket::CurlSocket(CurlStack* stack)
+  : m_stack(stack) {
 }
 
 CurlSocket::~CurlSocket() {
@@ -94,8 +96,8 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket(CURL_POLL_REMOVE) : socket never properly opened, removing from poll", 0);
 
       runtime::socket_manager()->unregister_event_or_throw(socket, [&]() {
-        this_thread::poll()->remove_and_close(socket);
-      });
+          this_thread::poll()->remove_and_close(socket);
+        });
 
       socket->clear_and_erase_self_or_throw();
       return 0;
@@ -106,17 +108,17 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     // TODO: Check m_uninterested flag?
 
     auto func = [socket]() {
-      this_thread::poll()->remove_read(socket);
-      this_thread::poll()->remove_write(socket);
+        this_thread::poll()->remove_read(socket);
+        this_thread::poll()->remove_write(socket);
 
-      socket->m_easy_handle  = nullptr;
-      socket->m_uninterested = true;
-    };
+        socket->m_easy_handle  = nullptr;
+        socket->m_uninterested = true;
+      };
 
     auto on_reuse = [socket]() {
-      this_thread::poll()->remove_and_close(socket);
-      socket->clear_and_erase_self_or_throw();
-    };
+        this_thread::poll()->remove_and_close(socket);
+        socket->clear_and_erase_self_or_throw();
+      };
 
     if (!runtime::socket_manager()->mark_stream_event_inactive(socket, func, on_reuse)) {
       // Socket was closed by the kernel, or reused.
@@ -134,14 +136,15 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     auto itr = stack->socket_map()->find(fd);
 
     if (itr == stack->socket_map()->end()) {
-      socket                    = new CurlSocket(fd, stack, easy_handle);
+      socket = new CurlSocket(fd, stack, easy_handle);
       socket->m_properly_opened = false;
 
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket() : unexpected fd encountered, creating new (not properly opened) CurlSocket", 0);
 
-      runtime::socket_manager()->register_event_or_throw(socket, [&]() {
+      runtime::socket_manager()->register_event_or_throw(socket, runtime::SocketManager::category_http, [&]() {
           this_thread::poll()->open(socket);
-          this_thread::poll()->insert_error(socket); }, runtime::SocketManager::category_http);
+          this_thread::poll()->insert_error(socket);
+        });
 
       stack->socket_map()->emplace(fd, std::unique_ptr<CurlSocket>(socket));
 
@@ -155,7 +158,7 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
         throw internal_error("CurlSocket::receive_socket(fd:" + std::to_string(fd) + ") existing CurlSocket easy_handle not null");
       }
 
-      socket                = itr->second.get();
+      socket = itr->second.get();
       socket->m_easy_handle = easy_handle;
 
       curl_multi_assign(stack->handle(), fd, socket);
@@ -171,8 +174,7 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
       }
 
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket() : existing socket found in map : socket:%s peer:%s",
-                                    sa_pretty_str(socket->socket_address()).c_str(),
-                                    sa_pretty_str(socket->peer_address()).c_str());
+                                    sa_pretty_str(socket->socket_address()).c_str(), sa_pretty_str(socket->peer_address()).c_str());
     }
   }
 
@@ -211,14 +213,14 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     socket->m_uninterested = true;
 
     auto func = [socket]() {
-      this_thread::poll()->remove_read(socket);
-      this_thread::poll()->remove_write(socket);
-    };
+        this_thread::poll()->remove_read(socket);
+        this_thread::poll()->remove_write(socket);
+      };
 
     auto on_reuse = [socket]() {
-      this_thread::poll()->remove_and_close(socket);
-      socket->clear_and_erase_self_or_throw();
-    };
+        this_thread::poll()->remove_and_close(socket);
+        socket->clear_and_erase_self_or_throw();
+      };
 
     if (!runtime::socket_manager()->mark_stream_event_inactive(socket, func, on_reuse)) {
       // Not connected...
@@ -271,7 +273,7 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
 
 // This is not called when libcurl creates socketpairs, yet it expects us to handle them in receive_socket().
 curl_socket_t
-CurlSocket::open_socket(CurlStack* stack, [[maybe_unused]] curlsocktype purpose, struct curl_sockaddr* address) {
+CurlSocket::open_socket(CurlStack *stack, [[maybe_unused]] curlsocktype purpose, struct curl_sockaddr *address) {
   assert(this_thread::thread() == stack->thread());
 
   if (!stack->is_running()) {
@@ -279,45 +281,45 @@ CurlSocket::open_socket(CurlStack* stack, [[maybe_unused]] curlsocktype purpose,
     return CURL_SOCKET_BAD;
   }
 
-  auto event               = std::make_unique<CurlSocket>(stack);
+  auto event = std::make_unique<CurlSocket>(stack);
   event->m_properly_opened = true;
 
   auto open_func = [&]() {
-    int fd = ::socket(address->family, address->socktype, address->protocol);
+      int fd = ::socket(address->family, address->socktype, address->protocol);
 
-    if (fd == -1) {
-      LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
-      return -1;
-    }
+      if (fd == -1) {
+        LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
+        return -1;
+      }
 
-    // TODO: Fail if fd is already in use, especially if it is m_properly_opened.
+      // TODO: Fail if fd is already in use, especially if it is m_properly_opened.
 
-    event->set_file_descriptor(fd);
+      event->set_file_descriptor(fd);
 
-    // TODO: We should add this to uninterested sockets until libcurl tells us to poll.
+      // TODO: We should add this to uninterested sockets until libcurl tells us to poll.
 
-    this_thread::poll()->open(event.get());
-    this_thread::poll()->insert_error(event.get());
+      this_thread::poll()->open(event.get());
+      this_thread::poll()->insert_error(event.get());
 
-    return fd;
-  };
+      return fd;
+    };
 
   auto cleanup_func = [&](bool) {
-    if (!event->is_open())
-      return;
+      if (!event->is_open())
+        return;
 
-    this_thread::poll()->remove_and_close(event.get());
+      this_thread::poll()->remove_and_close(event.get());
 
-    if (::close(event->file_descriptor()) == -1) {
-      LT_LOG_DEBUG("open_socket() : error closing socket during cleanup: %s", std::strerror(errno));
-      throw internal_error("CurlSocket::open_socket(): error closing socket during cleanup: " + std::string(std::strerror(errno)));
-    }
+      if (::close(event->file_descriptor()) == -1) {
+        LT_LOG_DEBUG("open_socket() : error closing socket during cleanup: %s", std::strerror(errno));
+        throw internal_error("CurlSocket::open_socket(): error closing socket during cleanup: " + std::string(std::strerror(errno)));
+      }
 
-    LT_LOG_DEBUG("open_socket() : socket manager requested cleanup: fd:%i", event->file_descriptor());
-    event->set_file_descriptor(-1);
-  };
+      LT_LOG_DEBUG("open_socket() : socket manager requested cleanup: fd:%i", event->file_descriptor());
+      event->set_file_descriptor(-1);
+    };
 
-  bool result = runtime::socket_manager()->open_event_or_cleanup(event.get(), open_func, cleanup_func, runtime::SocketManager::category_http);
+  bool result = runtime::socket_manager()->open_event_or_cleanup(event.get(), runtime::SocketManager::category_http, open_func, cleanup_func);
 
   if (!result) {
     LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
@@ -400,17 +402,17 @@ CurlSocket::close_socket(CurlStack* stack, curl_socket_t fd) {
   // TODO: Check if this is still the same socket?
 
   runtime::socket_manager()->close_event_or_throw(socket, [&]() {
-    // TODO: Change handling of curl remove event / uninterested to closing socket polling?
+      // TODO: Change handling of curl remove event / uninterested to closing socket polling?
 
-    // TODO: This is getting called twice?
-    this_thread::poll()->remove_and_close(socket);
+      // TODO: This is getting called twice?
+      this_thread::poll()->remove_and_close(socket);
 
-    if (::close(fd) == -1) {
-      LT_LOG_DEBUG_SOCKET_FD("close_socket() : error closing socket: %s", std::strerror(errno));
-    }
+      if (::close(fd) == -1) {
+        LT_LOG_DEBUG_SOCKET_FD("close_socket() : error closing socket: %s", std::strerror(errno));
+      }
 
-    socket->set_file_descriptor(-1);
-  });
+      socket->set_file_descriptor(-1);
+    });
 
   socket->clear_and_erase_self(itr);
   return 0;
@@ -455,8 +457,8 @@ CurlSocket::event_error() {
     auto stack = m_stack;
 
     runtime::socket_manager()->unregister_event_or_throw(this, [&]() {
-      this_thread::poll()->remove_and_close(this);
-    });
+        this_thread::poll()->remove_and_close(this);
+      });
 
     curl_multi_assign(m_stack->handle(), file_descriptor(), nullptr);
     clear_and_erase_self_or_throw();

--- a/src/net/curl_socket.cc
+++ b/src/net/curl_socket.cc
@@ -3,8 +3,8 @@
 #include "curl_socket.h"
 
 #include <cassert>
-#include <unistd.h>
 #include <curl/multi.h>
+#include <unistd.h>
 
 #include "net/curl_stack.h"
 #include "torrent/exceptions.h"
@@ -23,15 +23,15 @@
 
 #else
 
-#define LT_LOG_DEBUG(log_fmt, ...)                                      \
+#define LT_LOG_DEBUG(log_fmt, ...) \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket: " log_fmt, __VA_ARGS__)
-#define LT_LOG_DEBUG_THIS(log_fmt, ...)                                 \
+#define LT_LOG_DEBUG_THIS(log_fmt, ...) \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): " log_fmt, this, this->m_fileDesc, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET(log_fmt, ...)                               \
+#define LT_LOG_DEBUG_SOCKET(log_fmt, ...) \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET_FD(log_fmt, ...)                            \
+#define LT_LOG_DEBUG_SOCKET_FD(log_fmt, ...) \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): fd:%i : " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, fd, __VA_ARGS__)
-#define LT_LOG_DEBUG_SOCKET_FD_HANDLE(log_fmt, ...)                            \
+#define LT_LOG_DEBUG_SOCKET_FD_HANDLE(log_fmt, ...) \
   lt_log_print(LOG_CONNECTION_FD, "curl_socket->%p(%i): fd:%i easy_handle:%p : " log_fmt, socket, socket != nullptr ? socket->m_fileDesc : 0, fd, easy_handle, __VA_ARGS__)
 
 #endif
@@ -41,15 +41,13 @@
 
 namespace torrent::net {
 
-CurlSocket::CurlSocket(int fd, CurlStack* stack, CURL* easy_handle)
-  : m_stack(stack),
-    m_easy_handle(easy_handle) {
+CurlSocket::CurlSocket(int fd, CurlStack* stack, CURL* easy_handle) : m_stack(stack),
+                                                                      m_easy_handle(easy_handle) {
 
   set_file_descriptor(fd);
 }
 
-CurlSocket::CurlSocket(CurlStack* stack)
-  : m_stack(stack) {
+CurlSocket::CurlSocket(CurlStack* stack) : m_stack(stack) {
 }
 
 CurlSocket::~CurlSocket() {
@@ -96,8 +94,8 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket(CURL_POLL_REMOVE) : socket never properly opened, removing from poll", 0);
 
       runtime::socket_manager()->unregister_event_or_throw(socket, [&]() {
-          this_thread::poll()->remove_and_close(socket);
-        });
+        this_thread::poll()->remove_and_close(socket);
+      });
 
       socket->clear_and_erase_self_or_throw();
       return 0;
@@ -108,17 +106,17 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     // TODO: Check m_uninterested flag?
 
     auto func = [socket]() {
-        this_thread::poll()->remove_read(socket);
-        this_thread::poll()->remove_write(socket);
+      this_thread::poll()->remove_read(socket);
+      this_thread::poll()->remove_write(socket);
 
-        socket->m_easy_handle  = nullptr;
-        socket->m_uninterested = true;
-      };
+      socket->m_easy_handle  = nullptr;
+      socket->m_uninterested = true;
+    };
 
     auto on_reuse = [socket]() {
-        this_thread::poll()->remove_and_close(socket);
-        socket->clear_and_erase_self_or_throw();
-      };
+      this_thread::poll()->remove_and_close(socket);
+      socket->clear_and_erase_self_or_throw();
+    };
 
     if (!runtime::socket_manager()->mark_stream_event_inactive(socket, func, on_reuse)) {
       // Socket was closed by the kernel, or reused.
@@ -136,15 +134,14 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     auto itr = stack->socket_map()->find(fd);
 
     if (itr == stack->socket_map()->end()) {
-      socket = new CurlSocket(fd, stack, easy_handle);
+      socket                    = new CurlSocket(fd, stack, easy_handle);
       socket->m_properly_opened = false;
 
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket() : unexpected fd encountered, creating new (not properly opened) CurlSocket", 0);
 
       runtime::socket_manager()->register_event_or_throw(socket, [&]() {
           this_thread::poll()->open(socket);
-          this_thread::poll()->insert_error(socket);
-        });
+          this_thread::poll()->insert_error(socket); }, runtime::SocketManager::category_http);
 
       stack->socket_map()->emplace(fd, std::unique_ptr<CurlSocket>(socket));
 
@@ -158,7 +155,7 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
         throw internal_error("CurlSocket::receive_socket(fd:" + std::to_string(fd) + ") existing CurlSocket easy_handle not null");
       }
 
-      socket = itr->second.get();
+      socket                = itr->second.get();
       socket->m_easy_handle = easy_handle;
 
       curl_multi_assign(stack->handle(), fd, socket);
@@ -174,7 +171,8 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
       }
 
       LT_LOG_DEBUG_SOCKET_FD_HANDLE("receive_socket() : existing socket found in map : socket:%s peer:%s",
-                                    sa_pretty_str(socket->socket_address()).c_str(), sa_pretty_str(socket->peer_address()).c_str());
+                                    sa_pretty_str(socket->socket_address()).c_str(),
+                                    sa_pretty_str(socket->peer_address()).c_str());
     }
   }
 
@@ -213,14 +211,14 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
     socket->m_uninterested = true;
 
     auto func = [socket]() {
-        this_thread::poll()->remove_read(socket);
-        this_thread::poll()->remove_write(socket);
-      };
+      this_thread::poll()->remove_read(socket);
+      this_thread::poll()->remove_write(socket);
+    };
 
     auto on_reuse = [socket]() {
-        this_thread::poll()->remove_and_close(socket);
-        socket->clear_and_erase_self_or_throw();
-      };
+      this_thread::poll()->remove_and_close(socket);
+      socket->clear_and_erase_self_or_throw();
+    };
 
     if (!runtime::socket_manager()->mark_stream_event_inactive(socket, func, on_reuse)) {
       // Not connected...
@@ -273,7 +271,7 @@ CurlSocket::receive_socket(CURL* easy_handle, curl_socket_t fd, int what, CurlSt
 
 // This is not called when libcurl creates socketpairs, yet it expects us to handle them in receive_socket().
 curl_socket_t
-CurlSocket::open_socket(CurlStack *stack, [[maybe_unused]] curlsocktype purpose, struct curl_sockaddr *address) {
+CurlSocket::open_socket(CurlStack* stack, [[maybe_unused]] curlsocktype purpose, struct curl_sockaddr* address) {
   assert(this_thread::thread() == stack->thread());
 
   if (!stack->is_running()) {
@@ -281,45 +279,45 @@ CurlSocket::open_socket(CurlStack *stack, [[maybe_unused]] curlsocktype purpose,
     return CURL_SOCKET_BAD;
   }
 
-  auto event = std::make_unique<CurlSocket>(stack);
+  auto event               = std::make_unique<CurlSocket>(stack);
   event->m_properly_opened = true;
 
   auto open_func = [&]() {
-      int fd = ::socket(address->family, address->socktype, address->protocol);
+    int fd = ::socket(address->family, address->socktype, address->protocol);
 
-      if (fd == -1) {
-        LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
-        return -1;
-      }
+    if (fd == -1) {
+      LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
+      return -1;
+    }
 
-      // TODO: Fail if fd is already in use, especially if it is m_properly_opened.
+    // TODO: Fail if fd is already in use, especially if it is m_properly_opened.
 
-      event->set_file_descriptor(fd);
+    event->set_file_descriptor(fd);
 
-      // TODO: We should add this to uninterested sockets until libcurl tells us to poll.
+    // TODO: We should add this to uninterested sockets until libcurl tells us to poll.
 
-      this_thread::poll()->open(event.get());
-      this_thread::poll()->insert_error(event.get());
+    this_thread::poll()->open(event.get());
+    this_thread::poll()->insert_error(event.get());
 
-      return fd;
-    };
+    return fd;
+  };
 
   auto cleanup_func = [&](bool) {
-      if (!event->is_open())
-        return;
+    if (!event->is_open())
+      return;
 
-      this_thread::poll()->remove_and_close(event.get());
+    this_thread::poll()->remove_and_close(event.get());
 
-      if (::close(event->file_descriptor()) == -1) {
-        LT_LOG_DEBUG("open_socket() : error closing socket during cleanup: %s", std::strerror(errno));
-        throw internal_error("CurlSocket::open_socket(): error closing socket during cleanup: " + std::string(std::strerror(errno)));
-      }
+    if (::close(event->file_descriptor()) == -1) {
+      LT_LOG_DEBUG("open_socket() : error closing socket during cleanup: %s", std::strerror(errno));
+      throw internal_error("CurlSocket::open_socket(): error closing socket during cleanup: " + std::string(std::strerror(errno)));
+    }
 
-      LT_LOG_DEBUG("open_socket() : socket manager requested cleanup: fd:%i", event->file_descriptor());
-      event->set_file_descriptor(-1);
-    };
+    LT_LOG_DEBUG("open_socket() : socket manager requested cleanup: fd:%i", event->file_descriptor());
+    event->set_file_descriptor(-1);
+  };
 
-  bool result = runtime::socket_manager()->open_event_or_cleanup(event.get(), open_func, cleanup_func);
+  bool result = runtime::socket_manager()->open_event_or_cleanup(event.get(), open_func, cleanup_func, runtime::SocketManager::category_http);
 
   if (!result) {
     LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));
@@ -402,17 +400,17 @@ CurlSocket::close_socket(CurlStack* stack, curl_socket_t fd) {
   // TODO: Check if this is still the same socket?
 
   runtime::socket_manager()->close_event_or_throw(socket, [&]() {
-      // TODO: Change handling of curl remove event / uninterested to closing socket polling?
+    // TODO: Change handling of curl remove event / uninterested to closing socket polling?
 
-      // TODO: This is getting called twice?
-      this_thread::poll()->remove_and_close(socket);
+    // TODO: This is getting called twice?
+    this_thread::poll()->remove_and_close(socket);
 
-      if (::close(fd) == -1) {
-        LT_LOG_DEBUG_SOCKET_FD("close_socket() : error closing socket: %s", std::strerror(errno));
-      }
+    if (::close(fd) == -1) {
+      LT_LOG_DEBUG_SOCKET_FD("close_socket() : error closing socket: %s", std::strerror(errno));
+    }
 
-      socket->set_file_descriptor(-1);
-    });
+    socket->set_file_descriptor(-1);
+  });
 
   socket->clear_and_erase_self(itr);
   return 0;
@@ -457,8 +455,8 @@ CurlSocket::event_error() {
     auto stack = m_stack;
 
     runtime::socket_manager()->unregister_event_or_throw(this, [&]() {
-        this_thread::poll()->remove_and_close(this);
-      });
+      this_thread::poll()->remove_and_close(this);
+    });
 
     curl_multi_assign(m_stack->handle(), file_descriptor(), nullptr);
     clear_and_erase_self_or_throw();

--- a/src/net/listen.cc
+++ b/src/net/listen.cc
@@ -188,7 +188,7 @@ Listen::open_done(int fd, uint16_t port, int backlog) {
   set_file_descriptor(fd);
   m_port = port;
 
-  runtime::socket_manager()->register_event_or_throw(this, [this]() {
+  runtime::socket_manager()->register_event_or_throw(this, runtime::SocketManager::category_internal, [this]() {
       this_thread::poll()->open(this);
       this_thread::poll()->insert_read(this);
       this_thread::poll()->insert_error(this);
@@ -257,7 +257,7 @@ Listen::event_read() {
 
     // TODO: This needs to be handled differently as open_ isn't done, we're doing accept_event_or_cleanup? Add a close callback?
 
-    bool result = runtime::socket_manager()->open_event_or_cleanup(handshake.get(), open_func, cleanup_func);
+    bool result = runtime::socket_manager()->open_event_or_cleanup(handshake.get(), runtime::SocketManager::category_generic, open_func, cleanup_func);
 
     // If the handshake connection or socket manager failed, don't continue accepting connections.
     //

--- a/src/net/thread_net.cc
+++ b/src/net/thread_net.cc
@@ -8,7 +8,23 @@
 #include "net/udns_resolver.h"
 #include "torrent/exceptions.h"
 #include "torrent/net/http_stack.h"
+#include "torrent/runtime/socket_manager.h"
 #include "utils/instrumentation.h"
+
+namespace {
+
+// Derives max host connections from the HTTP total connections category limit.
+uint32_t
+calculate_max_http_host_connections(uint32_t http_total) {
+  if (http_total >= 128)
+    return 3;
+  else if (http_total >= 64)
+    return 2;
+  else // Assumes we don't try less than 64.
+    return 1;
+}
+
+} // namespace
 
 namespace torrent {
 
@@ -72,10 +88,22 @@ ThreadNet::init_thread() {
 void
 ThreadNet::init_thread_post_local() {
   m_dns_resolver->initialize(this);
+
+  runtime::socket_manager()->subscribe_to_changes(this, [this]() {
+      cancel_callback(this);
+
+      callback(this, [this]() {
+          auto total = runtime::socket_manager()->category_max_size(runtime::SocketManager::category_http);
+          m_http_stack->set_max_host_connections(calculate_max_http_host_connections(total));
+          m_http_stack->set_max_total_connections(total);
+        });
+    });
 }
 
 void
 ThreadNet::cleanup_thread() {
+  runtime::socket_manager()->unsubscribe_from_changes(this);
+
   m_http_stack->shutdown();
   m_dns_resolver->cleanup();
 }

--- a/src/net/thread_net.cc
+++ b/src/net/thread_net.cc
@@ -13,12 +13,12 @@
 
 namespace {
 
-// Derives max host connections from the HTTP total connections category limit.
+// Derives max host connections from the global max open sockets.
 uint32_t
-calculate_max_http_host_connections(uint32_t http_total) {
-  if (http_total >= 128)
+calculate_http_host_connections(uint32_t max_size) {
+  if (max_size >= 16384)
     return 3;
-  else if (http_total >= 64)
+  else if (max_size >= 8096)
     return 2;
   else // Assumes we don't try less than 64.
     return 1;
@@ -88,12 +88,10 @@ ThreadNet::init_thread_post_local() {
   m_dns_resolver->initialize(this);
 
   runtime::socket_manager()->subscribe_to_changes(this, [this]() {
-      cancel_callback(this);
+      cancel_callback(m_http_subscriber_id);
 
-      callback(this, [this]() {
-          auto total = runtime::socket_manager()->category_max_size(runtime::SocketManager::category_http);
-          m_http_stack->set_max_host_connections(calculate_max_http_host_connections(total));
-          m_http_stack->set_max_total_connections(total);
+      callback(m_http_subscriber_id, [this]() {
+          set_max_connections();
         });
     });
 }
@@ -104,6 +102,16 @@ ThreadNet::cleanup_thread() {
 
   m_http_stack->shutdown();
   m_dns_resolver->cleanup();
+}
+
+void
+ThreadNet::set_max_connections() {
+  auto sm    = runtime::socket_manager();
+  auto total = sm->category_max_size(runtime::SocketManager::category_http);
+  auto host  = calculate_http_host_connections(sm->max_size());
+
+  m_http_stack->set_max_host_connections(host);
+  m_http_stack->set_max_total_connections(total);
 }
 
 void

--- a/src/net/thread_net.cc
+++ b/src/net/thread_net.cc
@@ -88,9 +88,9 @@ ThreadNet::init_thread_post_local() {
   m_dns_resolver->initialize(this);
 
   runtime::socket_manager()->subscribe_to_changes(this, [this]() {
-      cancel_callback(m_http_subscriber_id);
+      cancel_callback(m_events_callback_id);
 
-      callback(m_http_subscriber_id, [this]() {
+      callback(m_events_callback_id, [this]() {
           set_max_connections();
         });
     });
@@ -106,12 +106,11 @@ ThreadNet::cleanup_thread() {
 
 void
 ThreadNet::set_max_connections() {
-  auto sm    = runtime::socket_manager();
-  auto total = sm->category_max_size(runtime::SocketManager::category_http);
-  auto host  = calculate_http_host_connections(sm->max_size());
+  auto total_size = runtime::socket_manager()->category_max_size(runtime::SocketManager::category_http);
+  auto host_size  = calculate_http_host_connections(runtime::socket_manager()->max_size());
 
-  m_http_stack->set_max_host_connections(host);
-  m_http_stack->set_max_total_connections(total);
+  m_http_stack->set_max_host_connections(host_size);
+  m_http_stack->set_max_total_connections(total_size);
 }
 
 void

--- a/src/net/thread_net.h
+++ b/src/net/thread_net.h
@@ -29,6 +29,8 @@ public:
   void                init_thread_post_local() override;
   void                cleanup_thread() override;
 
+  void                set_max_connections();
+
 protected:
   friend class ThreadNetInternal;
   friend class torrent::net::DnsCache;
@@ -55,6 +57,8 @@ private:
   std::unique_ptr<net::DnsBuffer>    m_dns_buffer;
   std::unique_ptr<net::DnsCache>     m_dns_cache;
   std::unique_ptr<net::UdnsResolver> m_dns_resolver;
+
+  system::callback_id m_http_subscriber_id;
 };
 
 } // namespace torrent

--- a/src/net/thread_net.h
+++ b/src/net/thread_net.h
@@ -58,7 +58,7 @@ private:
   std::unique_ptr<net::DnsCache>     m_dns_cache;
   std::unique_ptr<net::UdnsResolver> m_dns_resolver;
 
-  system::callback_id m_http_subscriber_id;
+  system::callback_id m_events_callback_id;
 };
 
 } // namespace torrent

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -112,7 +112,7 @@ HandshakeManager::add_incoming(std::unique_ptr<Handshake>& handshake, int fd, co
 
 void
 HandshakeManager::add_outgoing(const sockaddr* sa, DownloadMain* download) {
-  if (!runtime::socket_manager()->can_open_socket() ||
+  if (!runtime::socket_manager()->can_open_socket(runtime::SocketManager::category_generic) ||
       !manager->connection_manager()->filter(sa))
     return;
 
@@ -192,7 +192,7 @@ HandshakeManager::create_outgoing(const sockaddr* sa, DownloadMain* download, in
       handshake->destroy_connection(false);
     };
 
-  runtime::socket_manager()->open_event_or_cleanup(handshake.get(), open_func, cleanup_func);
+  runtime::socket_manager()->open_event_or_cleanup(handshake.get(), runtime::SocketManager::category_generic, open_func, cleanup_func);
 
   if (!handshake->is_open())
     return;

--- a/src/thread_main.cc
+++ b/src/thread_main.cc
@@ -2,10 +2,13 @@
 
 #include "thread_main.h"
 
+#include "manager.h"
 #include "data/hash_queue.h"
+#include "torrent/data/file_manager.h"
 #include "torrent/net/resolver.h"
 #include "torrent/runtime/network_config.h"
 #include "torrent/runtime/network_manager.h"
+#include "torrent/runtime/socket_manager.h"
 #include "torrent/system/callbacks.h"
 #include "utils/instrumentation.h"
 
@@ -79,7 +82,20 @@ ThreadMain::init_thread() {
 }
 
 void
+ThreadMain::init_thread_post_local() {
+  runtime::socket_manager()->subscribe_to_changes(this, [this]() {
+      cancel_callback(m_events_callback_id);
+
+      callback(m_events_callback_id, [this]() {
+          manager->file_manager()->set_max_open_files(
+            runtime::socket_manager()->category_max_size(runtime::SocketManager::category_files));
+        });
+    });
+}
+
+void
 ThreadMain::cleanup_thread() {
+  runtime::socket_manager()->unsubscribe_from_changes(this);
   runtime::network_config()->unsubscribe_from_changes(this);
   cancel_callback(m_events_callback_id);
 

--- a/src/thread_main.h
+++ b/src/thread_main.h
@@ -23,6 +23,7 @@ public:
   const char*            name() const override { return "rtorrent-main"; }
 
   void                   init_thread() override;
+  void                   init_thread_post_local() override;
   void                   cleanup_thread() override;
 
   void                   set_client_callback(std::function<void()> fn);

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -17,22 +17,6 @@
 namespace {
 
 uint32_t
-calculate_reserved(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 512;
-  else if (open_max >= 8096)
-    return 256;
-  else if (open_max >= 1024)
-    return 128;
-  else if (open_max >= 512)
-    return 64;
-  else if (open_max >= 128)
-    return 32;
-  else // Assumes we don't try less than 64.
-    return 16;
-}
-
-uint32_t
 calculate_internal(uint32_t open_max) {
   if (open_max >= 16384)
     return 32;
@@ -72,6 +56,22 @@ calculate_scgi(uint32_t open_max) {
     return 16;
 }
 
+uint32_t
+calculate_files(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 512;
+  else if (open_max >= 8096)
+    return 256;
+  else if (open_max >= 1024)
+    return 128;
+  else if (open_max >= 512)
+    return 64;
+  else if (open_max >= 128)
+    return 16;
+  else
+    return 4;
+}
+
 } // namespace
 
 namespace torrent::runtime {
@@ -108,17 +108,27 @@ void
 SocketManager::set_max_size_and_adjust(uint32_t max_open) {
   auto guard = lock_guard();
 
+  if (max_open < 512)
+    throw input_error("set_max_size_and_adjust: max_open too low, minimum is 512");
+
+  uint32_t total_allocated{};
+
+  auto set_category = [this, max_open, &total_allocated](category_t category, uint32_t allocation) {
+    total_allocated += allocation;
+
+    if (total_allocated + 8 > max_open)
+      throw internal_error("set_max_size_and_adjust: total allocated categories exceed max_open");
+
+    m_category_max_size[category] = allocation;
+  };
+
+  set_category(category_internal, calculate_internal(max_open));
+  set_category(category_http, calculate_http(max_open));
+  set_category(category_scgi, calculate_scgi(max_open));
+  set_category(category_files, calculate_files(max_open));
+
+  m_category_max_size[category_generic] = max_open - total_allocated;
   m_max_size = max_open;
-
-  m_category_max_size[category_internal] = calculate_internal(max_open);
-  m_category_max_size[category_http]     = calculate_http(max_open);
-  m_category_max_size[category_scgi]     = calculate_scgi(max_open);
-
-  m_category_max_size[category_generic]  = max_open
-    - calculate_reserved(max_open)
-    - m_category_max_size[category_internal]
-    - m_category_max_size[category_http]
-    - m_category_max_size[category_scgi];
 
   notify_changes();
 }

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -17,6 +17,22 @@
 namespace {
 
 uint32_t
+calculate_reserved(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 512;
+  else if (open_max >= 8096)
+    return 256;
+  else if (open_max >= 1024)
+    return 128;
+  else if (open_max >= 512)
+    return 64;
+  else if (open_max >= 128)
+    return 32;
+  else
+    return 16;
+}
+
+uint32_t
 calculate_internal(uint32_t open_max) {
   if (open_max >= 16384)
     return 32;
@@ -126,6 +142,12 @@ SocketManager::set_max_size_and_adjust(uint32_t max_open) {
   set_category(category_http, calculate_http(max_open));
   set_category(category_scgi, calculate_scgi(max_open));
   set_category(category_files, calculate_files(max_open));
+
+  auto reserved = calculate_reserved(max_open);
+  total_allocated += reserved;
+
+  if (total_allocated + 8 > max_open)
+    throw internal_error("set_max_size_and_adjust: total allocated plus reserved exceeds max_open");
 
   m_category_max_size[category_generic] = max_open - total_allocated;
   m_max_size = max_open;

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -69,6 +69,12 @@ SocketManager::account_remove_socket_unsafe(socket_map::iterator itr) {
 }
 
 void
+SocketManager::account_replace_socket_unsafe(socket_map::iterator itr, category_t new_category) {
+  m_category_managed_size[itr->second.category]--;
+  m_category_managed_size[new_category]++;
+}
+
+void
 SocketManager::add_unmanaged_socket() {
   m_unmanaged_size++;
 }
@@ -168,8 +174,9 @@ SocketManager::open_event_or_cleanup(Event* event, category_t category, std::fun
            this_thread::thread()->name(), event->type_name(), fd,
            itr->second.thread->name(), itr->second.event->type_name());
 
+    account_replace_socket_unsafe(itr, category);
     itr->second = SocketInfo{fd, event, this_thread::thread()};
-    account_new_socket_unsafe(itr, category);
+    itr->second.category = category;
     return true;
   }
 

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -2,6 +2,7 @@
 
 #include "torrent/runtime/socket_manager.h"
 
+#include <algorithm>
 #include <cassert>
 
 #include "torrent/event.h"
@@ -12,6 +13,68 @@
 
 #define LT_LOG(log_fmt, ...)                                            \
   lt_log_print(LOG_NET_SOCKET, "socket_manager: " log_fmt, __VA_ARGS__);
+
+namespace {
+
+uint32_t
+calculate_max_open_files(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 512;
+  else if (open_max >= 8096)
+    return 256;
+  else if (open_max >= 1024)
+    return 128;
+  else if (open_max >= 512)
+    return 64;
+  else if (open_max >= 128)
+    return 16;
+  else // Assumes we don't try less than 64.
+    return 4;
+}
+
+uint32_t
+calculate_reserved(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 512;
+  else if (open_max >= 8096)
+    return 256;
+  else if (open_max >= 1024)
+    return 128;
+  else if (open_max >= 512)
+    return 64;
+  else if (open_max >= 128)
+    return 32;
+  else // Assumes we don't try less than 64.
+    return 16;
+}
+
+uint32_t
+calculate_internal(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 32;
+  else if (open_max >= 1024)
+    return 16;
+  else
+    return 8;
+}
+
+uint32_t
+calculate_max_http_total_connections(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 128;
+  else if (open_max >= 8096)
+    return 64;
+  else if (open_max >= 1024)
+    return 32;
+  else if (open_max >= 512)
+    return 16;
+  else if (open_max >= 128)
+    return 8;
+  else // Assumes we don't try less than 64.
+    return 4;
+}
+
+} // namespace
 
 namespace torrent::runtime {
 
@@ -44,15 +107,45 @@ SocketManager::category_max_size(category_t category) const {
 }
 
 void
-SocketManager::set_max_size(uint32_t max_size) {
+SocketManager::set_max_size_and_adjust(uint32_t max_open) {
   auto guard = lock_guard();
-  m_max_size = max_size;
+
+  auto max_files = calculate_max_open_files(max_open);
+  auto reserved  = calculate_reserved(max_open);
+  m_max_size = max_open - max_files - reserved;
+
+  m_category_max_size[category_internal] = calculate_internal(max_open);
+  m_category_max_size[category_http]     = calculate_max_http_total_connections(max_open);
+
+  notify_changes();
 }
 
 void
 SocketManager::set_category_max_size(category_t category, uint32_t max_size) {
   auto guard                    = lock_guard();
   m_category_max_size[category] = max_size;
+}
+
+void
+SocketManager::subscribe_to_changes(void* target, const std::function<void()>& callback) {
+  auto guard = lock_guard();
+  m_change_subscribers.push_back(std::make_pair(target, callback));
+}
+
+void
+SocketManager::unsubscribe_from_changes(void* target) {
+  auto guard = lock_guard();
+
+  auto itr = std::remove_if(m_change_subscribers.begin(), m_change_subscribers.end(),
+                            [target](auto& p) { return p.first == target; });
+
+  m_change_subscribers.erase(itr, m_change_subscribers.end());
+}
+
+void
+SocketManager::notify_changes() const {
+  for (auto& p : m_change_subscribers)
+    p.second();
 }
 
 void

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -64,14 +64,17 @@ SocketManager::account_new_socket_unsafe(socket_map::iterator itr, category_t ca
 
 void
 SocketManager::account_remove_socket_unsafe(socket_map::iterator itr) {
-  m_managed_size--;
-  m_category_managed_size[itr->second.category]--;
-}
+  if (m_managed_size == 0) {
+    throw internal_error("SocketManager::account_remove_socket_unsafe(): m_managed_size underflow");
+  }
 
-void
-SocketManager::account_replace_socket_unsafe(socket_map::iterator itr, category_t new_category) {
-  m_category_managed_size[itr->second.category]--;
-  m_category_managed_size[new_category]++;
+  auto category = itr->second.category;
+  if (m_category_managed_size[category] == 0) {
+    throw internal_error("SocketManager::account_remove_socket_unsafe(): category managed size underflow");
+  }
+
+  m_managed_size--;
+  m_category_managed_size[category]--;
 }
 
 void
@@ -91,8 +94,18 @@ SocketManager::remove_unmanaged_socket() {
 bool
 SocketManager::can_open_socket(category_t category) {
   auto guard = lock_guard();
-  return size() < max_size() &&
-         (m_category_max_size[category] == 0 || m_category_managed_size[category] < m_category_max_size[category]);
+  return can_open_socket_unsafe(category);
+}
+
+bool
+SocketManager::can_open_socket_unsafe(category_t category) {
+  if (size() >= max_size())
+    return false;
+
+  if (m_category_max_size[category] != 0)
+    return m_category_managed_size[category] < m_category_max_size[category];
+
+  return true;
 }
 
 void
@@ -110,9 +123,9 @@ SocketManager::open_event_or_throw(Event* event, category_t category, std::funct
   }
 
   auto fd  = event->file_descriptor();
-  auto itr = m_socket_map.find(fd);
+  auto [itr, inserted] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
 
-  if (itr != m_socket_map.end()) {
+  if (!inserted) {
     // We don't allow conflicts for this function.
     LT_LOG("open_event_or_throw() : %s:%s:%i : tried to use an existing file descriptor : %s:%s",
            this_thread::thread()->name(), event->type_name(), fd,
@@ -127,8 +140,7 @@ SocketManager::open_event_or_throw(Event* event, category_t category, std::funct
   LT_LOG("open_event_or_throw() : %s:%s:%i : opened socket",
          this_thread::thread()->name(), event->type_name(), fd);
 
-  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket_unsafe(itr_new, category);
+  account_new_socket_unsafe(itr, category);
 }
 
 bool
@@ -138,8 +150,7 @@ SocketManager::open_event_or_cleanup(Event* event, category_t category, std::fun
   if (event->is_open())
     throw internal_error("SocketManager::open_event_or_cleanup(): event is already open");
 
-  if (m_managed_size + m_unmanaged_size >= m_max_size ||
-      (m_category_max_size[category] > 0 && m_category_managed_size[category] >= m_category_max_size[category])) {
+  if (!can_open_socket_unsafe(category)) {
     LT_LOG("open_event_or_cleanup() : %s:%s : cannot open socket, max open sockets reached",
            this_thread::thread()->name(), event->type_name());
 
@@ -157,34 +168,31 @@ SocketManager::open_event_or_cleanup(Event* event, category_t category, std::fun
   }
 
   auto fd  = event->file_descriptor();
-  auto itr = m_socket_map.find(fd);
+  auto [itr, inserted] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
 
-  if (itr != m_socket_map.end()) {
-    if (!handle_reused_socket(itr)) {
-      // TODO: Make this a macro. use (sss : ss)
-      LT_LOG("open_event_or_cleanup() : %s:%s:%i : failed to reuse existing file descriptor : %s:%s",
-             this_thread::thread()->name(), event->type_name(), fd,
-             itr->second.thread->name(), itr->second.event->type_name());
-
-      cleanup(true);
-      return false;
-    }
-
-    LT_LOG("open_event_or_cleanup() : %s:%s:%i : reused existing file descriptor : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
-
-    account_replace_socket_unsafe(itr, category);
-    itr->second = SocketInfo{fd, event, this_thread::thread()};
-    itr->second.category = category;
+  if (inserted) {
+    LT_LOG("open_event_or_cleanup() : %s:%s:%i : opened socket",
+           this_thread::thread()->name(), event->type_name(), fd);
+    account_new_socket_unsafe(itr, category);
     return true;
   }
 
-  LT_LOG("open_event_or_cleanup() : %s:%s:%i : opened socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+  if (!handle_reused_socket(itr)) {
+    LT_LOG("open_event_or_cleanup() : %s:%s:%i : failed to reuse existing file descriptor : %s:%s",
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
-  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket_unsafe(itr_new, category);
+    cleanup(true);
+    return false;
+  }
+
+  LT_LOG("open_event_or_cleanup() : %s:%s:%i : reused existing file descriptor : %s:%s",
+         this_thread::thread()->name(), event->type_name(), fd,
+         itr->second.thread->name(), itr->second.event->type_name());
+
+  account_remove_socket_unsafe(itr);
+  itr->second = SocketInfo{.fd=fd, .event=event, .thread=this_thread::thread()};
+  account_new_socket_unsafe(itr, category);
   return true;
 }
 
@@ -233,9 +241,9 @@ SocketManager::register_event_or_throw(Event* event, category_t category, std::f
     throw internal_error("SocketManager::register_event_or_throw(): event is not open");
 
   auto fd  = event->file_descriptor();
-  auto itr = m_socket_map.find(fd);
+  auto [itr, inserted] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
 
-  if (itr != m_socket_map.end()) {
+  if (!inserted) {
     LT_LOG("register_event_or_throw() : %s:%s:%i : tried to register an existing file descriptor : %s:%s",
            this_thread::thread()->name(), event->type_name(), fd,
            itr->second.thread->name(), itr->second.event->type_name());
@@ -250,8 +258,7 @@ SocketManager::register_event_or_throw(Event* event, category_t category, std::f
   LT_LOG("register_event_or_throw() : %s:%s:%i : registered socket",
          this_thread::thread()->name(), event->type_name(), fd);
 
-  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket_unsafe(itr_new, category);
+  account_new_socket_unsafe(itr, category);
 }
 
 void

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -7,10 +7,10 @@
 #include "torrent/event.h"
 #include "torrent/exceptions.h"
 #include "torrent/net/socket_address.h"
-#include "torrent/system/thread.h"
 #include "torrent/utils/log.h"
+#include "torrent/system/thread.h"
 
-#define LT_LOG(log_fmt, ...) \
+#define LT_LOG(log_fmt, ...)                                            \
   lt_log_print(LOG_NET_SOCKET, "socket_manager: " log_fmt, __VA_ARGS__);
 
 namespace torrent::runtime {
@@ -34,12 +34,12 @@ SocketManager::max_size() {
 }
 
 uint32_t
-SocketManager::category_managed_size(uint8_t category) const {
+SocketManager::category_managed_size(category_t category) const {
   return m_category_managed_size[category];
 }
 
 uint32_t
-SocketManager::category_max_size(uint8_t category) const {
+SocketManager::category_max_size(category_t category) const {
   return m_category_max_size[category];
 }
 
@@ -50,20 +50,20 @@ SocketManager::set_max_size(uint32_t max_size) {
 }
 
 void
-SocketManager::set_category_max_size(uint8_t category, uint32_t max_size) {
+SocketManager::set_category_max_size(category_t category, uint32_t max_size) {
   auto guard                    = lock_guard();
   m_category_max_size[category] = max_size;
 }
 
 void
-SocketManager::account_new_socket(socket_map::iterator itr, uint8_t category) {
+SocketManager::account_new_socket_unsafe(socket_map::iterator itr, category_t category) {
   itr->second.category = category;
   m_managed_size++;
   m_category_managed_size[category]++;
 }
 
 void
-SocketManager::account_remove_socket(socket_map::iterator itr) {
+SocketManager::account_remove_socket_unsafe(socket_map::iterator itr) {
   m_managed_size--;
   m_category_managed_size[itr->second.category]--;
 }
@@ -83,14 +83,14 @@ SocketManager::remove_unmanaged_socket() {
 
 // TODO: Add check to open_event_*.
 bool
-SocketManager::can_open_socket(uint8_t category) {
+SocketManager::can_open_socket(category_t category) {
   auto guard = lock_guard();
   return size() < max_size() &&
          (m_category_max_size[category] == 0 || m_category_managed_size[category] < m_category_max_size[category]);
 }
 
 void
-SocketManager::open_event_or_throw(Event* event, std::function<void()> func, uint8_t category) {
+SocketManager::open_event_or_throw(Event* event, category_t category, std::function<void ()> func) {
   auto guard = lock_guard();
 
   if (event->is_open())
@@ -109,11 +109,8 @@ SocketManager::open_event_or_throw(Event* event, std::function<void()> func, uin
   if (itr != m_socket_map.end()) {
     // We don't allow conflicts for this function.
     LT_LOG("open_event_or_throw() : %s:%s:%i : tried to use an existing file descriptor : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
     throw internal_error("SocketManager::open_event_or_throw(): tried to use an existing file descriptor: " +
                          std::string(itr->second.thread->name()) + ":" +
@@ -122,16 +119,14 @@ SocketManager::open_event_or_throw(Event* event, std::function<void()> func, uin
   }
 
   LT_LOG("open_event_or_throw() : %s:%s:%i : opened socket",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
-  m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket(m_socket_map.find(fd), category);
+  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
+  account_new_socket_unsafe(itr_new, category);
 }
 
 bool
-SocketManager::open_event_or_cleanup(Event* event, std::function<void()> func, std::function<void(bool)> cleanup, uint8_t category) {
+SocketManager::open_event_or_cleanup(Event* event, category_t category, std::function<void ()> func, std::function<void (bool)> cleanup) {
   auto guard = lock_guard();
 
   if (event->is_open())
@@ -140,8 +135,7 @@ SocketManager::open_event_or_cleanup(Event* event, std::function<void()> func, s
   if (m_managed_size + m_unmanaged_size >= m_max_size ||
       (m_category_max_size[category] > 0 && m_category_managed_size[category] >= m_category_max_size[category])) {
     LT_LOG("open_event_or_cleanup() : %s:%s : cannot open socket, max open sockets reached",
-           this_thread::thread()->name(),
-           event->type_name());
+           this_thread::thread()->name(), event->type_name());
 
     cleanup(false);
     return false;
@@ -163,40 +157,32 @@ SocketManager::open_event_or_cleanup(Event* event, std::function<void()> func, s
     if (!handle_reused_socket(itr)) {
       // TODO: Make this a macro. use (sss : ss)
       LT_LOG("open_event_or_cleanup() : %s:%s:%i : failed to reuse existing file descriptor : %s:%s",
-             this_thread::thread()->name(),
-             event->type_name(),
-             fd,
-             itr->second.thread->name(),
-             itr->second.event->type_name());
+             this_thread::thread()->name(), event->type_name(), fd,
+             itr->second.thread->name(), itr->second.event->type_name());
 
       cleanup(true);
       return false;
     }
 
     LT_LOG("open_event_or_cleanup() : %s:%s:%i : reused existing file descriptor : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
     itr->second = SocketInfo{fd, event, this_thread::thread()};
-    account_new_socket(itr, category);
+    account_new_socket_unsafe(itr, category);
     return true;
   }
 
   LT_LOG("open_event_or_cleanup() : %s:%s:%i : opened socket",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
-  m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket(m_socket_map.find(fd), category);
+  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
+  account_new_socket_unsafe(itr_new, category);
   return true;
 }
 
 void
-SocketManager::close_event_or_throw(Event* event, std::function<void()> func) {
+SocketManager::close_event_or_throw(Event* event, std::function<void ()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -207,20 +193,15 @@ SocketManager::close_event_or_throw(Event* event, std::function<void()> func) {
 
   if (itr == m_socket_map.end()) {
     LT_LOG("close_event_or_throw() : %s:%s:%i : trying to close unknown socket",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd);
+           this_thread::thread()->name(), event->type_name(), fd);
 
     throw internal_error("SocketManager::close_event_or_throw(): trying to close unknown socket fd");
   }
 
   if (itr->second.event != event) {
     LT_LOG("close_event_or_throw() : %s:%s:%i : event mismatch when trying to close socket : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
     throw internal_error("SocketManager::close_event_or_throw(): event mismatch when trying to close socket fd");
   }
@@ -231,16 +212,14 @@ SocketManager::close_event_or_throw(Event* event, std::function<void()> func) {
     throw internal_error("SocketManager::close_event_or_throw(): event is still open after close function");
 
   LT_LOG("close_event_or_throw() : %s:%s:%i : closed socket",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
-  account_remove_socket(itr);
+  account_remove_socket_unsafe(itr);
   m_socket_map.erase(itr);
 }
 
 void
-SocketManager::register_event_or_throw(Event* event, std::function<void()> func, uint8_t category) {
+SocketManager::register_event_or_throw(Event* event, category_t category, std::function<void ()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -251,11 +230,8 @@ SocketManager::register_event_or_throw(Event* event, std::function<void()> func,
 
   if (itr != m_socket_map.end()) {
     LT_LOG("register_event_or_throw() : %s:%s:%i : tried to register an existing file descriptor : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
     throw internal_error("SocketManager::register_event_or_throw(): tried to register an existing file descriptor: " +
                          std::string(this_thread::thread()->name()) + ":" + std::string(event->type_name()) + ":" + std::to_string(fd) + " -> " +
@@ -265,16 +241,14 @@ SocketManager::register_event_or_throw(Event* event, std::function<void()> func,
   func();
 
   LT_LOG("register_event_or_throw() : %s:%s:%i : registered socket",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
-  m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  account_new_socket(m_socket_map.find(fd), category);
+  auto [itr_new, _] = m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
+  account_new_socket_unsafe(itr_new, category);
 }
 
 void
-SocketManager::unregister_event_or_throw(Event* event, std::function<void()> func) {
+SocketManager::unregister_event_or_throw(Event* event, std::function<void ()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -285,20 +259,15 @@ SocketManager::unregister_event_or_throw(Event* event, std::function<void()> fun
 
   if (itr == m_socket_map.end()) {
     LT_LOG("unregister_event_or_throw() : %s:%s:%i : trying to unregister unknown socket",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd);
+           this_thread::thread()->name(), event->type_name(), fd);
 
     throw internal_error("SocketManager::unregister_event_or_throw(): trying to unregister unknown socket fd");
   }
 
   if (itr->second.event != event) {
     LT_LOG("unregister_event_or_throw() : %s:%s:%i : event mismatch when trying to unregister socket : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
 
     throw internal_error("SocketManager::unregister_event_or_throw(): event mismatch when trying to unregister socket fd");
   }
@@ -306,17 +275,15 @@ SocketManager::unregister_event_or_throw(Event* event, std::function<void()> fun
   func();
 
   LT_LOG("unregister_event_or_throw() : %s:%s:%i : unregistered socket",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
-  account_remove_socket(itr);
+  account_remove_socket_unsafe(itr);
   m_socket_map.erase(itr);
 }
 
 // Always returns non-null if func() succeeds.
 Event*
-SocketManager::transfer_event(Event* event_from, std::function<Event*()> func) {
+SocketManager::transfer_event(Event* event_from, std::function<Event* ()> func) {
   auto guard = lock_guard();
 
   if (!event_from->is_open())
@@ -327,9 +294,7 @@ SocketManager::transfer_event(Event* event_from, std::function<Event*()> func) {
 
   if (itr == m_socket_map.end()) {
     LT_LOG("transfer_event() : %s:%s:%i : trying to transfer unknown socket",
-           this_thread::thread()->name(),
-           event_from->type_name(),
-           fd);
+           this_thread::thread()->name(), event_from->type_name(), fd);
 
     throw internal_error("SocketManager::transfer_event(): trying to transfer unknown socket fd");
   }
@@ -342,11 +307,9 @@ SocketManager::transfer_event(Event* event_from, std::function<Event*()> func) {
   if (event_to == nullptr) {
     // Transfer failed, the func is responsible for cleaning up event_from.
     LT_LOG("transfer_event() : %s:%s:%i : socket transfer function returned nullptr",
-           this_thread::thread()->name(),
-           event_from->type_name(),
-           fd);
+           this_thread::thread()->name(), event_from->type_name(), fd);
 
-    account_remove_socket(itr);
+    account_remove_socket_unsafe(itr);
     m_socket_map.erase(itr);
     return nullptr;
   }
@@ -357,16 +320,13 @@ SocketManager::transfer_event(Event* event_from, std::function<Event*()> func) {
   itr->second.event = event_to;
 
   LT_LOG("transfer_event() : %s:%s:%i : transferred socket : %s",
-         this_thread::thread()->name(),
-         event_from->type_name(),
-         fd,
-         event_to->type_name());
+         this_thread::thread()->name(), event_from->type_name(), fd, event_to->type_name());
 
   return event_to;
 }
 
 bool
-SocketManager::execute_if_not_present(int fd, std::function<void()> func) {
+SocketManager::execute_if_not_present(int fd, std::function<void ()> func) {
   auto guard = lock_guard();
   auto itr   = m_socket_map.find(fd);
 
@@ -389,36 +349,27 @@ SocketManager::mark_event_active_or_fail(Event* event) {
 
   if (itr == m_socket_map.end()) {
     LT_LOG("mark_event_active_or_fail() : %s:%s:%i : fd was likely reused, then closed",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd);
+           this_thread::thread()->name(), event->type_name(), fd);
     return false;
   }
 
   if (itr->second.event != event) {
     LT_LOG("mark_event_active_or_fail() : %s:%s:%i : fd has been reused and is active : %s:%s",
-           this_thread::thread()->name(),
-           event->type_name(),
-           fd,
-           itr->second.thread->name(),
-           itr->second.event->type_name());
+           this_thread::thread()->name(), event->type_name(), fd,
+           itr->second.thread->name(), itr->second.event->type_name());
     return false;
   }
 
   if (event->socket_address() != nullptr) {
     if (!event->update_and_verify_socket_address()) {
       LT_LOG("mark_event_active_or_fail() : %s:%s:%i : socket address verification failed",
-             this_thread::thread()->name(),
-             event->type_name(),
-             fd);
+             this_thread::thread()->name(), event->type_name(), fd);
       return false;
     }
 
     if (!event->update_and_verify_peer_address()) {
       LT_LOG("mark_event_active_or_fail() : %s:%s:%i : peer address verification failed",
-             this_thread::thread()->name(),
-             event->type_name(),
-             fd);
+             this_thread::thread()->name(), event->type_name(), fd);
       return false;
     }
   }
@@ -426,15 +377,13 @@ SocketManager::mark_event_active_or_fail(Event* event) {
   itr->second.flags &= ~flag_inactive;
 
   LT_LOG("mark_event_active() : %s:%s:%i : marked socket active",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
   return true;
 }
 
 void
-SocketManager::mark_event_inactive(Event* event, std::function<void()> func) {
+SocketManager::mark_event_inactive(Event* event, std::function<void ()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -454,9 +403,7 @@ SocketManager::mark_event_inactive(Event* event, std::function<void()> func) {
   itr->second.flags |= flag_inactive;
 
   LT_LOG("mark_event_inactive() : %s:%s:%i : marked socket inactive",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 }
 
 // The socket must be in read/write to avoid reuse before calling this.
@@ -466,10 +413,11 @@ SocketManager::mark_event_inactive(Event* event, std::function<void()> func) {
 // Some of this relies on no non-SocketManager managed sockets being added to this_thread's
 // poller. Or else cleanup that removes reused fd's can cause issues.
 
+
 // TODO: Rename inet?
 
 bool
-SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> func, std::function<void()> on_reuse) {
+SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> func, std::function<void ()> on_reuse) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -486,9 +434,7 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> fu
 
   if (!event->update_and_verify_socket_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : socket address verification failed",
-           this_thread::thread()->name(),
-           event->type_name(),
-           event->file_descriptor());
+           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
 
     on_reuse();
     return false;
@@ -496,9 +442,7 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> fu
 
   if (!event->update_and_verify_peer_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : peer address verification failed",
-           this_thread::thread()->name(),
-           event->type_name(),
-           event->file_descriptor());
+           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
 
     // TODO: Check if socket is still valid?
     on_reuse();
@@ -507,9 +451,7 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> fu
 
   if (!event->socket_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : socket address is null after update",
-           this_thread::thread()->name(),
-           event->type_name(),
-           event->file_descriptor());
+           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
 
     on_reuse();
     return false;
@@ -518,20 +460,15 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> fu
   // TODO: Check if we got a valid socket_address (a must).
 
   LT_LOG("mark_stream_event_inactive() : %s:%s:%i : marking stream socket inactive : socket:%s peer:%s",
-         this_thread::thread()->name(),
-         event->type_name(),
-         event->file_descriptor(),
-         sa_pretty_str(event->socket_address()).c_str(),
-         sa_pretty_str(event->peer_address()).c_str());
+         this_thread::thread()->name(), event->type_name(), event->file_descriptor(),
+         sa_pretty_str(event->socket_address()).c_str(), sa_pretty_str(event->peer_address()).c_str());
 
   func();
 
   itr->second.flags |= flag_inactive;
 
   LT_LOG("mark_event_inactive() : %s:%s:%i : marked socket inactive",
-         this_thread::thread()->name(),
-         event->type_name(),
-         fd);
+         this_thread::thread()->name(), event->type_name(), fd);
 
   return true;
 }

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -17,22 +17,6 @@
 namespace {
 
 uint32_t
-calculate_max_open_files(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 512;
-  else if (open_max >= 8096)
-    return 256;
-  else if (open_max >= 1024)
-    return 128;
-  else if (open_max >= 512)
-    return 64;
-  else if (open_max >= 128)
-    return 16;
-  else // Assumes we don't try less than 64.
-    return 4;
-}
-
-uint32_t
 calculate_reserved(uint32_t open_max) {
   if (open_max >= 16384)
     return 512;
@@ -59,7 +43,7 @@ calculate_internal(uint32_t open_max) {
 }
 
 uint32_t
-calculate_max_http_total_connections(uint32_t open_max) {
+calculate_http(uint32_t open_max) {
   if (open_max >= 16384)
     return 128;
   else if (open_max >= 8096)
@@ -72,6 +56,20 @@ calculate_max_http_total_connections(uint32_t open_max) {
     return 8;
   else // Assumes we don't try less than 64.
     return 4;
+}
+
+uint32_t
+calculate_scgi(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 256;
+  else if (open_max >= 8096)
+    return 128;
+  else if (open_max >= 1024)
+    return 64;
+  else if (open_max >= 512)
+    return 32;
+  else
+    return 16;
 }
 
 } // namespace
@@ -110,12 +108,17 @@ void
 SocketManager::set_max_size_and_adjust(uint32_t max_open) {
   auto guard = lock_guard();
 
-  auto max_files = calculate_max_open_files(max_open);
-  auto reserved  = calculate_reserved(max_open);
-  m_max_size = max_open - max_files - reserved;
+  m_max_size = max_open;
 
   m_category_max_size[category_internal] = calculate_internal(max_open);
-  m_category_max_size[category_http]     = calculate_max_http_total_connections(max_open);
+  m_category_max_size[category_http]     = calculate_http(max_open);
+  m_category_max_size[category_scgi]     = calculate_scgi(max_open);
+
+  m_category_max_size[category_generic]  = max_open
+    - calculate_reserved(max_open)
+    - m_category_max_size[category_internal]
+    - m_category_max_size[category_http]
+    - m_category_max_size[category_scgi];
 
   notify_changes();
 }

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -7,10 +7,10 @@
 #include "torrent/event.h"
 #include "torrent/exceptions.h"
 #include "torrent/net/socket_address.h"
-#include "torrent/utils/log.h"
 #include "torrent/system/thread.h"
+#include "torrent/utils/log.h"
 
-#define LT_LOG(log_fmt, ...)                                            \
+#define LT_LOG(log_fmt, ...) \
   lt_log_print(LOG_NET_SOCKET, "socket_manager: " log_fmt, __VA_ARGS__);
 
 namespace torrent::runtime {
@@ -33,10 +33,39 @@ SocketManager::max_size() {
   return m_max_size;
 }
 
+uint32_t
+SocketManager::category_managed_size(uint8_t category) const {
+  return m_category_managed_size[category];
+}
+
+uint32_t
+SocketManager::category_max_size(uint8_t category) const {
+  return m_category_max_size[category];
+}
+
 void
 SocketManager::set_max_size(uint32_t max_size) {
   auto guard = lock_guard();
   m_max_size = max_size;
+}
+
+void
+SocketManager::set_category_max_size(uint8_t category, uint32_t max_size) {
+  auto guard                    = lock_guard();
+  m_category_max_size[category] = max_size;
+}
+
+void
+SocketManager::account_new_socket(socket_map::iterator itr, uint8_t category) {
+  itr->second.category = category;
+  m_managed_size++;
+  m_category_managed_size[category]++;
+}
+
+void
+SocketManager::account_remove_socket(socket_map::iterator itr) {
+  m_managed_size--;
+  m_category_managed_size[itr->second.category]--;
 }
 
 void
@@ -54,13 +83,14 @@ SocketManager::remove_unmanaged_socket() {
 
 // TODO: Add check to open_event_*.
 bool
-SocketManager::can_open_socket() {
+SocketManager::can_open_socket(uint8_t category) {
   auto guard = lock_guard();
-  return size() < max_size();
+  return size() < max_size() &&
+         (m_category_max_size[category] == 0 || m_category_managed_size[category] < m_category_max_size[category]);
 }
 
 void
-SocketManager::open_event_or_throw(Event* event, std::function<void ()> func) {
+SocketManager::open_event_or_throw(Event* event, std::function<void()> func, uint8_t category) {
   auto guard = lock_guard();
 
   if (event->is_open())
@@ -79,8 +109,11 @@ SocketManager::open_event_or_throw(Event* event, std::function<void ()> func) {
   if (itr != m_socket_map.end()) {
     // We don't allow conflicts for this function.
     LT_LOG("open_event_or_throw() : %s:%s:%i : tried to use an existing file descriptor : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
 
     throw internal_error("SocketManager::open_event_or_throw(): tried to use an existing file descriptor: " +
                          std::string(itr->second.thread->name()) + ":" +
@@ -89,22 +122,26 @@ SocketManager::open_event_or_throw(Event* event, std::function<void ()> func) {
   }
 
   LT_LOG("open_event_or_throw() : %s:%s:%i : opened socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
   m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  m_managed_size++;
+  account_new_socket(m_socket_map.find(fd), category);
 }
 
 bool
-SocketManager::open_event_or_cleanup(Event* event, std::function<void ()> func, std::function<void (bool)> cleanup) {
+SocketManager::open_event_or_cleanup(Event* event, std::function<void()> func, std::function<void(bool)> cleanup, uint8_t category) {
   auto guard = lock_guard();
 
   if (event->is_open())
     throw internal_error("SocketManager::open_event_or_cleanup(): event is already open");
 
-  if (m_managed_size + m_unmanaged_size >= m_max_size) {
+  if (m_managed_size + m_unmanaged_size >= m_max_size ||
+      (m_category_max_size[category] > 0 && m_category_managed_size[category] >= m_category_max_size[category])) {
     LT_LOG("open_event_or_cleanup() : %s:%s : cannot open socket, max open sockets reached",
-           this_thread::thread()->name(), event->type_name());
+           this_thread::thread()->name(),
+           event->type_name());
 
     cleanup(false);
     return false;
@@ -126,31 +163,40 @@ SocketManager::open_event_or_cleanup(Event* event, std::function<void ()> func, 
     if (!handle_reused_socket(itr)) {
       // TODO: Make this a macro. use (sss : ss)
       LT_LOG("open_event_or_cleanup() : %s:%s:%i : failed to reuse existing file descriptor : %s:%s",
-             this_thread::thread()->name(), event->type_name(), fd,
-             itr->second.thread->name(), itr->second.event->type_name());
+             this_thread::thread()->name(),
+             event->type_name(),
+             fd,
+             itr->second.thread->name(),
+             itr->second.event->type_name());
 
       cleanup(true);
       return false;
     }
 
     LT_LOG("open_event_or_cleanup() : %s:%s:%i : reused existing file descriptor : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
 
     itr->second = SocketInfo{fd, event, this_thread::thread()};
+    account_new_socket(itr, category);
     return true;
   }
 
   LT_LOG("open_event_or_cleanup() : %s:%s:%i : opened socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
   m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  m_managed_size++;
+  account_new_socket(m_socket_map.find(fd), category);
   return true;
 }
 
 void
-SocketManager::close_event_or_throw(Event* event, std::function<void ()> func) {
+SocketManager::close_event_or_throw(Event* event, std::function<void()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -161,15 +207,20 @@ SocketManager::close_event_or_throw(Event* event, std::function<void ()> func) {
 
   if (itr == m_socket_map.end()) {
     LT_LOG("close_event_or_throw() : %s:%s:%i : trying to close unknown socket",
-           this_thread::thread()->name(), event->type_name(), fd);
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd);
 
     throw internal_error("SocketManager::close_event_or_throw(): trying to close unknown socket fd");
   }
 
   if (itr->second.event != event) {
     LT_LOG("close_event_or_throw() : %s:%s:%i : event mismatch when trying to close socket : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
 
     throw internal_error("SocketManager::close_event_or_throw(): event mismatch when trying to close socket fd");
   }
@@ -180,14 +231,16 @@ SocketManager::close_event_or_throw(Event* event, std::function<void ()> func) {
     throw internal_error("SocketManager::close_event_or_throw(): event is still open after close function");
 
   LT_LOG("close_event_or_throw() : %s:%s:%i : closed socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
+  account_remove_socket(itr);
   m_socket_map.erase(itr);
-  m_managed_size--;
 }
 
 void
-SocketManager::register_event_or_throw(Event* event, std::function<void ()> func) {
+SocketManager::register_event_or_throw(Event* event, std::function<void()> func, uint8_t category) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -198,8 +251,11 @@ SocketManager::register_event_or_throw(Event* event, std::function<void ()> func
 
   if (itr != m_socket_map.end()) {
     LT_LOG("register_event_or_throw() : %s:%s:%i : tried to register an existing file descriptor : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
 
     throw internal_error("SocketManager::register_event_or_throw(): tried to register an existing file descriptor: " +
                          std::string(this_thread::thread()->name()) + ":" + std::string(event->type_name()) + ":" + std::to_string(fd) + " -> " +
@@ -209,14 +265,16 @@ SocketManager::register_event_or_throw(Event* event, std::function<void ()> func
   func();
 
   LT_LOG("register_event_or_throw() : %s:%s:%i : registered socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
   m_socket_map.emplace(fd, SocketInfo{fd, event, this_thread::thread()});
-  m_managed_size++;
+  account_new_socket(m_socket_map.find(fd), category);
 }
 
 void
-SocketManager::unregister_event_or_throw(Event* event, std::function<void ()> func) {
+SocketManager::unregister_event_or_throw(Event* event, std::function<void()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -227,15 +285,20 @@ SocketManager::unregister_event_or_throw(Event* event, std::function<void ()> fu
 
   if (itr == m_socket_map.end()) {
     LT_LOG("unregister_event_or_throw() : %s:%s:%i : trying to unregister unknown socket",
-           this_thread::thread()->name(), event->type_name(), fd);
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd);
 
     throw internal_error("SocketManager::unregister_event_or_throw(): trying to unregister unknown socket fd");
   }
 
   if (itr->second.event != event) {
     LT_LOG("unregister_event_or_throw() : %s:%s:%i : event mismatch when trying to unregister socket : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
 
     throw internal_error("SocketManager::unregister_event_or_throw(): event mismatch when trying to unregister socket fd");
   }
@@ -243,15 +306,17 @@ SocketManager::unregister_event_or_throw(Event* event, std::function<void ()> fu
   func();
 
   LT_LOG("unregister_event_or_throw() : %s:%s:%i : unregistered socket",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
+  account_remove_socket(itr);
   m_socket_map.erase(itr);
-  m_managed_size--;
 }
 
 // Always returns non-null if func() succeeds.
 Event*
-SocketManager::transfer_event(Event* event_from, std::function<Event* ()> func) {
+SocketManager::transfer_event(Event* event_from, std::function<Event*()> func) {
   auto guard = lock_guard();
 
   if (!event_from->is_open())
@@ -262,7 +327,9 @@ SocketManager::transfer_event(Event* event_from, std::function<Event* ()> func) 
 
   if (itr == m_socket_map.end()) {
     LT_LOG("transfer_event() : %s:%s:%i : trying to transfer unknown socket",
-           this_thread::thread()->name(), event_from->type_name(), fd);
+           this_thread::thread()->name(),
+           event_from->type_name(),
+           fd);
 
     throw internal_error("SocketManager::transfer_event(): trying to transfer unknown socket fd");
   }
@@ -275,10 +342,12 @@ SocketManager::transfer_event(Event* event_from, std::function<Event* ()> func) 
   if (event_to == nullptr) {
     // Transfer failed, the func is responsible for cleaning up event_from.
     LT_LOG("transfer_event() : %s:%s:%i : socket transfer function returned nullptr",
-           this_thread::thread()->name(), event_from->type_name(), fd);
+           this_thread::thread()->name(),
+           event_from->type_name(),
+           fd);
 
+    account_remove_socket(itr);
     m_socket_map.erase(itr);
-    m_managed_size--;
     return nullptr;
   }
 
@@ -288,13 +357,16 @@ SocketManager::transfer_event(Event* event_from, std::function<Event* ()> func) 
   itr->second.event = event_to;
 
   LT_LOG("transfer_event() : %s:%s:%i : transferred socket : %s",
-         this_thread::thread()->name(), event_from->type_name(), fd, event_to->type_name());
+         this_thread::thread()->name(),
+         event_from->type_name(),
+         fd,
+         event_to->type_name());
 
   return event_to;
 }
 
 bool
-SocketManager::execute_if_not_present(int fd, std::function<void ()> func) {
+SocketManager::execute_if_not_present(int fd, std::function<void()> func) {
   auto guard = lock_guard();
   auto itr   = m_socket_map.find(fd);
 
@@ -317,27 +389,36 @@ SocketManager::mark_event_active_or_fail(Event* event) {
 
   if (itr == m_socket_map.end()) {
     LT_LOG("mark_event_active_or_fail() : %s:%s:%i : fd was likely reused, then closed",
-           this_thread::thread()->name(), event->type_name(), fd);
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd);
     return false;
   }
 
   if (itr->second.event != event) {
     LT_LOG("mark_event_active_or_fail() : %s:%s:%i : fd has been reused and is active : %s:%s",
-           this_thread::thread()->name(), event->type_name(), fd,
-           itr->second.thread->name(), itr->second.event->type_name());
+           this_thread::thread()->name(),
+           event->type_name(),
+           fd,
+           itr->second.thread->name(),
+           itr->second.event->type_name());
     return false;
   }
 
   if (event->socket_address() != nullptr) {
     if (!event->update_and_verify_socket_address()) {
       LT_LOG("mark_event_active_or_fail() : %s:%s:%i : socket address verification failed",
-             this_thread::thread()->name(), event->type_name(), fd);
+             this_thread::thread()->name(),
+             event->type_name(),
+             fd);
       return false;
     }
 
     if (!event->update_and_verify_peer_address()) {
       LT_LOG("mark_event_active_or_fail() : %s:%s:%i : peer address verification failed",
-             this_thread::thread()->name(), event->type_name(), fd);
+             this_thread::thread()->name(),
+             event->type_name(),
+             fd);
       return false;
     }
   }
@@ -345,13 +426,15 @@ SocketManager::mark_event_active_or_fail(Event* event) {
   itr->second.flags &= ~flag_inactive;
 
   LT_LOG("mark_event_active() : %s:%s:%i : marked socket active",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
   return true;
 }
 
 void
-SocketManager::mark_event_inactive(Event* event, std::function<void ()> func) {
+SocketManager::mark_event_inactive(Event* event, std::function<void()> func) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -371,7 +454,9 @@ SocketManager::mark_event_inactive(Event* event, std::function<void ()> func) {
   itr->second.flags |= flag_inactive;
 
   LT_LOG("mark_event_inactive() : %s:%s:%i : marked socket inactive",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 }
 
 // The socket must be in read/write to avoid reuse before calling this.
@@ -381,11 +466,10 @@ SocketManager::mark_event_inactive(Event* event, std::function<void ()> func) {
 // Some of this relies on no non-SocketManager managed sockets being added to this_thread's
 // poller. Or else cleanup that removes reused fd's can cause issues.
 
-
 // TODO: Rename inet?
 
 bool
-SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> func, std::function<void ()> on_reuse) {
+SocketManager::mark_stream_event_inactive(Event* event, std::function<void()> func, std::function<void()> on_reuse) {
   auto guard = lock_guard();
 
   if (!event->is_open())
@@ -402,7 +486,9 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> f
 
   if (!event->update_and_verify_socket_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : socket address verification failed",
-           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
+           this_thread::thread()->name(),
+           event->type_name(),
+           event->file_descriptor());
 
     on_reuse();
     return false;
@@ -410,7 +496,9 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> f
 
   if (!event->update_and_verify_peer_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : peer address verification failed",
-           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
+           this_thread::thread()->name(),
+           event->type_name(),
+           event->file_descriptor());
 
     // TODO: Check if socket is still valid?
     on_reuse();
@@ -419,7 +507,9 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> f
 
   if (!event->socket_address()) {
     LT_LOG("mark_stream_event_inactive() : %s:%s:%i : socket address is null after update",
-           this_thread::thread()->name(), event->type_name(), event->file_descriptor());
+           this_thread::thread()->name(),
+           event->type_name(),
+           event->file_descriptor());
 
     on_reuse();
     return false;
@@ -428,15 +518,20 @@ SocketManager::mark_stream_event_inactive(Event* event, std::function<void ()> f
   // TODO: Check if we got a valid socket_address (a must).
 
   LT_LOG("mark_stream_event_inactive() : %s:%s:%i : marking stream socket inactive : socket:%s peer:%s",
-         this_thread::thread()->name(), event->type_name(), event->file_descriptor(),
-         sa_pretty_str(event->socket_address()).c_str(), sa_pretty_str(event->peer_address()).c_str());
+         this_thread::thread()->name(),
+         event->type_name(),
+         event->file_descriptor(),
+         sa_pretty_str(event->socket_address()).c_str(),
+         sa_pretty_str(event->peer_address()).c_str());
 
   func();
 
   itr->second.flags |= flag_inactive;
 
   LT_LOG("mark_event_inactive() : %s:%s:%i : marked socket inactive",
-         this_thread::thread()->name(), event->type_name(), fd);
+         this_thread::thread()->name(),
+         event->type_name(),
+         fd);
 
   return true;
 }

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -107,6 +107,7 @@ private:
 
   void                account_new_socket_unsafe(socket_map::iterator itr, category_t category);
   void                account_remove_socket_unsafe(socket_map::iterator itr);
+  void                account_replace_socket_unsafe(socket_map::iterator itr, category_t new_category);
 
   bool                handle_reused_socket(socket_map::iterator itr);
 

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -4,8 +4,8 @@
 #include <array>
 #include <atomic>
 #include <mutex>
-#include <torrent/common.h>
 #include <unordered_map>
+#include <torrent/common.h>
 
 // A socket that is closed by the kernel while neitehr ready nor write polling will be considered
 // uninterested by the kernel, and possibly reused.
@@ -25,11 +25,11 @@ struct SocketInfo {
   // TODO: Event should contain the owning thread, and not be included here.
   // TODO: Fd not needed here.
 
-  int             fd{-1};
-  Event*          event{};
-  system::Thread* thread{};
-  int             flags{};
-  uint8_t         category{};
+  int                 fd{-1};
+  Event*              event{};
+  system::Thread*     thread{};
+  int                 flags{};
+  uint8_t             category{};
 };
 
 class LIBTORRENT_EXPORT SocketManager {
@@ -39,30 +39,30 @@ public:
   // Categories of allocated sockets within the global pool.
   // When a category's max is non-zero, open operations additionally check
   // that the category's current usage has not reached its limit.
-  static constexpr uint8_t category_generic  = 0; // peer connections, BT listen, uncategorized
-  static constexpr uint8_t category_http     = 1; // HTTP/curl
-  static constexpr uint8_t category_dht      = 2; // DHT server
-  static constexpr uint8_t category_tracker  = 3; // UDP tracker router
-  static constexpr uint8_t category_internal = 4; // thread interrupt pairs, system signals
-  static constexpr uint8_t category_scgi     = 5; // SCGI/RPC
-  static constexpr uint8_t category_count    = 6;
+  enum category_t : uint8_t {
+    category_generic,   // peer connections, uncategorized
+    category_http,      // HTTP/curl
+    category_internal,  // DHT, UDP tracker, thread interrupt, BT listen
+    category_scgi,      // SCGI/RPC
+    category_count,
+  };
 
   SocketManager();
   ~SocketManager();
 
-  uint32_t size();
-  uint32_t max_size();
+  uint32_t            size();
+  uint32_t            max_size();
 
-  uint32_t category_managed_size(uint8_t category) const;
-  uint32_t category_max_size(uint8_t category) const;
+  uint32_t            category_managed_size(category_t category) const;
+  uint32_t            category_max_size(category_t category) const;
 
-  void     set_max_size(uint32_t max_size);
-  void     set_category_max_size(uint8_t category, uint32_t max_size);
+  void                set_max_size(uint32_t max_size);
+  void                set_category_max_size(category_t category, uint32_t max_size);
 
-  void     add_unmanaged_socket();
-  void     remove_unmanaged_socket();
+  void                add_unmanaged_socket();
+  void                remove_unmanaged_socket();
 
-  bool     can_open_socket(uint8_t category = category_generic);
+  bool                can_open_socket(category_t category);
 
   // TODO: Rename / change _or_throw to be more specific about what we throw, as it currently calls
   // internal errors. DHT server should probably throw resource_error instead? Or retry. (this
@@ -73,52 +73,53 @@ public:
   // To avoid reuse race conditions, these calls must also add the Event to read/write polling.
 
   // Throw internal_error on conflicts, as the caller isn't expecting conflicts.
-  void open_event_or_throw(Event* event, std::function<void()> func, uint8_t category = category_generic);
+  void                open_event_or_throw(Event* event, category_t category, std::function<void ()> func);
 
   // Try to reuse existing socket, if that fails call cleanup.
   //
   // This is used for listen accept and other cases where the caller doesn't mind ignoring failures.
-  bool open_event_or_cleanup(Event* event, std::function<void()> func, std::function<void(bool)> cleanup, uint8_t category = category_generic);
+  bool                open_event_or_cleanup(Event* event, category_t category, std::function<void ()> func, std::function<void (bool)> cleanup);
 
-  void close_event_or_throw(Event* event, std::function<void()> func);
+  void                close_event_or_throw(Event* event, std::function<void ()> func);
 
   // Event already opened the socket, just register it.
-  void register_event_or_throw(Event* event, std::function<void()> func, uint8_t category = category_generic);
-  void unregister_event_or_throw(Event* event, std::function<void()> func);
+  void                register_event_or_throw(Event* event, category_t category, std::function<void ()> func);
+  void                unregister_event_or_throw(Event* event, std::function<void ()> func);
 
   // The func must close event_from and the pointer must remain valid.
-  Event*             transfer_event(Event* event_from, std::function<Event*()> func);
+  Event*              transfer_event(Event* event_from, std::function<Event* ()> func);
 
-  bool               execute_if_not_present(int fd, std::function<void()> func);
+  bool                execute_if_not_present(int fd, std::function<void ()> func);
 
-  [[nodiscard]] bool mark_event_active_or_fail(Event* event);
-  void               mark_event_inactive(Event* event, std::function<void()> func);
-  [[nodiscard]] bool mark_stream_event_inactive(Event* event, std::function<void()> func, std::function<void()> on_reuse);
+  [[nodiscard]] bool  mark_event_active_or_fail(Event* event);
+  void                mark_event_inactive(Event* event, std::function<void ()> func);
+  [[nodiscard]] bool  mark_stream_event_inactive(Event* event, std::function<void ()> func, std::function<void ()> on_reuse);
 
   // No, this should take Event*?
   // bool                is_socket_reused(int fd);
 
 protected:
-  auto lock_guard() { return std::lock_guard(m_mutex); }
+
+  auto                lock_guard() { return std::lock_guard(m_mutex); }
 
 private:
   using socket_map = std::unordered_map<int, SocketInfo>;
 
-  void                                              account_new_socket(socket_map::iterator itr, uint8_t category);
-  void                                              account_remove_socket(socket_map::iterator itr);
+  void                account_new_socket_unsafe(socket_map::iterator itr, category_t category);
+  void                account_remove_socket_unsafe(socket_map::iterator itr);
 
-  bool                                              handle_reused_socket(socket_map::iterator itr);
+  bool                handle_reused_socket(socket_map::iterator itr);
 
-  std::atomic<uint32_t>                             m_managed_size{};
-  std::atomic<uint32_t>                             m_unmanaged_size{};
-  std::atomic<uint32_t>                             m_max_size{};
+  std::atomic<uint32_t> m_managed_size{};
+  std::atomic<uint32_t> m_unmanaged_size{};
+  std::atomic<uint32_t> m_max_size{};
 
   std::array<std::atomic<uint32_t>, category_count> m_category_managed_size{};
   std::array<std::atomic<uint32_t>, category_count> m_category_max_size{};
 
-  std::mutex                                        m_mutex;
+  std::mutex          m_mutex;
 
-  socket_map                                        m_socket_map;
+  socket_map          m_socket_map;
 };
 
 } // namespace torrent::runtime

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -3,8 +3,10 @@
 
 #include <array>
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 #include <torrent/common.h>
 
 // A socket that is closed by the kernel while neitehr ready nor write polling will be considered
@@ -56,8 +58,12 @@ public:
   uint32_t            category_managed_size(category_t category) const;
   uint32_t            category_max_size(category_t category) const;
 
-  void                set_max_size(uint32_t max_size);
+  void                set_max_size_and_adjust(uint32_t max_open);
   void                set_category_max_size(category_t category, uint32_t max_size);
+
+  // The lock is held while the callback is called, so use Thread::callback().
+  void                subscribe_to_changes(void* target, const std::function<void()>& callback);
+  void                unsubscribe_from_changes(void* target);
 
   void                add_unmanaged_socket();
   void                remove_unmanaged_socket();
@@ -103,8 +109,9 @@ protected:
   auto                lock_guard() { return std::lock_guard(m_mutex); }
 
 private:
-  using socket_map    = std::unordered_map<int, SocketInfo>;
-  using category_list = std::array<std::atomic<uint32_t>, category_count>;
+  using socket_map       = std::unordered_map<int, SocketInfo>;
+  using category_list    = std::array<std::atomic<uint32_t>, category_count>;
+  using subscriber_list  = std::vector<std::pair<void*, std::function<void()>>>;
 
   void                account_new_socket_unsafe(socket_map::iterator itr, category_t category);
   void                account_remove_socket_unsafe(socket_map::iterator itr);
@@ -113,6 +120,8 @@ private:
 
   bool                handle_reused_socket(socket_map::iterator itr);
 
+  void                notify_changes() const;
+
   std::atomic<uint32_t> m_managed_size{};
   std::atomic<uint32_t> m_unmanaged_size{};
   std::atomic<uint32_t> m_max_size{};
@@ -120,7 +129,9 @@ private:
   category_list       m_category_managed_size{};
   category_list       m_category_max_size{};
 
-  std::mutex          m_mutex;
+  alignas(std::hardware_destructive_interference_size) std::mutex m_mutex;
+
+  subscriber_list     m_change_subscribers;
 
   socket_map          m_socket_map;
 };

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -46,6 +46,7 @@ public:
     category_http,      // HTTP/curl
     category_internal,  // DHT, UDP tracker, thread interrupt, BT listen
     category_scgi,      // SCGI/RPC
+    category_files,     // open files (mmap, etc.)
     category_count,
   };
 
@@ -129,7 +130,7 @@ private:
   category_list       m_category_managed_size{};
   category_list       m_category_max_size{};
 
-  alignas(std::hardware_destructive_interference_size) std::mutex m_mutex;
+  align_cacheline std::mutex m_mutex;
 
   subscriber_list     m_change_subscribers;
 

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -1,10 +1,11 @@
 #ifndef LIBTORRENT_TORRENT_RUNTIME_SOCKET_MANAGER_H
 #define LIBTORRENT_TORRENT_RUNTIME_SOCKET_MANAGER_H
 
+#include <array>
 #include <atomic>
 #include <mutex>
-#include <unordered_map>
 #include <torrent/common.h>
+#include <unordered_map>
 
 // A socket that is closed by the kernel while neitehr ready nor write polling will be considered
 // uninterested by the kernel, and possibly reused.
@@ -24,28 +25,44 @@ struct SocketInfo {
   // TODO: Event should contain the owning thread, and not be included here.
   // TODO: Fd not needed here.
 
-  int                 fd{-1};
-  Event*              event{};
-  system::Thread*     thread{};
-  int                 flags{};
+  int             fd{-1};
+  Event*          event{};
+  system::Thread* thread{};
+  int             flags{};
+  uint8_t         category{};
 };
 
 class LIBTORRENT_EXPORT SocketManager {
 public:
   static constexpr int flag_inactive = (1 << 0);
 
+  // Categories of allocated sockets within the global pool.
+  // When a category's max is non-zero, open operations additionally check
+  // that the category's current usage has not reached its limit.
+  static constexpr uint8_t category_generic  = 0; // peer connections, BT listen, uncategorized
+  static constexpr uint8_t category_http     = 1; // HTTP/curl
+  static constexpr uint8_t category_dht      = 2; // DHT server
+  static constexpr uint8_t category_tracker  = 3; // UDP tracker router
+  static constexpr uint8_t category_internal = 4; // thread interrupt pairs, system signals
+  static constexpr uint8_t category_scgi     = 5; // SCGI/RPC
+  static constexpr uint8_t category_count    = 6;
+
   SocketManager();
   ~SocketManager();
 
-  uint32_t            size();
-  uint32_t            max_size();
+  uint32_t size();
+  uint32_t max_size();
 
-  void                set_max_size(uint32_t max_size);
+  uint32_t category_managed_size(uint8_t category) const;
+  uint32_t category_max_size(uint8_t category) const;
 
-  void                add_unmanaged_socket();
-  void                remove_unmanaged_socket();
+  void     set_max_size(uint32_t max_size);
+  void     set_category_max_size(uint8_t category, uint32_t max_size);
 
-  bool                can_open_socket();
+  void     add_unmanaged_socket();
+  void     remove_unmanaged_socket();
+
+  bool     can_open_socket(uint8_t category = category_generic);
 
   // TODO: Rename / change _or_throw to be more specific about what we throw, as it currently calls
   // internal errors. DHT server should probably throw resource_error instead? Or retry. (this
@@ -56,47 +73,52 @@ public:
   // To avoid reuse race conditions, these calls must also add the Event to read/write polling.
 
   // Throw internal_error on conflicts, as the caller isn't expecting conflicts.
-  void                open_event_or_throw(Event* event, std::function<void ()> func);
+  void open_event_or_throw(Event* event, std::function<void()> func, uint8_t category = category_generic);
 
   // Try to reuse existing socket, if that fails call cleanup.
   //
   // This is used for listen accept and other cases where the caller doesn't mind ignoring failures.
-  bool                open_event_or_cleanup(Event* event, std::function<void ()> func, std::function<void (bool)> cleanup);
+  bool open_event_or_cleanup(Event* event, std::function<void()> func, std::function<void(bool)> cleanup, uint8_t category = category_generic);
 
-  void                close_event_or_throw(Event* event, std::function<void ()> func);
+  void close_event_or_throw(Event* event, std::function<void()> func);
 
   // Event already opened the socket, just register it.
-  void                register_event_or_throw(Event* event, std::function<void ()> func);
-  void                unregister_event_or_throw(Event* event, std::function<void ()> func);
+  void register_event_or_throw(Event* event, std::function<void()> func, uint8_t category = category_generic);
+  void unregister_event_or_throw(Event* event, std::function<void()> func);
 
   // The func must close event_from and the pointer must remain valid.
-  Event*              transfer_event(Event* event_from, std::function<Event* ()> func);
+  Event*             transfer_event(Event* event_from, std::function<Event*()> func);
 
-  bool                execute_if_not_present(int fd, std::function<void ()> func);
+  bool               execute_if_not_present(int fd, std::function<void()> func);
 
-  [[nodiscard]] bool  mark_event_active_or_fail(Event* event);
-  void                mark_event_inactive(Event* event, std::function<void ()> func);
-  [[nodiscard]] bool  mark_stream_event_inactive(Event* event, std::function<void ()> func, std::function<void ()> on_reuse);
+  [[nodiscard]] bool mark_event_active_or_fail(Event* event);
+  void               mark_event_inactive(Event* event, std::function<void()> func);
+  [[nodiscard]] bool mark_stream_event_inactive(Event* event, std::function<void()> func, std::function<void()> on_reuse);
 
   // No, this should take Event*?
   // bool                is_socket_reused(int fd);
 
 protected:
-
-  auto                lock_guard() { return std::lock_guard(m_mutex); }
+  auto lock_guard() { return std::lock_guard(m_mutex); }
 
 private:
   using socket_map = std::unordered_map<int, SocketInfo>;
 
-  bool                handle_reused_socket(socket_map::iterator itr);
+  void                                              account_new_socket(socket_map::iterator itr, uint8_t category);
+  void                                              account_remove_socket(socket_map::iterator itr);
 
-  std::atomic<uint32_t> m_managed_size{};
-  std::atomic<uint32_t> m_unmanaged_size{};
-  std::atomic<uint32_t> m_max_size{};
+  bool                                              handle_reused_socket(socket_map::iterator itr);
 
-  std::mutex          m_mutex;
+  std::atomic<uint32_t>                             m_managed_size{};
+  std::atomic<uint32_t>                             m_unmanaged_size{};
+  std::atomic<uint32_t>                             m_max_size{};
 
-  socket_map          m_socket_map;
+  std::array<std::atomic<uint32_t>, category_count> m_category_managed_size{};
+  std::array<std::atomic<uint32_t>, category_count> m_category_max_size{};
+
+  std::mutex                                        m_mutex;
+
+  socket_map                                        m_socket_map;
 };
 
 } // namespace torrent::runtime

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -103,11 +103,13 @@ protected:
   auto                lock_guard() { return std::lock_guard(m_mutex); }
 
 private:
-  using socket_map = std::unordered_map<int, SocketInfo>;
+  using socket_map    = std::unordered_map<int, SocketInfo>;
+  using category_list = std::array<std::atomic<uint32_t>, category_count>;
 
   void                account_new_socket_unsafe(socket_map::iterator itr, category_t category);
   void                account_remove_socket_unsafe(socket_map::iterator itr);
-  void                account_replace_socket_unsafe(socket_map::iterator itr, category_t new_category);
+
+  bool                can_open_socket_unsafe(category_t category);
 
   bool                handle_reused_socket(socket_map::iterator itr);
 
@@ -115,8 +117,8 @@ private:
   std::atomic<uint32_t> m_unmanaged_size{};
   std::atomic<uint32_t> m_max_size{};
 
-  std::array<std::atomic<uint32_t>, category_count> m_category_managed_size{};
-  std::array<std::atomic<uint32_t>, category_count> m_category_max_size{};
+  category_list       m_category_managed_size{};
+  category_list       m_category_max_size{};
 
   std::mutex          m_mutex;
 

--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -3,8 +3,8 @@
 #include "torrent/system/thread.h"
 
 #include <cassert>
-#include <cstring>
 #include <condition_variable>
+#include <cstring>
 #include <mutex>
 #include <unistd.h>
 
@@ -25,12 +25,17 @@ thread_local Thread* Thread::m_self{};
 
 Thread::~Thread() = default;
 
-Thread* Thread::self() { return m_self; }
+Thread*
+Thread::self() { return m_self; }
 
-void Thread::init_thread() {}
-void Thread::init_thread_pre_start() {}
-void Thread::init_thread_post_local() {}
-void Thread::cleanup_thread() {}
+void
+Thread::init_thread() {}
+void
+Thread::init_thread_pre_start() {}
+void
+Thread::init_thread_post_local() {}
+void
+Thread::cleanup_thread() {}
 
 Thread::Thread() :
     m_instrumentation_index(INSTRUMENTATION_POLLING_DO_POLL_OTHERS - INSTRUMENTATION_POLLING_DO_POLL),
@@ -71,7 +76,7 @@ Thread::stop_thread_wait() {
 }
 
 void
-Thread::callback(void* target, std::function<void ()>&& fn) {
+Thread::callback(void* target, std::function<void()>&& fn) {
   {
     auto lock = std::lock_guard(m_callbacks_lock);
 
@@ -82,7 +87,7 @@ Thread::callback(void* target, std::function<void ()>&& fn) {
 }
 
 void
-Thread::callback_interrupt_polling(void* target, std::function<void ()>&& fn) {
+Thread::callback_interrupt_polling(void* target, std::function<void()>&& fn) {
   {
     auto lock = std::lock_guard(m_callbacks_lock);
 
@@ -94,22 +99,22 @@ Thread::callback_interrupt_polling(void* target, std::function<void ()>&& fn) {
 }
 
 void
-Thread::callback_interrupt_polling_and_wait(void* target, std::function<void ()>&& fn) {
+Thread::callback_interrupt_polling_and_wait(void* target, std::function<void()>&& fn) {
   std::mutex              callback_mutex;
   std::condition_variable callback_cv;
 
-  bool done{};
+  bool                    done{};
 
-  auto wrapped_fn = [&callback_mutex, &callback_cv, &done, fn = std::move(fn)]() {
-      fn();
+  auto                    wrapped_fn = [&callback_mutex, &callback_cv, &done, fn = std::move(fn)]() {
+    fn();
 
-      {
-        auto lock = std::lock_guard(callback_mutex);
-        done = true;
-      }
+    {
+      auto lock = std::lock_guard(callback_mutex);
+      done      = true;
+    }
 
-      callback_cv.notify_one();
-    };
+    callback_cv.notify_one();
+  };
 
   callback_interrupt_polling(target, std::move(wrapped_fn));
 
@@ -250,9 +255,8 @@ Thread::event_loop() {
     runtime::socket_manager()->register_event_or_throw(m_interrupt_receiver.get(), [this]() {
         m_poll->open(m_interrupt_receiver.get());
         m_poll->insert_read(m_interrupt_receiver.get());
-        m_poll->insert_error(m_interrupt_receiver.get());
-    });
-    runtime::socket_manager()->register_event_or_throw(m_interrupt_sender.get(), []() {});
+        m_poll->insert_error(m_interrupt_receiver.get()); }, runtime::SocketManager::category_internal);
+    runtime::socket_manager()->register_event_or_throw(m_interrupt_sender.get(), []() {}, runtime::SocketManager::category_internal);
 
     while (true) {
       process_events();
@@ -291,10 +295,10 @@ Thread::event_loop() {
   }
 
   runtime::socket_manager()->unregister_event_or_throw(m_interrupt_receiver.get(), [this]() {
-      m_poll->remove_read(m_interrupt_receiver.get());
-      m_poll->remove_error(m_interrupt_receiver.get());
-      m_poll->close(m_interrupt_receiver.get());
-    });
+    m_poll->remove_read(m_interrupt_receiver.get());
+    m_poll->remove_error(m_interrupt_receiver.get());
+    m_poll->close(m_interrupt_receiver.get());
+  });
   runtime::socket_manager()->unregister_event_or_throw(m_interrupt_sender.get(), []() {});
 
   auto previous_state = STATE_ACTIVE;
@@ -312,8 +316,8 @@ Thread::init_thread_local() {
   pthread_setname_np(pthread_self(), name());
 #endif
 
-  m_self = this;
-  m_thread = pthread_self();
+  m_self      = this;
+  m_thread    = pthread_self();
   m_thread_id = std::this_thread::get_id();
 
   m_scheduler->set_thread_id(m_thread_id);
@@ -369,7 +373,7 @@ Thread::process_callbacks(bool only_interrupt) {
   m_callbacks_should_interrupt_polling = false;
 
   while (true) {
-    std::function<void ()> callback;
+    std::function<void()> callback;
 
     {
       auto lock = std::lock_guard(m_callbacks_lock);
@@ -444,22 +448,32 @@ Thread::set_cached_time(std::chrono::microseconds t) {
   m_scheduler->set_cached_time(t);
 }
 
-} // namespace torrent::utils
+} // namespace torrent::system
 
 namespace torrent::this_thread {
 
-torrent::system::Thread*  thread()                                            { return system::ThreadInternal::thread(); }
-std::thread::id           thread_id()                                         { return system::ThreadInternal::thread_id(); }
+torrent::system::Thread*
+thread() { return system::ThreadInternal::thread(); }
+std::thread::id
+thread_id() { return system::ThreadInternal::thread_id(); }
 
-std::chrono::microseconds cached_time()                                       { return system::ThreadInternal::cached_time(); }
-std::chrono::seconds      cached_seconds()                                    { return system::ThreadInternal::cached_seconds(); }
+std::chrono::microseconds
+cached_time() { return system::ThreadInternal::cached_time(); }
+std::chrono::seconds
+cached_seconds() { return system::ThreadInternal::cached_seconds(); }
 
-void                      callback(void* target, std::function<void ()>&& fn) { system::ThreadInternal::callback(target, std::move(fn)); }
-void                      cancel_callback(void* target)                       { system::ThreadInternal::cancel_callback(target); }
-void                      cancel_callback_and_wait(void* target)              { system::ThreadInternal::cancel_callback_and_wait(target); }
+void
+callback(void* target, std::function<void()>&& fn) { system::ThreadInternal::callback(target, std::move(fn)); }
+void
+cancel_callback(void* target) { system::ThreadInternal::cancel_callback(target); }
+void
+cancel_callback_and_wait(void* target) { system::ThreadInternal::cancel_callback_and_wait(target); }
 
-net::Poll*                poll()                                              { return system::ThreadInternal::poll(); }
-net::Resolver*            resolver()                                          { return system::ThreadInternal::resolver(); }
-utils::Scheduler*         scheduler()                                         { return system::ThreadInternal::scheduler(); }
+net::Poll*
+poll() { return system::ThreadInternal::poll(); }
+net::Resolver*
+resolver() { return system::ThreadInternal::resolver(); }
+utils::Scheduler*
+scheduler() { return system::ThreadInternal::scheduler(); }
 
 } // namespace torrent::this_thread

--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -3,8 +3,8 @@
 #include "torrent/system/thread.h"
 
 #include <cassert>
-#include <condition_variable>
 #include <cstring>
+#include <condition_variable>
 #include <mutex>
 #include <unistd.h>
 
@@ -25,17 +25,12 @@ thread_local Thread* Thread::m_self{};
 
 Thread::~Thread() = default;
 
-Thread*
-Thread::self() { return m_self; }
+Thread* Thread::self() { return m_self; }
 
-void
-Thread::init_thread() {}
-void
-Thread::init_thread_pre_start() {}
-void
-Thread::init_thread_post_local() {}
-void
-Thread::cleanup_thread() {}
+void Thread::init_thread() {}
+void Thread::init_thread_pre_start() {}
+void Thread::init_thread_post_local() {}
+void Thread::cleanup_thread() {}
 
 Thread::Thread() :
     m_instrumentation_index(INSTRUMENTATION_POLLING_DO_POLL_OTHERS - INSTRUMENTATION_POLLING_DO_POLL),
@@ -76,7 +71,7 @@ Thread::stop_thread_wait() {
 }
 
 void
-Thread::callback(void* target, std::function<void()>&& fn) {
+Thread::callback(void* target, std::function<void ()>&& fn) {
   {
     auto lock = std::lock_guard(m_callbacks_lock);
 
@@ -87,7 +82,7 @@ Thread::callback(void* target, std::function<void()>&& fn) {
 }
 
 void
-Thread::callback_interrupt_polling(void* target, std::function<void()>&& fn) {
+Thread::callback_interrupt_polling(void* target, std::function<void ()>&& fn) {
   {
     auto lock = std::lock_guard(m_callbacks_lock);
 
@@ -99,22 +94,22 @@ Thread::callback_interrupt_polling(void* target, std::function<void()>&& fn) {
 }
 
 void
-Thread::callback_interrupt_polling_and_wait(void* target, std::function<void()>&& fn) {
+Thread::callback_interrupt_polling_and_wait(void* target, std::function<void ()>&& fn) {
   std::mutex              callback_mutex;
   std::condition_variable callback_cv;
 
-  bool                    done{};
+  bool done{};
 
-  auto                    wrapped_fn = [&callback_mutex, &callback_cv, &done, fn = std::move(fn)]() {
-    fn();
+  auto wrapped_fn = [&callback_mutex, &callback_cv, &done, fn = std::move(fn)]() {
+      fn();
 
-    {
-      auto lock = std::lock_guard(callback_mutex);
-      done      = true;
-    }
+      {
+        auto lock = std::lock_guard(callback_mutex);
+        done = true;
+      }
 
-    callback_cv.notify_one();
-  };
+      callback_cv.notify_one();
+    };
 
   callback_interrupt_polling(target, std::move(wrapped_fn));
 
@@ -252,11 +247,12 @@ Thread::event_loop() {
 
   try {
 
-    runtime::socket_manager()->register_event_or_throw(m_interrupt_receiver.get(), [this]() {
+    runtime::socket_manager()->register_event_or_throw(m_interrupt_receiver.get(), runtime::SocketManager::category_internal, [this]() {
         m_poll->open(m_interrupt_receiver.get());
         m_poll->insert_read(m_interrupt_receiver.get());
-        m_poll->insert_error(m_interrupt_receiver.get()); }, runtime::SocketManager::category_internal);
-    runtime::socket_manager()->register_event_or_throw(m_interrupt_sender.get(), []() {}, runtime::SocketManager::category_internal);
+        m_poll->insert_error(m_interrupt_receiver.get());
+    });
+    runtime::socket_manager()->register_event_or_throw(m_interrupt_sender.get(), runtime::SocketManager::category_internal, []() {});
 
     while (true) {
       process_events();
@@ -295,10 +291,10 @@ Thread::event_loop() {
   }
 
   runtime::socket_manager()->unregister_event_or_throw(m_interrupt_receiver.get(), [this]() {
-    m_poll->remove_read(m_interrupt_receiver.get());
-    m_poll->remove_error(m_interrupt_receiver.get());
-    m_poll->close(m_interrupt_receiver.get());
-  });
+      m_poll->remove_read(m_interrupt_receiver.get());
+      m_poll->remove_error(m_interrupt_receiver.get());
+      m_poll->close(m_interrupt_receiver.get());
+    });
   runtime::socket_manager()->unregister_event_or_throw(m_interrupt_sender.get(), []() {});
 
   auto previous_state = STATE_ACTIVE;
@@ -316,8 +312,8 @@ Thread::init_thread_local() {
   pthread_setname_np(pthread_self(), name());
 #endif
 
-  m_self      = this;
-  m_thread    = pthread_self();
+  m_self = this;
+  m_thread = pthread_self();
   m_thread_id = std::this_thread::get_id();
 
   m_scheduler->set_thread_id(m_thread_id);
@@ -373,7 +369,7 @@ Thread::process_callbacks(bool only_interrupt) {
   m_callbacks_should_interrupt_polling = false;
 
   while (true) {
-    std::function<void()> callback;
+    std::function<void ()> callback;
 
     {
       auto lock = std::lock_guard(m_callbacks_lock);
@@ -448,32 +444,22 @@ Thread::set_cached_time(std::chrono::microseconds t) {
   m_scheduler->set_cached_time(t);
 }
 
-} // namespace torrent::system
+} // namespace torrent::utils
 
 namespace torrent::this_thread {
 
-torrent::system::Thread*
-thread() { return system::ThreadInternal::thread(); }
-std::thread::id
-thread_id() { return system::ThreadInternal::thread_id(); }
+torrent::system::Thread*  thread()                                            { return system::ThreadInternal::thread(); }
+std::thread::id           thread_id()                                         { return system::ThreadInternal::thread_id(); }
 
-std::chrono::microseconds
-cached_time() { return system::ThreadInternal::cached_time(); }
-std::chrono::seconds
-cached_seconds() { return system::ThreadInternal::cached_seconds(); }
+std::chrono::microseconds cached_time()                                       { return system::ThreadInternal::cached_time(); }
+std::chrono::seconds      cached_seconds()                                    { return system::ThreadInternal::cached_seconds(); }
 
-void
-callback(void* target, std::function<void()>&& fn) { system::ThreadInternal::callback(target, std::move(fn)); }
-void
-cancel_callback(void* target) { system::ThreadInternal::cancel_callback(target); }
-void
-cancel_callback_and_wait(void* target) { system::ThreadInternal::cancel_callback_and_wait(target); }
+void                      callback(void* target, std::function<void ()>&& fn) { system::ThreadInternal::callback(target, std::move(fn)); }
+void                      cancel_callback(void* target)                       { system::ThreadInternal::cancel_callback(target); }
+void                      cancel_callback_and_wait(void* target)              { system::ThreadInternal::cancel_callback_and_wait(target); }
 
-net::Poll*
-poll() { return system::ThreadInternal::poll(); }
-net::Resolver*
-resolver() { return system::ThreadInternal::resolver(); }
-utils::Scheduler*
-scheduler() { return system::ThreadInternal::scheduler(); }
+net::Poll*                poll()                                              { return system::ThreadInternal::poll(); }
+net::Resolver*            resolver()                                          { return system::ThreadInternal::resolver(); }
+utils::Scheduler*         scheduler()                                         { return system::ThreadInternal::scheduler(); }
 
 } // namespace torrent::this_thread

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -8,6 +8,7 @@
 
 #include "manager.h"
 #include "runtime.h"
+#include "torrent/runtime/socket_manager.h"
 #include "thread_main.h"
 #include "data/file_manager.h"
 #include "data/hash_queue.h"
@@ -94,6 +95,16 @@ calculate_reserved(uint32_t open_max) {
     return 16;
 }
 
+uint32_t
+calculate_internal(uint32_t open_max) {
+  if (open_max >= 16384)
+    return 32;
+  else if (open_max >= 1024)
+    return 16;
+  else
+    return 8;
+}
+
 std::string
 generate_random(size_t length) {
   std::random_device rd;
@@ -136,9 +147,12 @@ initialize() {
   auto max_open             = this_thread::poll()->open_max();
   auto max_files            = calculate_max_open_files(max_open);
   auto max_http_connections = calculate_max_http_total_connections(max_open);
+  auto max_internal         = calculate_internal(max_open);
   auto reserved             = calculate_reserved(max_open);
 
-  runtime::socket_manager()->set_max_size(max_open - max_files - max_http_connections - reserved);
+  runtime::socket_manager()->set_max_size(max_open - max_files - reserved);
+  runtime::socket_manager()->set_category_max_size(runtime::SocketManager::category_http, max_http_connections);
+  runtime::socket_manager()->set_category_max_size(runtime::SocketManager::category_internal, max_internal);
 
   manager->file_manager()->set_max_open_files(max_files);
 

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -37,22 +37,6 @@ namespace torrent {
 
 namespace {
 
-uint32_t
-calculate_max_open_files(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 512;
-  else if (open_max >= 8096)
-    return 256;
-  else if (open_max >= 1024)
-    return 128;
-  else if (open_max >= 512)
-    return 64;
-  else if (open_max >= 128)
-    return 16;
-  else // Assumes we don't try less than 64.
-    return 4;
-}
-
 std::string
 generate_random(size_t length) {
   std::random_device rd;
@@ -95,7 +79,7 @@ initialize() {
   auto max_open = this_thread::poll()->open_max();
 
   runtime::socket_manager()->set_max_size_and_adjust(max_open);
-  manager->file_manager()->set_max_open_files(calculate_max_open_files(max_open));
+  manager->file_manager()->set_max_open_files(runtime::socket_manager()->category_max_size(runtime::SocketManager::category_files));
 
   ThreadNet::thread_net()->set_max_connections();
 

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -53,17 +53,6 @@ calculate_max_open_files(uint32_t open_max) {
     return 4;
 }
 
-// Derives max host connections from the HTTP total connections category limit.
-uint32_t
-calculate_max_http_host_connections(uint32_t http_total) {
-  if (http_total >= 128)
-    return 3;
-  else if (http_total >= 64)
-    return 2;
-  else // Assumes we don't try less than 64.
-    return 1;
-}
-
 std::string
 generate_random(size_t length) {
   std::random_device rd;
@@ -106,12 +95,9 @@ initialize() {
   auto max_open = this_thread::poll()->open_max();
 
   runtime::socket_manager()->set_max_size_and_adjust(max_open);
-
-  auto http_total = runtime::socket_manager()->category_max_size(runtime::SocketManager::category_http);
-
   manager->file_manager()->set_max_open_files(calculate_max_open_files(max_open));
-  net_thread::http_stack()->set_max_host_connections(calculate_max_http_host_connections(http_total));
-  net_thread::http_stack()->set_max_total_connections(http_total);
+
+  ThreadNet::thread_net()->set_max_connections();
 
   disk_thread::thread()->init_thread();
   net_thread::thread()->init_thread();

--- a/src/torrent/torrent.cc
+++ b/src/torrent/torrent.cc
@@ -53,56 +53,15 @@ calculate_max_open_files(uint32_t open_max) {
     return 4;
 }
 
+// Derives max host connections from the HTTP total connections category limit.
 uint32_t
-calculate_max_http_host_connections(uint32_t open_max) {
-  if (open_max >= 16384)
+calculate_max_http_host_connections(uint32_t http_total) {
+  if (http_total >= 128)
     return 3;
-  else if (open_max >= 8096)
+  else if (http_total >= 64)
     return 2;
   else // Assumes we don't try less than 64.
     return 1;
-}
-
-uint32_t
-calculate_max_http_total_connections(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 128;
-  else if (open_max >= 8096)
-    return 64;
-  else if (open_max >= 1024)
-    return 32;
-  else if (open_max >= 512)
-    return 16;
-  else if (open_max >= 128)
-    return 8;
-  else // Assumes we don't try less than 64.
-    return 4;
-}
-
-uint32_t
-calculate_reserved(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 512;
-  else if (open_max >= 8096)
-    return 256;
-  else if (open_max >= 1024)
-    return 128;
-  else if (open_max >= 512)
-    return 64;
-  else if (open_max >= 128)
-    return 32;
-  else // Assumes we don't try less than 64.
-    return 16;
-}
-
-uint32_t
-calculate_internal(uint32_t open_max) {
-  if (open_max >= 16384)
-    return 32;
-  else if (open_max >= 1024)
-    return 16;
-  else
-    return 8;
 }
 
 std::string
@@ -144,20 +103,15 @@ initialize() {
   ThreadNet::create_thread();
   ThreadTracker::create_thread();
 
-  auto max_open             = this_thread::poll()->open_max();
-  auto max_files            = calculate_max_open_files(max_open);
-  auto max_http_connections = calculate_max_http_total_connections(max_open);
-  auto max_internal         = calculate_internal(max_open);
-  auto reserved             = calculate_reserved(max_open);
+  auto max_open = this_thread::poll()->open_max();
 
-  runtime::socket_manager()->set_max_size(max_open - max_files - reserved);
-  runtime::socket_manager()->set_category_max_size(runtime::SocketManager::category_http, max_http_connections);
-  runtime::socket_manager()->set_category_max_size(runtime::SocketManager::category_internal, max_internal);
+  runtime::socket_manager()->set_max_size_and_adjust(max_open);
 
-  manager->file_manager()->set_max_open_files(max_files);
+  auto http_total = runtime::socket_manager()->category_max_size(runtime::SocketManager::category_http);
 
-  net_thread::http_stack()->set_max_host_connections(calculate_max_http_host_connections(max_open));
-  net_thread::http_stack()->set_max_total_connections(max_http_connections);
+  manager->file_manager()->set_max_open_files(calculate_max_open_files(max_open));
+  net_thread::http_stack()->set_max_host_connections(calculate_max_http_host_connections(http_total));
+  net_thread::http_stack()->set_max_total_connections(http_total);
 
   disk_thread::thread()->init_thread();
   net_thread::thread()->init_thread();

--- a/src/tracker/udp_router.cc
+++ b/src/tracker/udp_router.cc
@@ -15,9 +15,9 @@
 #include "torrent/system/system.h"
 #include "torrent/utils/log.h"
 
-#define LT_LOG(log_fmt, ...)                                            \
+#define LT_LOG(log_fmt, ...) \
   lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", log_fmt, __VA_ARGS__);
-  // lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", "%p : " log_fmt, static_cast<TrackerWorker*>(this), __VA_ARGS__);
+// lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", "%p : " log_fmt, static_cast<TrackerWorker*>(this), __VA_ARGS__);
 
 // TODO: Add m_connections::iterator to info so we don't need to look them up. We should be able to
 // replace unordered_map with map then to reduce memory usage after initial startup tracker rush.
@@ -66,7 +66,9 @@ UdpRouter::open(int family) {
 
   if (!fd_bind(fd, bind_address.get())) {
     LT_LOG("opening router failed : bind failed : family:%s bind_address:%s errno:%s",
-           family_str(family), sa_pretty_str(bind_address.get()).c_str(), system::errno_enum_str(errno).c_str());
+           family_str(family),
+           sa_pretty_str(bind_address.get()).c_str(),
+           system::errno_enum_str(errno).c_str());
     fd_close(fd);
     return;
   }
@@ -76,8 +78,7 @@ UdpRouter::open(int family) {
   runtime::socket_manager()->register_event_or_throw(this, [this]() {
       this_thread::poll()->open(this);
       this_thread::poll()->insert_read(this);
-      this_thread::poll()->insert_error(this);
-    });
+      this_thread::poll()->insert_error(this); }, runtime::SocketManager::category_tracker);
 
   set_socket_address(sa_copy(bind_address.get()));
 
@@ -94,11 +95,11 @@ UdpRouter::close() {
   this_thread::scheduler()->erase(&m_task_timeout);
 
   runtime::socket_manager()->unregister_event_or_throw(this, [this]() {
-      this_thread::poll()->remove_and_close(this);
+    this_thread::poll()->remove_and_close(this);
 
-      fd_close(file_descriptor());
-      set_file_descriptor(-1);
-    });
+    fd_close(file_descriptor());
+    set_file_descriptor(-1);
+  });
 
   // TODO: Do we just let timeout expire connections, or do we send errors?
   // this_thread::resolver()->cancel_all_for_requester(this);
@@ -133,7 +134,6 @@ UdpRouter::updated_network_config(int family) {
   close();
   open(family);
 }
-
 
 uint32_t
 UdpRouter::connect(c_sa_shared_ptr address, connection_params params) {
@@ -179,8 +179,8 @@ UdpRouter::connect(const std::string hostname, uint16_t port, connection_params 
   // TODO: Set params.connected for hostname lookups?
 
   auto fn = [this, id = itr->first, port](c_sin_shared_ptr sin, int err, c_sin6_shared_ptr sin6, int err6) {
-      resolved_hostname(id, port, sin, err, sin6, err6);
-    };
+    resolved_hostname(id, port, sin, err, sin6, err6);
+  };
 
   this_thread::resolver()->resolve_both(this, hostname, router_family(), std::move(fn));
 
@@ -273,7 +273,7 @@ UdpRouter::disconnect_unsafe(connection_map::iterator itr) {
 
   if (itr->second.queue_ptr != nullptr) {
     *itr->second.queue_ptr = nullptr;
-    itr->second.queue_ptr = nullptr;
+    itr->second.queue_ptr  = nullptr;
   }
 
   clear_timeout(&itr->second);
@@ -341,7 +341,6 @@ UdpRouter::resolved_hostname(uint32_t id, uint16_t port, c_sin_shared_ptr& sin, 
     queue_write(id, &itr->second);
 }
 
-
 bool
 UdpRouter::try_write(uint32_t id, connection_info* info) {
   if (info->retry_count >= 3)
@@ -407,7 +406,7 @@ UdpRouter::clear_timeout(connection_info* info) {
     return;
 
   *info->timeout_ptr = nullptr;
-  info->timeout_ptr = nullptr;
+  info->timeout_ptr  = nullptr;
 }
 
 void

--- a/src/tracker/udp_router.cc
+++ b/src/tracker/udp_router.cc
@@ -15,9 +15,9 @@
 #include "torrent/system/system.h"
 #include "torrent/utils/log.h"
 
-#define LT_LOG(log_fmt, ...) \
+#define LT_LOG(log_fmt, ...)                                            \
   lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", log_fmt, __VA_ARGS__);
-// lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", "%p : " log_fmt, static_cast<TrackerWorker*>(this), __VA_ARGS__);
+  // lt_log_print_subsystem(LOG_TRACKER_REQUESTS, "udp_router", "%p : " log_fmt, static_cast<TrackerWorker*>(this), __VA_ARGS__);
 
 // TODO: Add m_connections::iterator to info so we don't need to look them up. We should be able to
 // replace unordered_map with map then to reduce memory usage after initial startup tracker rush.
@@ -66,19 +66,18 @@ UdpRouter::open(int family) {
 
   if (!fd_bind(fd, bind_address.get())) {
     LT_LOG("opening router failed : bind failed : family:%s bind_address:%s errno:%s",
-           family_str(family),
-           sa_pretty_str(bind_address.get()).c_str(),
-           system::errno_enum_str(errno).c_str());
+           family_str(family), sa_pretty_str(bind_address.get()).c_str(), system::errno_enum_str(errno).c_str());
     fd_close(fd);
     return;
   }
 
   set_file_descriptor(fd);
 
-  runtime::socket_manager()->register_event_or_throw(this, [this]() {
+  runtime::socket_manager()->register_event_or_throw(this, runtime::SocketManager::category_internal, [this]() {
       this_thread::poll()->open(this);
       this_thread::poll()->insert_read(this);
-      this_thread::poll()->insert_error(this); }, runtime::SocketManager::category_tracker);
+      this_thread::poll()->insert_error(this);
+    });
 
   set_socket_address(sa_copy(bind_address.get()));
 
@@ -95,11 +94,11 @@ UdpRouter::close() {
   this_thread::scheduler()->erase(&m_task_timeout);
 
   runtime::socket_manager()->unregister_event_or_throw(this, [this]() {
-    this_thread::poll()->remove_and_close(this);
+      this_thread::poll()->remove_and_close(this);
 
-    fd_close(file_descriptor());
-    set_file_descriptor(-1);
-  });
+      fd_close(file_descriptor());
+      set_file_descriptor(-1);
+    });
 
   // TODO: Do we just let timeout expire connections, or do we send errors?
   // this_thread::resolver()->cancel_all_for_requester(this);
@@ -134,6 +133,7 @@ UdpRouter::updated_network_config(int family) {
   close();
   open(family);
 }
+
 
 uint32_t
 UdpRouter::connect(c_sa_shared_ptr address, connection_params params) {
@@ -179,8 +179,8 @@ UdpRouter::connect(const std::string hostname, uint16_t port, connection_params 
   // TODO: Set params.connected for hostname lookups?
 
   auto fn = [this, id = itr->first, port](c_sin_shared_ptr sin, int err, c_sin6_shared_ptr sin6, int err6) {
-    resolved_hostname(id, port, sin, err, sin6, err6);
-  };
+      resolved_hostname(id, port, sin, err, sin6, err6);
+    };
 
   this_thread::resolver()->resolve_both(this, hostname, router_family(), std::move(fn));
 
@@ -273,7 +273,7 @@ UdpRouter::disconnect_unsafe(connection_map::iterator itr) {
 
   if (itr->second.queue_ptr != nullptr) {
     *itr->second.queue_ptr = nullptr;
-    itr->second.queue_ptr  = nullptr;
+    itr->second.queue_ptr = nullptr;
   }
 
   clear_timeout(&itr->second);
@@ -341,6 +341,7 @@ UdpRouter::resolved_hostname(uint32_t id, uint16_t port, c_sin_shared_ptr& sin, 
     queue_write(id, &itr->second);
 }
 
+
 bool
 UdpRouter::try_write(uint32_t id, connection_info* info) {
   if (info->retry_count >= 3)
@@ -406,7 +407,7 @@ UdpRouter::clear_timeout(connection_info* info) {
     return;
 
   *info->timeout_ptr = nullptr;
-  info->timeout_ptr  = nullptr;
+  info->timeout_ptr = nullptr;
 }
 
 void


### PR DESCRIPTION
Adds per-category tracking within SocketManager so that different socket types can be independently capped via `set_category_max_size()`.

**Categories defined (4):**
- `category_generic` (0) — peer connections, BT accept, uncategorized
- `category_http` (1) — HTTP/curl
- `category_internal` (2) — DHT server, UDP tracker router, thread interrupt pairs, BT listen
- `category_scgi` (3) — SCGI/RPC

**How it works:**
- Each `SocketInfo` stores its category
- Per-category managed counts are tracked alongside the global `m_managed_size`
- When a category's max is set to non-zero, `open_event_or_cleanup()` and `can_open_socket()` additionally check that the category hasn't reached its limit
- `close_event_or_throw()` / `unregister_event_or_throw()` read the stored category from `SocketInfo` to decrement the correct counter

**`set_max_size_and_adjust(max_open)`** is the single entry point for fd allocation:
- Moves all `calculate_*` logic into `socket_manager.cc`
- Computes `m_max_size`, `category_http`, `category_internal` from `max_open`
- Calls `notify_changes()` to notify subscribers

**Subscriber mechanism:**
- `subscribe_to_changes()` / `unsubscribe_from_changes()` follow the same pattern as `NetworkConfig`
- `ThreadNet::init_thread_post_local()` subscribes to update `http_stack` at runtime

**Callers updated to pass explicit categories:**
- `curl_socket.cc` → `category_http`
- `dht_server.cc` → `category_internal`
- `udp_router.cc` → `category_internal`
- `thread.cc` → `category_internal`
- `listen.cc` → `category_internal` (BT listen), `category_generic` (accept)
- `handshake_manager.cc` → `category_generic`
- `download_main.cc` → `category_generic`

This is the libtorrent side of the fix for rakshasa/rtorrent#1777.