### PR TITLE
O_CLOEXEC everywhere

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ if test "x$use_kqueue" != "xyes" && test "x$use_epoll" != "xyes"; then
 fi
 
 AX_PTHREAD
-AC_CHECK_FUNCS([fallocate posix_fallocate])
+AC_CHECK_FUNCS([fallocate posix_fallocate accept4 pipe2 epoll_create1 kqueue1 inotify_init1])
 
 TORRENT_ENABLE_CUSTOM_STACK_SIZE
 

--- a/src/data/socket_file.cc
+++ b/src/data/socket_file.cc
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include "torrent/exceptions.h"
+#include "torrent/net/fd.h"
 #include "torrent/utils/file_stat.h"
 #include "torrent/utils/log.h"
 
@@ -30,7 +31,7 @@ SocketFile::open(const std::string& path, int prot, int flags, mode_t mode) {
   else
     throw internal_error("torrent::SocketFile::open(...) Tried to open file with no protection flags");
 
-  fd_type fd = ::open(path.c_str(), flags, mode);
+  fd_type fd = fd_open_file(path, flags, mode);
 
   if (fd == invalid_fd)
     return false;

--- a/src/net/curl_socket.cc
+++ b/src/net/curl_socket.cc
@@ -142,7 +142,13 @@ CurlSocket::open_socket(CurlStack *stack, curlsocktype purpose, struct curl_sock
   auto socket     = socket_ptr.get();
 
   auto open_func = [socket, address]() {
-      int fd = ::socket(address->family, address->socktype, address->protocol);
+      int socktype = address->socktype;
+
+#ifdef SOCK_CLOEXEC
+      socktype |= SOCK_CLOEXEC;
+#endif
+
+      int fd = ::socket(address->family, socktype, address->protocol);
 
       if (fd == -1) {
         LT_LOG_DEBUG("open_socket() : error creating socket: %s", std::strerror(errno));

--- a/src/torrent/net/fd.cc
+++ b/src/torrent/net/fd.cc
@@ -7,6 +7,19 @@
 #include <netinet/tcp.h>
 #include <unistd.h>
 
+#if defined(USE_EPOLL)
+#include <sys/epoll.h>
+#elif defined(USE_KQUEUE)
+#include <sys/time.h>
+#include <sys/event.h>
+#else
+#error "Must enable at least one of either kqueue or epoll"
+#endif
+
+#ifdef USE_INOTIFY
+#include <sys/inotify.h>
+#endif
+
 #include "torrent/exceptions.h"
 #include "torrent/net/socket_address.h"
 #include "torrent/utils/log.h"
@@ -45,14 +58,25 @@
 
 namespace torrent {
 
-int fd__accept(int socket, sockaddr *address, socklen_t *address_len) { return ::accept(socket, address, address_len); }
+int fd__accept(int socket, sockaddr *address, socklen_t *address_len) {
+#ifdef HAVE_ACCEPT4
+  return ::accept4(socket, address, address_len, SOCK_CLOEXEC);
+#else
+  return ::accept(socket, address, address_len);
+#endif
+}
 int fd__bind(int socket, const sockaddr *address, socklen_t address_len) { return ::bind(socket, address, address_len); }
 int fd__close(int fildes) { return ::close(fildes); }
 int fd__connect(int socket, const sockaddr *address, socklen_t address_len) { return ::connect(socket, address, address_len); }
 int fd__fcntl_int(int fildes, int cmd, int arg) { return ::fcntl(fildes, cmd, arg); }
 int fd__listen(int socket, int backlog) { return ::listen(socket, backlog); }
 int fd__setsockopt_int(int socket, int level, int option_name, int option_value) { return ::setsockopt(socket, level, option_name, &option_value, sizeof(int)); }
-int fd__socket(int domain, int type, int protocol) { return ::socket(domain, type, protocol); }
+int fd__socket(int domain, int type, int protocol) {
+#ifdef SOCK_CLOEXEC
+  type |= SOCK_CLOEXEC;
+#endif
+  return ::socket(domain, type, protocol);
+}
 
 int
 fd_open(fd_flags flags) {
@@ -158,11 +182,31 @@ fd_open_local(fd_flags flags) {
   return fd;
 }
 
+int
+fd_open_file(const std::string& path, int flags, mode_t mode) {
+  int fd = ::open(path.c_str(), flags | O_CLOEXEC, mode);
+
+  if (fd == -1) {
+    LT_LOG_FLAG_ERROR("fd_open_file failed to open file");
+    return -1;
+  }
+
+  LT_LOG_FD_FLAG("fd_open_file succeeded");
+  return fd;
+}
+
 void
 fd_open_pipe(int& fd1, int& fd2) {
   int result[2];
+  int status;
 
-  if (pipe(result) == -1)
+#ifdef HAVE_PIPE2
+  status = pipe2(result, O_CLOEXEC);
+#else
+  status = pipe(result);
+#endif
+
+  if (status == -1)
     throw internal_error("torrent::fd_open_pipe failed: " + std::string(strerror(errno)));
 
   fd1 = result[0];
@@ -174,14 +218,82 @@ fd_open_pipe(int& fd1, int& fd2) {
 void
 fd_open_socket_pair(int& fd1, int& fd2) {
   int result[2];
+  int type = SOCK_STREAM;
 
-  if (socketpair(AF_LOCAL, SOCK_STREAM, 0, result) == -1)
+#ifdef SOCK_CLOEXEC
+  type |= SOCK_CLOEXEC;
+#endif
+
+  if (socketpair(AF_LOCAL, type, 0, result) == -1)
     throw internal_error("torrent::fd_open_socket_pair failed: " + std::string(strerror(errno)));
 
   fd1 = result[0];
   fd2 = result[1];
 
   LT_LOG("fd_open_socket_pair succeeded : fd1:%i fd2:%i", fd1, fd2);
+}
+
+int
+fd_open_epoll([[maybe_unused]] int size) {
+#ifdef USE_EPOLL
+#ifdef HAVE_EPOLL_CREATE1
+  int fd = epoll_create1(EPOLL_CLOEXEC);
+#else
+  int fd = epoll_create(size);
+#endif
+
+  if (fd == -1) {
+    LT_LOG("fd_open_epoll failed : errno:%i message:'%s'", errno, std::strerror(errno));
+    return -1;
+  }
+
+  LT_LOG_FD("fd_open_epoll succeeded");
+  return fd;
+#else
+  throw internal_error("torrent::fd_open_epoll called but epoll support is not compiled in");
+#endif
+}
+
+int
+fd_open_kqueue() {
+#ifdef USE_KQUEUE
+#ifdef HAVE_KQUEUE1
+  int fd = kqueue1(O_CLOEXEC);
+#else
+  int fd = kqueue();
+#endif
+
+  if (fd == -1) {
+    LT_LOG("fd_open_kqueue failed : errno:%i message:'%s'", errno, std::strerror(errno));
+    return -1;
+  }
+
+  LT_LOG_FD("fd_open_kqueue succeeded");
+  return fd;
+#else
+  throw internal_error("torrent::fd_open_kqueue called but kqueue support is not compiled in");
+#endif
+}
+
+int
+fd_open_inotify() {
+#ifdef USE_INOTIFY
+#ifdef HAVE_INOTIFY_INIT1
+  int fd = inotify_init1(IN_CLOEXEC);
+#else
+  int fd = inotify_init();
+#endif
+
+  if (fd == -1) {
+    LT_LOG("fd_open_inotify failed : errno:%i message:'%s'", errno, std::strerror(errno));
+    return -1;
+  }
+
+  LT_LOG_FD("fd_open_inotify succeeded");
+  return fd;
+#else
+  throw internal_error("torrent::fd_open_inotify called but inotify support is not compiled in");
+#endif
 }
 
 void

--- a/src/torrent/net/fd.h
+++ b/src/torrent/net/fd.h
@@ -2,6 +2,7 @@
 #define LIBTORRENT_NET_FD_H
 
 #include <string>
+#include <sys/types.h>
 #include <torrent/common.h>
 #include <torrent/net/types.h>
 
@@ -23,8 +24,12 @@ constexpr bool  fd_valid_flags(fd_flags flags);
 int             fd_open(fd_flags flags) LIBTORRENT_EXPORT;
 int             fd_open_family(fd_flags flags, int family) LIBTORRENT_EXPORT;
 int             fd_open_local(fd_flags flags) LIBTORRENT_EXPORT;
+int             fd_open_file(const std::string& path, int flags, mode_t mode) LIBTORRENT_EXPORT;
 void            fd_open_pipe(int& fd1, int& fd2) LIBTORRENT_EXPORT;
 void            fd_open_socket_pair(int& fd1, int& fd2) LIBTORRENT_EXPORT;
+int             fd_open_epoll(int size) LIBTORRENT_EXPORT;
+int             fd_open_kqueue() LIBTORRENT_EXPORT;
+int             fd_open_inotify() LIBTORRENT_EXPORT;
 void            fd_close(int fd) LIBTORRENT_EXPORT;
 
 int             fd_accept(int fd) LIBTORRENT_EXPORT;

--- a/src/torrent/system/poll_epoll.cc
+++ b/src/torrent/system/poll_epoll.cc
@@ -11,6 +11,7 @@
 #include "net/event_fd.h"
 #include "torrent/exceptions.h"
 #include "torrent/event.h"
+#include "torrent/net/fd.h"
 #include "torrent/system/thread.h"
 #include "torrent/utils/log.h"
 
@@ -154,10 +155,10 @@ Poll::create() {
   if (socket_open_max == -1)
     throw internal_error("Poll::create() : sysconf(_SC_OPEN_MAX) failed : " + std::string(std::strerror(errno)));
 
-  int fd = epoll_create(socket_open_max);
+  int fd = fd_open_epoll(socket_open_max);
 
   if (fd == -1)
-    throw internal_error("Poll::create() : kqueue() failed : " + std::string(std::strerror(errno)));
+    throw internal_error("Poll::create() : epoll_create() failed : " + std::string(std::strerror(errno)));
 
   auto poll = new Poll();
 

--- a/src/torrent/system/poll_kqueue.cc
+++ b/src/torrent/system/poll_kqueue.cc
@@ -13,6 +13,7 @@
 #include "utils/log.h"
 #include "torrent/event.h"
 #include "torrent/exceptions.h"
+#include "torrent/net/fd.h"
 #include "torrent/system/thread.h"
 
 // TODO: Change to LOG_CONNECTION_POLL
@@ -162,7 +163,7 @@ Poll::create() {
   if (socket_open_max == -1)
     throw internal_error("Poll::create() : sysconf(_SC_OPEN_MAX) failed : " + std::string(std::strerror(errno)));
 
-  int fd = ::kqueue();
+  int fd = fd_open_kqueue();
 
   if (fd == -1)
     throw internal_error("Poll::create() : kqueue() failed : " + std::string(std::strerror(errno)));

--- a/src/torrent/utils/directory_events.cc
+++ b/src/torrent/utils/directory_events.cc
@@ -57,9 +57,9 @@ directory_events::open() {
   errno = 0;
 
 #ifdef USE_INOTIFY
-  m_fileDesc = inotify_init();
+  m_fileDesc = fd_open_inotify();
 
-  if (!fd_set_nonblock(m_fileDesc)) {
+  if (is_open() && !fd_set_nonblock(m_fileDesc)) {
     fd_close(m_fileDesc);
     m_fileDesc = -1;
   }


### PR DESCRIPTION
Try to prevent leaking fds to child processes by atomically setting O_CLOEXEC.

Related to https://github.com/rakshasa/rtorrent/issues/1848