### PR TITLE
fix: populate empty HeuristicType enum in Download class

### DIFF
--- a/src/torrent/download.h
+++ b/src/torrent/download.h
@@ -149,6 +149,10 @@ public:
   void                set_connection_type(ConnectionType t);
 
   enum HeuristicType {
+    HEURISTICS_UPLOAD_LEECH              = 0,
+    HEURISTICS_UPLOAD_SEED               = 1,
+    HEURISTICS_UPLOAD_LEECH_EXPERIMENTAL = 2,
+    HEURISTICS_DOWNLOAD_LEECH            = 3,
   };
 
   HeuristicType       upload_choke_heuristic() const;


### PR DESCRIPTION
The `torrent::Download::HeuristicType` enum was declared as `enum HeuristicType {};` with no enumerators. When `option_find_string` returns choke heuristic values (e.g. HEURISTICS_DOWNLOAD_LEECH = 3), the C-style cast to this empty enum type triggers UBSan: 'load of value 3, which is not valid for type HeuristicType'.

Fixed by populating the enum with the four valid choke heuristic values matching `choke_queue::heuristics_enum`.