### PR TITLE
Fix encryption_require bitmask falsely matching allow_incoming

### DIFF
--- a/src/protocol/encryption_info.h
+++ b/src/protocol/encryption_info.h
@@ -37,12 +37,28 @@
 #ifndef LIBTORRENT_PROTOCOL_ENCRYPTION_H
 #define LIBTORRENT_PROTOCOL_ENCRYPTION_H
 
+#include <cstdint>
+
 #include "utils/rc4.h"
 
 namespace torrent {
 
 class EncryptionInfo {
 public:
+  static constexpr uint32_t option_none             = 0;
+  static constexpr uint32_t option_allow_incoming   = 0x1;
+  static constexpr uint32_t option_try_outgoing     = 0x2;
+  static constexpr uint32_t option_require          = 0x3;
+  static constexpr uint32_t option_require_RC4      = 0x4;
+  static constexpr uint32_t option_enable_retry     = 0x8;
+  static constexpr uint32_t option_prefer_plaintext = 0x10;
+  // Internal to libtorrent.
+  static constexpr uint32_t option_retrying         = 0x40;
+
+  static bool         try_outgoing(uint32_t opts);
+  static bool         is_required(uint32_t opts);
+  static bool         allow_incoming(uint32_t opts);
+
   void                encrypt(const void *indata, void *outdata, unsigned int length) { m_encrypt.crypt(indata, outdata, length); }
   void                encrypt(void *data, unsigned int length)                        { m_encrypt.crypt(data, length); }
   void                decrypt(const void *indata, void *outdata, unsigned int length) { m_decrypt.crypt(indata, outdata, length); }
@@ -64,6 +80,24 @@ private:
   RC4                 m_encrypt;
   RC4                 m_decrypt;
 };
+
+// Encryption options are OR-combined flags, and option_require is a preset
+// (allow_incoming | try_outgoing). Bitwise checks against option_require
+// also match allow_incoming alone; use these helpers for require-specific logic.
+inline bool
+EncryptionInfo::try_outgoing(uint32_t opts) {
+  return (opts & option_try_outgoing) != 0;
+}
+
+inline bool
+EncryptionInfo::is_required(uint32_t opts) {
+  return (opts & option_require) == option_require;
+}
+
+inline bool
+EncryptionInfo::allow_incoming(uint32_t opts) {
+  return (opts & option_allow_incoming) != 0;
+}
 
 } // namespace torrent
 

--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -8,6 +8,7 @@
 #include "download/download_main.h"
 #include "download/download_wrapper.h"
 #include "manager.h"
+#include "protocol/encryption_info.h"
 #include "protocol/peer_connection_base.h"
 #include "torrent/download/download_manager.h"
 #include "torrent/download_info.h"
@@ -103,8 +104,8 @@ ProtocolExtension::generate_handshake_message() {
 
   // Add "e" key if encryption is enabled, set it to 1 if we require
   // encryption for incoming connections, or 0 otherwise.
-  if ((runtime::network_config()->encryption_options() & runtime::NetworkConfig::encryption_allow_incoming) != 0)
-    message[key_e] = (runtime::network_config()->encryption_options() & runtime::NetworkConfig::encryption_require) != 0;
+  if (EncryptionInfo::allow_incoming(runtime::network_config()->encryption_options()))
+    message[key_e] = EncryptionInfo::is_required(runtime::network_config()->encryption_options());
 
   message[key_p] = runtime::listen_port();
   message[key_v] = raw_string::from_c_str("libTorrent " VERSION);

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -112,7 +112,7 @@ Handshake::initialize_incoming(HandshakeManager* handshake_manager, int fd, cons
   m_address    = sa_copy(sa);
   m_encryption = encryption_options;
 
-  if (m_encryption.options() & (runtime::NetworkConfig::encryption_allow_incoming | runtime::NetworkConfig::encryption_require))
+  if (EncryptionInfo::allow_incoming(m_encryption.options()))
     m_state = READ_ENC_KEY;
   else
     m_state = READ_INFO;
@@ -219,12 +219,12 @@ Handshake::destroy_connection(bool use_socket_manager) {
 
 int
 Handshake::retry_options() {
-  uint32_t options = m_encryption.options() & ~runtime::NetworkConfig::encryption_enable_retry;
+  uint32_t options = m_encryption.options() & ~EncryptionInfo::option_enable_retry;
 
   if (m_encryption.retry() == HandshakeEncryption::RETRY_PLAIN)
-    options &= ~runtime::NetworkConfig::encryption_try_outgoing;
+    options &= ~EncryptionInfo::option_try_outgoing;
   else if (m_encryption.retry() == HandshakeEncryption::RETRY_ENCRYPTED)
-    options |= runtime::NetworkConfig::encryption_try_outgoing;
+    options |= EncryptionInfo::option_try_outgoing;
   else
     throw internal_error("Invalid retry type.");
 
@@ -287,7 +287,7 @@ Handshake::read_encryption_key() {
 
     if (m_readBuffer.peek_8() == 19 && std::memcmp(m_readBuffer.position() + 1, m_protocol, 19) == 0) {
       // got unencrypted BT handshake
-      if (m_encryption.options() & runtime::NetworkConfig::encryption_require)
+      if (EncryptionInfo::is_required(m_encryption.options()))
         throw handshake_error(handshake_dropped, e_handshake_unencrypted_rejected);
 
       m_state = READ_INFO;
@@ -432,10 +432,10 @@ Handshake::read_encryption_negotiation() {
 
   // choose one of the offered encryptions, or check the chosen one is valid
   if (m_incoming) {
-    if ((m_encryption.options() & runtime::NetworkConfig::encryption_prefer_plaintext) && m_encryption.has_crypto_plain()) {
+    if ((m_encryption.options() & EncryptionInfo::option_prefer_plaintext) && m_encryption.has_crypto_plain()) {
       m_encryption.set_crypto(HandshakeEncryption::crypto_plain);
 
-    } else if ((m_encryption.options() & runtime::NetworkConfig::encryption_require_RC4) && !m_encryption.has_crypto_rc4()) {
+    } else if ((m_encryption.options() & EncryptionInfo::option_require_RC4) && !m_encryption.has_crypto_rc4()) {
       throw handshake_error(handshake_dropped, e_handshake_unencrypted_rejected);
 
     } else if (m_encryption.has_crypto_rc4()) {
@@ -457,7 +457,7 @@ Handshake::read_encryption_negotiation() {
     if (m_encryption.crypto() != HandshakeEncryption::crypto_rc4 && m_encryption.crypto() != HandshakeEncryption::crypto_plain)
       throw handshake_error(handshake_failed, e_handshake_invalid_encryption);
 
-    if ((m_encryption.options() & runtime::NetworkConfig::encryption_require_RC4) && (m_encryption.crypto() != HandshakeEncryption::crypto_rc4))
+    if ((m_encryption.options() & EncryptionInfo::option_require_RC4) && (m_encryption.crypto() != HandshakeEncryption::crypto_rc4))
       throw handshake_error(handshake_failed, e_handshake_invalid_encryption);
   }
 
@@ -996,11 +996,11 @@ Handshake::event_write() {
 
       m_writeBuffer.reset();
 
-      if (m_encryption.options() & (runtime::NetworkConfig::encryption_try_outgoing | runtime::NetworkConfig::encryption_require)) {
+      if (EncryptionInfo::try_outgoing(m_encryption.options())) {
         prepare_key_plus_pad();
 
         // if connection fails, peer probably closed it because it was encrypted, so retry encrypted if enabled
-        if (!(m_encryption.options() & runtime::NetworkConfig::encryption_require))
+        if (!EncryptionInfo::is_required(m_encryption.options()))
           m_encryption.set_retry(HandshakeEncryption::RETRY_PLAIN);
 
         m_state = READ_ENC_KEY;
@@ -1091,7 +1091,7 @@ Handshake::prepare_enc_negotiation() {
   HandshakeEncryption::copy_vc(m_writeBuffer.end());
   m_writeBuffer.move_end(HandshakeEncryption::vc_length);
 
-  if (m_encryption.options() & runtime::NetworkConfig::encryption_require_RC4)
+  if (m_encryption.options() & EncryptionInfo::option_require_RC4)
     m_writeBuffer.write_32(HandshakeEncryption::crypto_rc4);
   else
     m_writeBuffer.write_32(HandshakeEncryption::crypto_plain | HandshakeEncryption::crypto_rc4);

--- a/src/protocol/handshake_encryption.cc
+++ b/src/protocol/handshake_encryption.cc
@@ -2,7 +2,6 @@
 
 #include "handshake_encryption.h"
 
-#include "torrent/runtime/network_config.h"
 #include "utils/diffie_hellman.h"
 #include "utils/sha1.h"
 
@@ -24,7 +23,7 @@ const unsigned char HandshakeEncryption::vc_data[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
 bool
 HandshakeEncryption::should_retry() const {
-  return (m_options & runtime::NetworkConfig::encryption_enable_retry) != 0 && m_retry != HandshakeEncryption::RETRY_NONE;
+  return (m_options & EncryptionInfo::option_enable_retry) != 0 && m_retry != HandshakeEncryption::RETRY_NONE;
 }
 
 HandshakeEncryption::HandshakeEncryption(int options) :

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -128,10 +128,10 @@ HandshakeManager::add_outgoing(const sockaddr* sa, DownloadMain* download) {
   auto encryption_options = runtime::network_config()->encryption_options();
 
   if (download->info()->is_meta_download()) {
-    encryption_options &= ~runtime::NetworkConfig::encryption_try_outgoing;
-    encryption_options &= ~runtime::NetworkConfig::encryption_require;
-    encryption_options &= ~runtime::NetworkConfig::encryption_require_RC4;
-    encryption_options &= ~runtime::NetworkConfig::encryption_enable_retry;
+    encryption_options &= ~EncryptionInfo::option_try_outgoing;
+    encryption_options &= ~EncryptionInfo::option_require;
+    encryption_options &= ~EncryptionInfo::option_require_RC4;
+    encryption_options &= ~EncryptionInfo::option_enable_retry;
   }
 
   if (sa_is_v4mapped(sa))
@@ -144,7 +144,7 @@ void
 HandshakeManager::create_outgoing(const sockaddr* sa, DownloadMain* download, int encryption_options) {
   int connection_options = PeerList::connect_keep_handshakes;
 
-  if (!(encryption_options & runtime::NetworkConfig::encryption_retrying))
+  if (!(encryption_options & EncryptionInfo::option_retrying))
     connection_options |= PeerList::connect_filter_recent;
 
   PeerInfo* peer_info = download->peer_list()->connected(sa, connection_options);
@@ -174,10 +174,10 @@ HandshakeManager::create_outgoing(const sockaddr* sa, DownloadMain* download, in
         return;
 
       auto type_fn = [&]() {
-          if (encryption_options & runtime::NetworkConfig::encryption_try_outgoing)
-            return "try encrypted";
-          else if (encryption_options & runtime::NetworkConfig::encryption_require)
+          if (EncryptionInfo::is_required(encryption_options))
             return "require encrypted";
+          else if (EncryptionInfo::try_outgoing(encryption_options))
+            return "try encrypted";
           else
             return "plain";
         };
@@ -285,10 +285,10 @@ HandshakeManager::receive_failed(Handshake* ptr, int message, int error) {
   LT_LOG_SA(sa, "Received error: message:%x %s.", message, handshake_strerror(error));
 
   if (handshake->encryption()->should_retry()) {
-    int retry_options = handshake->retry_options() | runtime::NetworkConfig::encryption_retrying;
+    int retry_options = handshake->retry_options() | EncryptionInfo::option_retrying;
     DownloadMain* download = handshake->download();
 
-    LT_LOG_SA(sa, "Retrying %s.", retry_options & runtime::NetworkConfig::encryption_try_outgoing ? "encrypted" : "plaintext");
+    LT_LOG_SA(sa, "Retrying %s.", retry_options & EncryptionInfo::option_try_outgoing ? "encrypted" : "plaintext");
 
     create_outgoing(sa, download, retry_options);
   }

--- a/src/torrent/runtime/network_config.h
+++ b/src/torrent/runtime/network_config.h
@@ -21,16 +21,6 @@ public:
   static constexpr int      iptos_throughput            = IPTOS_THROUGHPUT;
   static constexpr int      iptos_reliability           = IPTOS_RELIABILITY;
 
-  static constexpr uint32_t encryption_none             = 0;
-  static constexpr uint32_t encryption_allow_incoming   = 0x1;
-  static constexpr uint32_t encryption_try_outgoing     = 0x2;
-  static constexpr uint32_t encryption_require          = 0x3;
-  static constexpr uint32_t encryption_require_RC4      = 0x4;
-  static constexpr uint32_t encryption_enable_retry     = 0x8;
-  static constexpr uint32_t encryption_prefer_plaintext = 0x10;
-  // Internal to libtorrent.
-  static constexpr uint32_t encryption_retrying         = 0x40;
-
   NetworkConfig();
 
   // TODO: Move helper functions in rtorrent manager here.
@@ -174,7 +164,7 @@ private:
   c_sa_shared_ptr     m_local_inet_address;
   c_sa_shared_ptr     m_local_inet6_address;
 
-  int                 m_encryption_options{encryption_none};
+  int                 m_encryption_options{0};
   int                 m_listen_backlog{SOMAXCONN};
   uint16_t            m_override_dht_port{0};
   uint32_t            m_send_buffer_size{0};

--- a/src/torrent/utils/option_strings.cc
+++ b/src/torrent/utils/option_strings.cc
@@ -9,6 +9,7 @@
 #include "torrent/download/choke_group.h"
 #include "torrent/download/choke_queue.h"
 #include "torrent/peer/peer_info.h"
+#include "protocol/encryption_info.h"
 #include "torrent/runtime/network_config.h"
 #include "torrent/utils/option_strings.h"
 
@@ -54,14 +55,14 @@ constexpr option_pair option_list_heuristics_upload[] = {
 };
 
 constexpr option_pair option_list_encryption[] = {
-  { "none",             runtime::NetworkConfig::encryption_none },
-  { "allow_incoming",   runtime::NetworkConfig::encryption_allow_incoming },
-  { "try_outgoing",     runtime::NetworkConfig::encryption_try_outgoing },
-  { "require",          runtime::NetworkConfig::encryption_require },
-  { "require_RC4",      runtime::NetworkConfig::encryption_require_RC4 },
-  { "require_rc4",      runtime::NetworkConfig::encryption_require_RC4 },
-  { "enable_retry",     runtime::NetworkConfig::encryption_enable_retry },
-  { "prefer_plaintext", runtime::NetworkConfig::encryption_prefer_plaintext },
+  { "none",             EncryptionInfo::option_none },
+  { "allow_incoming",   EncryptionInfo::option_allow_incoming },
+  { "try_outgoing",     EncryptionInfo::option_try_outgoing },
+  { "require",          EncryptionInfo::option_require },
+  { "require_RC4",      EncryptionInfo::option_require_RC4 },
+  { "require_rc4",      EncryptionInfo::option_require_RC4 },
+  { "enable_retry",     EncryptionInfo::option_enable_retry },
+  { "prefer_plaintext", EncryptionInfo::option_prefer_plaintext },
   { NULL, 0 }
 };
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -117,6 +117,8 @@ LibTorrent_Test_SOURCES = $(LibTorrent_Test_Common) \
 	rak/ranges_test.cc \
 	rak/ranges_test.h \
 	\
+	protocol/test_encryption_option.cc \
+	protocol/test_encryption_option.h \
 	protocol/test_request_list.cc \
 	protocol/test_request_list.h
 

--- a/test/protocol/test_encryption_option.cc
+++ b/test/protocol/test_encryption_option.cc
@@ -1,0 +1,34 @@
+#include "config.h"
+
+#include "test_encryption_option.h"
+
+#include <protocol/encryption_info.h>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(test_encryption_option);
+
+void
+test_encryption_option::test_encryption_helpers() {
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::try_outgoing(torrent::EncryptionInfo::option_none));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::is_required(torrent::EncryptionInfo::option_none));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::allow_incoming(torrent::EncryptionInfo::option_none));
+
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::try_outgoing(torrent::EncryptionInfo::option_allow_incoming));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::is_required(torrent::EncryptionInfo::option_allow_incoming));
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::allow_incoming(torrent::EncryptionInfo::option_allow_incoming));
+
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::try_outgoing(torrent::EncryptionInfo::option_try_outgoing));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::is_required(torrent::EncryptionInfo::option_try_outgoing));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::allow_incoming(torrent::EncryptionInfo::option_try_outgoing));
+
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::try_outgoing(torrent::EncryptionInfo::option_require));
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::is_required(torrent::EncryptionInfo::option_require));
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::allow_incoming(torrent::EncryptionInfo::option_require));
+
+  const uint32_t user_config = torrent::EncryptionInfo::option_allow_incoming
+                             | torrent::EncryptionInfo::option_enable_retry
+                             | torrent::EncryptionInfo::option_prefer_plaintext;
+
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::try_outgoing(user_config));
+  CPPUNIT_ASSERT(!torrent::EncryptionInfo::is_required(user_config));
+  CPPUNIT_ASSERT(torrent::EncryptionInfo::allow_incoming(user_config));
+}

--- a/test/protocol/test_encryption_option.h
+++ b/test/protocol/test_encryption_option.h
@@ -1,0 +1,10 @@
+#include "helpers/test_fixture.h"
+
+class test_encryption_option : public test_fixture {
+  CPPUNIT_TEST_SUITE(test_encryption_option);
+  CPPUNIT_TEST(test_encryption_helpers);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void test_encryption_helpers();
+};


### PR DESCRIPTION
found this when sendfile() testing

encryption_require is 0x3 (allow_incoming | try_outgoing). Bitwise checks against it also matched allow_incoming alone, causing outgoing connections to use encrypted handshakes when only allow_incoming was configured. Add NetworkConfig helper functions and use exact-match semantics for require-specific behavior.