### PR TITLE
Fix use-after-free in UdpRouter::disconnect_failure_unsafe

### DIFF
--- a/src/tracker/udp_router.cc
+++ b/src/tracker/udp_router.cc
@@ -284,10 +284,11 @@ void
 UdpRouter::disconnect_failure_unsafe(connection_map::iterator itr, int errno_err, int gai_err) {
   assert(itr != m_connections.end());
 
+  auto id = itr->first;
   auto failure_fn = std::move(itr->second.failure);
   disconnect_unsafe(itr);
 
-  failure_fn(itr->first, errno_err, gai_err);
+  failure_fn(id, errno_err, gai_err);
 }
 
 void


### PR DESCRIPTION
Copy the connection id before destroying the map entry in disconnect_unsafe.