### PR TITLE
fix: skip fallocate for priority=0 files in resize_file()

### DIFF
--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -145,7 +145,7 @@ File::resize_file() const {
   if (!SocketFile(m_fd).set_size(m_size))
     return false;
 
-  if (m_flags & flag_fallocate) {
+  if ((m_flags & flag_fallocate) && m_priority != PRIORITY_OFF) {
     // Only do non-blocking fallocate.
     if (!SocketFile(m_fd).allocate(m_size, SocketFile::flag_fallocate))
       return false;


### PR DESCRIPTION
## Summary

Prevents `fallocate()` on files with `PRIORITY_OFF` (priority=0), even when `flag_fallocate` is set on the file.

## Problem

When `system.file.allocate=1`, `Download::open()` sets `flag_fallocate` on all files indiscriminately. If the user has deselected some files (set priority=0), they still get fully preallocated when a boundary chunk triggers `File::prepare()` → `File::resize_file()`.

## Fix

Add a `m_priority != PRIORITY_OFF` check in `File::resize_file()` so that priority=0 files are only truncated (sparse) via `ftruncate`, never preallocated via `fallocate`.

## Related

- rtorrent PR: [fix: define default_resume_flags sentinel, clearing open_enable_fallocate](https://github.com/rakshasa/rtorrent/pull/1810)