### PR TITLE
fix: retry hash check on ENOMEM instead of failing

### DIFF
--- a/src/data/hash_torrent.cc
+++ b/src/data/hash_torrent.cc
@@ -17,6 +17,7 @@ namespace torrent {
 
 HashTorrent::HashTorrent(ChunkList* c) :
     m_chunk_list(c) {
+  m_delay_retry.slot() = [this] { queue(false); };
 }
 
 bool
@@ -45,6 +46,7 @@ HashTorrent::clear() {
   m_errno = 0;
 
   this_thread::scheduler()->erase(&m_delay_checked);
+  this_thread::scheduler()->erase(&m_delay_retry);
 }
 
 bool
@@ -155,6 +157,15 @@ HashTorrent::queue(bool quick) {
     // If the error number is not valid, then we've just encountered a
     // file that hasn't be created/resized. Which means we ignore it
     // when doing initial hashing.
+    if (handle.error_number() == ENOMEM) {
+      LT_LOG_THIS(INFO, "ENOMEM during hash, retrying: position:%u outstanding:%i", m_position, m_outstanding);
+
+      if (m_outstanding == 0)
+        this_thread::scheduler()->update_wait_for(&m_delay_retry, std::chrono::milliseconds(100));
+
+      return;
+    }
+
     if (handle.error_number() != 0 && handle.error_number() != ENOENT) {
       if (handle.is_valid())
         throw internal_error("HashTorrent::queue() valid handle with error number: " + system::errno_enum_str(handle.error_number()));

--- a/src/data/hash_torrent.h
+++ b/src/data/hash_torrent.h
@@ -40,6 +40,7 @@ public:
   slot_chunk_handle&  slot_check_chunk() { return m_slot_check_chunk; }
 
   auto&               delay_checked()                        { return m_delay_checked; }
+  auto&               delay_retry()                          { return m_delay_retry; }
 
   void                receive_chunkdone(uint32_t index);
   void                receive_chunk_cleared(uint32_t index);
@@ -58,6 +59,7 @@ private:
 
   slot_chunk_handle     m_slot_check_chunk;
   utils::SchedulerEntry m_delay_checked;
+  utils::SchedulerEntry m_delay_retry;
 };
 
 } // namespace torrent


### PR DESCRIPTION
## Summary

- When `ChunkManager::allocate()` fails due to memory limit, `HashTorrent::queue()` now treats ENOMEM as a transient condition and schedules a 100ms retry instead of aborting the hash check entirely.
- If there are outstanding chunks (`m_outstanding > 0`), it simply returns and lets `receive_chunkdone()` naturally retry via `queue()`.
- If no outstanding chunks, a `m_delay_retry` SchedulerEntry triggers `queue(false)` after 100ms.

#750

## Impact

Hash checks will no longer fail with "Cannot allocate memory" under temporary memory pressure. Users on memory-constrained environments (containers, VPS) no longer need to over-allocate `pieces.memory.max`.