### PR TITLE
feat: expose hash error message via Download::hash_error_message()

### DIFF
--- a/src/data/hash_torrent.cc
+++ b/src/data/hash_torrent.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <cstring>
+
 #include "data/chunk_list.h"
 #include "torrent/exceptions.h"
 #include "torrent/data/download_data.h"
@@ -27,6 +29,7 @@ HashTorrent::start(bool try_quick) {
   if (m_position > 0 || m_chunk_list->empty())
     throw internal_error("HashTorrent::start() call failed.");
 
+  m_error_message.clear();
   m_outstanding = 0;
 
   queue(try_quick);
@@ -164,9 +167,12 @@ HashTorrent::queue(bool quick) {
 
       // The rest of the outstanding chunks get ignored by
       // DownloadWrapper::receive_hash_done. Obsolete.
+      auto error_pos = m_position;
+
       clear();
 
       m_errno = handle.error_number();
+      m_error_message = "Hash check I/O error at chunk " + std::to_string(error_pos) + ": " + std::strerror(handle.error_number());
 
       LT_LOG_THIS(INFO, "completed with error: position:%u errno:%s", m_position, system::errno_enum(handle.error_number()));
 

--- a/src/data/hash_torrent.h
+++ b/src/data/hash_torrent.h
@@ -35,6 +35,7 @@ public:
   uint32_t            outstanding() const                    { return m_outstanding; }
 
   int                 error_number() const                   { return m_errno; }
+  const std::string&  error_message() const                  { return m_error_message; }
 
   slot_chunk_handle&  slot_check_chunk() { return m_slot_check_chunk; }
 
@@ -51,6 +52,7 @@ private:
   Ranges              m_ranges;
 
   int                 m_errno{0};
+  std::string         m_error_message;
 
   ChunkList*          m_chunk_list;
 

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -198,6 +198,11 @@ Download::is_hash_checking() const {
   return m_ptr->hash_checker()->is_checking();
 }
 
+int
+Download::hash_error_number() const {
+  return m_ptr->hash_checker()->error_number();
+}
+
 void
 Download::set_pex_enabled(bool enabled) {
   if (enabled)

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -198,9 +198,9 @@ Download::is_hash_checking() const {
   return m_ptr->hash_checker()->is_checking();
 }
 
-int
-Download::hash_error_number() const {
-  return m_ptr->hash_checker()->error_number();
+const std::string&
+Download::hash_error_message() const {
+  return m_ptr->hash_checker()->error_message();
 }
 
 void

--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -60,7 +60,7 @@ public:
 
   bool                is_hash_checked() const;
   bool                is_hash_checking() const;
-  int                 hash_error_number() const;
+  const std::string&  hash_error_message() const;
 
   void                set_pex_enabled(bool enabled);
 

--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -60,6 +60,7 @@ public:
 
   bool                is_hash_checked() const;
   bool                is_hash_checking() const;
+  int                 hash_error_number() const;
 
   void                set_pex_enabled(bool enabled);
 


### PR DESCRIPTION
## Summary

- Add `HashTorrent::error_message()` accessor and `Download::hash_error_message()` public API to expose a descriptive error message string when hash check fails due to I/O errors.

## Motivation

When a hash check fails due to an I/O error (e.g. "too many open files"), `d.hashing_failed` is set but there is no way to retrieve the underlying error description. The errno-only approach (`hash_error_number()`) is unreliable as it can be zero. Storing and exposing the full error message string enables clients (like rtorrent) to populate `d.message` with actionable debugging information.

## Changes

- `src/data/hash_torrent.h`: add `std::string m_error_message` field and `error_message()` accessor
- `src/data/hash_torrent.cc`: store error message in `queue()` on I/O error, clear in `clear()`
- `src/torrent/download.h`: declare `const std::string& hash_error_message() const`
- `src/torrent/download.cc`: implement by delegating to `HashTorrent::error_message()`