### PR TITLE
Fix libcurlpp package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ BUILD DEPENDENCIES
 --------
 Ubuntu, for example
 ```
-sudo apt install make curl-libcurlpp-dev autoconf
+sudo apt install make libcurlpp-dev autoconf
 ```
 
 BUILDING


### PR DESCRIPTION
There is no package named curl-libcurlpp-dev on recent versions of Ubuntu:

```
# sudo apt install make curl-libcurlpp-dev autoconf
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package curl-libcurlpp-dev
```

```
# sudo apt install libcurlpp-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  libcurl4-openssl-dev libcurlpp0t64
Suggested packages:
  libcurl4-doc libidn-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev libcurlpp-dev libcurlpp0t64
0 upgraded, 3 newly installed, 0 to remove and 6 not upgraded.
```