### PR TITLE
perf: skip sync_chunks early when queue is empty

### DIFF
--- a/src/data/chunk_list.cc
+++ b/src/data/chunk_list.cc
@@ -250,6 +250,13 @@ uint32_t
 ChunkList::sync_chunks(sync_flags flags) {
   LT_LOG_THIS(DEBUG, "Sync chunks: flags:%#x.", flags);
 
+  // An empty queue means no chunks were written since the last sync,
+  // so there is nothing to flush. Skipping early avoids unnecessary
+  // statvfs calls in the free_diskspace check below - especially
+  // optimize for seeding torrents where no data is being written.
+  if (m_queue.empty())
+    return 0;
+
   Queue::iterator split;
 
   if ((flags & sync_all))


### PR DESCRIPTION
Avoid unnecessary statvfs calls in the periodic sync path by returning
early from ChunkList::sync_chunks when m_queue is empty.

The free_diskspace check (which calls statvfs) is only needed when there
are dirty chunks to flush, but the previous code evaluated it unconditionally.
This is especially wasteful for seeding torrents where m_queue is always
empty since no data is written.

## Background

`sync_chunks()` is called every 30s via `ChunkManager::periodic_sync()`
for *all* downloads in the ChunkManager, including seeding/stopped torrents.
Before this change, `statvfs` was invoked for every download on every tick,
even when there were no dirty chunks to flush.

## Change

Add an early return at the start of `ChunkList::sync_chunks()` when
`m_queue` is empty — nothing to sync means nothing to check.