### PR TITLE
fix: prevent null pointer dereference when ResourceManager entries vector is empty

### DIFF
--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -60,6 +60,9 @@ ResourceManager::insert(const resource_manager_entry& entry) {
 
 void
 ResourceManager::update_group_iterators() {
+  if (base_type::empty())
+    return;
+
   auto       entry_itr = base_type::begin();
   auto group_itr = choke_base_type::begin();
 
@@ -75,6 +78,9 @@ ResourceManager::update_group_iterators() {
 
 void
 ResourceManager::validate_group_iterators() {
+  if (base_type::empty())
+    return;
+
   auto       entry_itr = base_type::begin();
   auto group_itr = choke_base_type::begin();
 
@@ -120,8 +126,11 @@ ResourceManager::push_group(const std::string& name) {
   choke_base_type::push_back(new choke_group());
 
   choke_base_type::back()->set_name(name);
-  choke_base_type::back()->set_first(&*base_type::end());
-  choke_base_type::back()->set_last(&*base_type::end());
+
+  if (!base_type::empty()) {
+    choke_base_type::back()->set_first(&*base_type::end());
+    choke_base_type::back()->set_last(&*base_type::end());
+  }
 
   choke_base_type::back()->up_queue()->set_heuristics(choke_queue::HEURISTICS_UPLOAD_LEECH);
   choke_base_type::back()->down_queue()->set_heuristics(choke_queue::HEURISTICS_DOWNLOAD_LEECH);


### PR DESCRIPTION
push_group, update_group_iterators and validate_group_iterators derferenced `&*base_type::end()` which is undefined behavior when the entries vector is empty. In debug builds with libc++ debug iterators this triggers a 'reference binding to null pointer' panic.

The fix adds early guards: skip `set_first`/`set_last` for empty `base_type` in `push_group`, and early-return from `update_group_iterators`/`validate_group_iterators` when entries are empty. The `choke_group` constructor already default-initializes `m_first`/`m_last` to nullptr, which correctly represents an empty group (`m_first == m_last`).