### PR TITLE
fix: scheduler O(N) make_heap to O(log N) via SchedulerHandle lazy deletion

### DIFF
--- a/src/torrent/system/thread.cc
+++ b/src/torrent/system/thread.cc
@@ -278,9 +278,7 @@ Thread::event_loop() {
       instrumentation_update(instrumentation_enum(INSTRUMENTATION_POLLING_DO_POLL + m_instrumentation_index), 1);
 
       auto timeout = std::max(next_timeout(), std::chrono::microseconds(0));
-
-      if (!m_scheduler->empty())
-        timeout = std::min(timeout, m_scheduler->next_timeout());
+      timeout = m_scheduler->next_timeout(timeout);
 
       int event_count = m_poll->do_poll(timeout);
 

--- a/src/torrent/utils/scheduler.cc
+++ b/src/torrent/utils/scheduler.cc
@@ -10,35 +10,33 @@
 
 namespace torrent::utils {
 
+static constexpr auto compare = [](const std::unique_ptr<SchedulerHandle>& a,
+                                   const std::unique_ptr<SchedulerHandle>& b) {
+  return a->time > b->time;
+};
+
 SchedulerEntry::~SchedulerEntry() {
   assert(!is_scheduled() && "SchedulerEntry::~SchedulerEntry() called on a scheduled item.");
-  assert(m_time == time_type{} && "SchedulerEntry::~SchedulerEntry() called on an item with a time.");
 
   m_slot = nullptr;
-  m_scheduler = nullptr;
-  m_time = time_type{};
-}
-
-
-inline void
-Scheduler::make_heap() {
-  std::make_heap(begin(), end(), [](const SchedulerEntry* a, const SchedulerEntry* b) {
-      return a->time() > b->time();
-    });
-}
-
-inline void
-Scheduler::push_heap() {
-  std::push_heap(begin(), end(), [](const SchedulerEntry* a, const SchedulerEntry* b) {
-      return a->time() > b->time();
-    });
 }
 
 Scheduler::time_type
-Scheduler::next_timeout() const {
-  assert(!empty());
+Scheduler::next_timeout(Scheduler::time_type max_timeout) {
+  while (!m_heap.empty() && m_heap.front()->entry == nullptr) {
+    std::ranges::pop_heap(m_heap, compare);
+    m_heap.pop_back();
+  }
 
-  return std::max(front()->time() - m_cached_time, Scheduler::time_type());
+  if (m_heap.empty())
+    return max_timeout;
+
+  auto timeout = m_heap.front()->time - m_cached_time;
+
+  if (timeout >= max_timeout)
+    return max_timeout;
+
+  return std::max(timeout, Scheduler::time_type());
 }
 
 // We can't make erase/update part of SchedulerItem in case another thread tries to call the
@@ -55,21 +53,20 @@ Scheduler::erase(SchedulerEntry* entry) {
   if (!entry->is_valid())
     throw torrent::internal_error("Scheduler::erase(...) called on an invalid entry.");
 
-  if (entry->scheduler() != this)
+  if (entry->m_handle->scheduler != this)
     throw torrent::internal_error("Scheduler::erase(...) called on an entry that is in another scheduler.");
 
-  auto itr = std::find_if(begin(), end(), [entry](const SchedulerEntry* e) {
-      return e == entry;
-    });
+  entry->m_handle->entry = nullptr;
+  entry->set_handle(nullptr);
+}
 
-  if (itr == end())
-    throw torrent::internal_error("Scheduler::erase(...) could not find item in queue.");
+void
+Scheduler::push_entry(SchedulerEntry* entry, time_type time) {
+  auto handle = std::make_unique<SchedulerHandle>(SchedulerHandle{entry, this, time});
+  entry->set_handle(handle.get());
 
-  entry->set_scheduler(nullptr);
-  entry->set_time(Scheduler::time_type{});
-
-  base_type::erase(itr);
-  make_heap();
+  m_heap.push_back(std::move(handle));
+  std::ranges::push_heap(m_heap, compare);
 }
 
 void
@@ -88,11 +85,7 @@ Scheduler::wait_until(SchedulerEntry* entry, Scheduler::time_type time) {
   if (entry->is_scheduled())
     throw torrent::internal_error("Scheduler::wait_until(...) called on an already scheduled entry.");
 
-  entry->set_scheduler(this);
-  entry->set_time(time);
-
-  base_type::push_back(entry);
-  push_heap();
+  push_entry(entry, time);
 }
 
 void
@@ -125,19 +118,15 @@ Scheduler::update_wait_until(SchedulerEntry* entry, Scheduler::time_type time) {
     throw torrent::internal_error("Scheduler::update_wait(...) called on an invalid entry.");
 
   if (entry->is_scheduled()) {
-    if (entry->scheduler() != this)
+    if (entry->m_handle->scheduler != this)
       throw torrent::internal_error("Scheduler::update_wait(...) called on an entry that is in another scheduler.");
 
-    entry->set_time(time);
-    make_heap();
+    entry->m_handle->entry = nullptr;
+    push_entry(entry, time);
     return;
   }
 
-  entry->set_scheduler(this);
-  entry->set_time(time);
-
-  base_type::push_back(entry);
-  push_heap();
+  push_entry(entry, time);
 }
 
 void
@@ -158,17 +147,16 @@ Scheduler::update_wait_for_ceil_seconds(SchedulerEntry* entry, Scheduler::time_t
 
 void
 Scheduler::perform(Scheduler::time_type current_time) {
-  while (!empty() && base_type::front()->time() <= current_time) {
-    auto entry = base_type::front();
+  while (!m_heap.empty() && m_heap.front()->time <= current_time) {
+    std::ranges::pop_heap(m_heap, compare);
+    auto handle = std::move(m_heap.back());
+    m_heap.pop_back();
 
-    std::pop_heap(begin(), end(), [](const SchedulerEntry* a, const SchedulerEntry* b) {
-        return a->time() > b->time();
-      });
-    base_type::pop_back();
+    if (handle->entry == nullptr)
+      continue;
 
-    entry->set_scheduler(nullptr);
-    entry->set_time(Scheduler::time_type{});
-    entry->slot()();
+    handle->entry->set_handle(nullptr);
+    handle->entry->slot()();
   }
 }
 

--- a/src/torrent/utils/scheduler.h
+++ b/src/torrent/utils/scheduler.h
@@ -3,28 +3,30 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <thread>
 #include <vector>
 #include <torrent/common.h>
 
 namespace torrent::utils {
 
-class LIBTORRENT_EXPORT Scheduler : public std::vector<SchedulerEntry*> {
-public:
-  using base_type = std::vector<SchedulerEntry*>;
-  using time_type = std::chrono::microseconds;
+class SchedulerEntry;
+class Scheduler;
 
-  using base_type::begin;
-  using base_type::end;
-  using base_type::front;
-  using base_type::size;
-  using base_type::empty;
-  using base_type::clear;
+struct SchedulerHandle {
+  SchedulerEntry* entry{};
+  Scheduler*      scheduler{};
+  std::chrono::microseconds time{};
+};
+
+class LIBTORRENT_EXPORT Scheduler {
+public:
+  using time_type = std::chrono::microseconds;
 
   ~Scheduler() = default;
 
-  // time_type is microseconds since unix epoch.
-  time_type           next_timeout() const;
+  bool                empty() const                       { return m_heap.empty(); }
+  time_type           next_timeout(time_type max_timeout);
 
   void                erase(SchedulerEntry* entry);
 
@@ -45,12 +47,14 @@ protected:
   void                set_cached_time(time_type t)      { m_cached_time = t; }
 
 private:
-  void                make_heap();
-  void                push_heap();
+  using heap_type = std::vector<std::unique_ptr<SchedulerHandle>>;
+
+  void                push_entry(SchedulerEntry* entry, time_type time);
 
   std::atomic<std::thread::id> m_thread_id;
 
   align_cacheline time_type    m_cached_time{};
+  heap_type                    m_heap;
 };
 
 class LIBTORRENT_EXPORT SchedulerEntry {
@@ -62,25 +66,23 @@ public:
   ~SchedulerEntry();
 
   bool                is_valid() const     { return m_slot != nullptr; }
-  bool                is_scheduled() const { return m_scheduler != nullptr; }
+  bool                is_scheduled() const { return m_handle != nullptr; }
 
   slot_type&          slot()               { return m_slot; }
-  Scheduler*          scheduler() const    { return m_scheduler; }
-  time_type           time() const         { return m_time; }
+  time_type           time_or_zero() const { return m_handle ? m_handle->time : time_type{}; }
 
 protected:
   friend class Scheduler;
 
-  void                set_scheduler(Scheduler* s) { m_scheduler = s; }
-  void                set_time(time_type t)       { m_time = t; }
+  SchedulerHandle*    handle() const       { return m_handle; }
+  void                set_handle(SchedulerHandle* h) { m_handle = h; }
 
 private:
   SchedulerEntry(const SchedulerEntry&) = delete;
   SchedulerEntry& operator=(const SchedulerEntry&) = delete;
 
   slot_type           m_slot;
-  Scheduler*          m_scheduler{};
-  time_type           m_time{};
+  SchedulerHandle*    m_handle{};
 };
 
 class LIBTORRENT_EXPORT ExternalScheduler : public Scheduler {

--- a/src/tracker/tracker_controller.cc
+++ b/src/tracker/tracker_controller.cc
@@ -63,24 +63,21 @@ TrackerController::is_scrape_queued() const {
 
 int64_t
 TrackerController::next_timeout() const {
-  return m_task_timeout.time().count();
+  return m_task_timeout.time_or_zero().count();
 }
 
 int64_t
 TrackerController::next_scrape() const {
-  return m_task_scrape.time().count();
+  return m_task_scrape.time_or_zero().count();
 }
 
 // seconds_to_next_timeout/scrape() is for display purposes only, and returns 0 if the
 // timeout/scrape is unscheduled.
 uint32_t
 TrackerController::seconds_to_next_timeout() const {
-  auto timeout = m_task_timeout.time() - this_thread::cached_time();
+  auto timeout = std::max(m_task_timeout.time_or_zero() - this_thread::cached_time(), std::chrono::microseconds{});
 
   // LT_LOG_TRACKER_EVENTS("seconds_to_next_timeout() : %" PRId64, timeout.count());
-
-  if (timeout <= 0s)
-    return 0;
 
   // LT_LOG_TRACKER_EVENTS("seconds_to_next_timeout() : %" PRId64, utils::ceil_cast_seconds(timeout).count());
 
@@ -89,10 +86,7 @@ TrackerController::seconds_to_next_timeout() const {
 
 uint32_t
 TrackerController::seconds_to_next_scrape() const {
-  auto timeout = m_task_scrape.time() - this_thread::cached_time();
-
-  if (timeout <= 0s)
-    return 0;
+  auto timeout = std::max(m_task_scrape.time_or_zero() - this_thread::cached_time(), std::chrono::microseconds{});
 
   return utils::ceil_cast_seconds(timeout).count();
 }


### PR DESCRIPTION
## Summary

Replace `make_heap()` (O(N)) in `erase()`/`update_wait_until()` with lazy deletion via `SchedulerHandle` — an intermediate heap-owned struct.

## Design

- **`SchedulerHandle`** — struct with `entry`, `scheduler`, `time`; owned by `unique_ptr` in `Scheduler::m_heap`
- **`Scheduler`** — owns `std::vector` (composition), one-liner `next_timeout(timeout)` handles empty/clamp internally
- **`erase()`** — clears `handle->entry` (O(1)), handle stays in heap for lazy cleanup
- **`update_wait_until()`** — cancels old handle + pushes new (O(log N))
- **`perform()`** — `std::ranges::pop_heap`, skips cancelled handles
- **`SchedulerEntry`** — removed `m_scheduler`, `scheduler()`, `time()`, `m_time`; now only `slot()`, `handle()`, `is_valid()`, `is_scheduled()`
- Removed: `sift_up/down`, `make_heap/push_heap` wrappers, `using base_type::`, vector inheritance

| Operation | Before | After |
|-----------|--------|-------|
| `erase()` | O(N) | O(1) |
| `update_wait_until()` | O(N) | O(log N) |
| `perform()` | O(log N) | O(log N) |

## Requires

- https://github.com/rakshasa/rtorrent/pull/1819