### PR TITLE
Add libcurl limits on maximum announce size and redirect protocols

### DIFF
--- a/src/net/curl_get.cc
+++ b/src/net/curl_get.cc
@@ -248,7 +248,13 @@ CurlGet::prepare_start_unsafe(CurlStack* stack) {
   lt_easy_setopt(m_handle, CURLOPT_NOSIGNAL,       1l);
   lt_easy_setopt(m_handle, CURLOPT_FOLLOWLOCATION, 1l);
   lt_easy_setopt(m_handle, CURLOPT_MAXREDIRS,      5l);
+#if CURL_AT_LEAST_VERSION(7, 85, 0)
+  lt_easy_setopt(m_handle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
+  lt_easy_setopt(m_handle, CURLOPT_REDIR_PROTOCOLS,     CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
   lt_easy_setopt(m_handle, CURLOPT_ENCODING,       "");
+  lt_easy_setopt(m_handle, CURLOPT_MAXFILESIZE,    1l << 20); // 1 MiB
 
   // Note that if the url has a numeric IP address, libcurl will not respect the CURLOPT_IPRESOLVE
   // option.


### PR DESCRIPTION
Healthy tracker announces are always going to be quite small, and the default lack of upper bound on content length means that curl can allocate as much memory as the tracker sends over the network.

This can result in OOM killer going after rtorrent when trackers deploy buggy releases, and return an infinte loop of the same peers or if the announce URL is pointed at a large static file rather than a tracker.

We can mitigate that by telling curl to abort any requests with responses over 1 MiB, which is a very high limit relative to the average announce response, and better than unbounded.

The other new limit, is restricting which protocols curl will follow as part of CURLOPT_FOLLOWLOCATION. Old versions of curl would follow anything including file:// url's, while more recent versions include ftp by default.

I expect no tracker has ever actually redirected rtorrent to connect to an FTP server, but it would probably be preferable it wasn't possible.