### PR TITLE
net: accept blocking libcurl internal eventfd in verify_libcurl_internal_wakeup

### DIFF
--- a/src/net/curl_socket.cc
+++ b/src/net/curl_socket.cc
@@ -447,18 +447,6 @@ verify_libcurl_internal_wakeup(int fd) {
 
   // Linux eventfd (Only probe if it's an anonymous inode, NOT a socket)
   if (!S_ISREG(sb.st_mode) && !S_ISDIR(sb.st_mode)) {
-    bool is_nonblock{};
-
-    if (!fd_get_nonblock(fd, &is_nonblock)) {
-      LT_LOG_DEBUG("verify_libcurl_internal_wakeup(fd:%i) : fd_get_nonblock failed: %s", fd, system::errno_enum(errno));
-      throw internal_error("verify_libcurl_internal_wakeup(fd:" + std::to_string(fd) + "): fd_get_nonblock failed: " + system::errno_enum_str(errno));
-    }
-
-    if (!is_nonblock) {
-      LT_LOG_DEBUG("verify_libcurl_internal_wakeup(fd:%i) : fd is blocking, expected non-blocking", fd);
-      throw internal_error("verify_libcurl_internal_wakeup(fd:" + std::to_string(fd) + "): fd is blocking, expected non-blocking");
-    }
-
     char dummy[7] = {0};
 
     // Passing 7 bytes to an eventfd instantly returns EINVAL without altering state.


### PR DESCRIPTION
verify_libcurl_internal_wakeup() rejected any internal eventfd that was not non-blocking. This aborts rtorrent on the first DNS-resolving HTTP tracker request on every Linux libcurl built with the threaded resolver and eventfd support -- the Debian/Ubuntu default.

libcurl's threaded resolver signals completion over the eventfd-based socketpair replacement added in curl 8.11.1 (lib/socketpair.c), and that eventfd is created blocking (nonblocking=false). The multi-wakeup eventfd is the only one libcurl makes non-blocking, but rtorrent drives its own poll and never calls curl_multi_wakeup, so the resolver eventfd is the only internal eventfd it can ever receive. The non-blocking assertion is thus inverted for the single case that reaches it.

The blocking mode is irrelevant to rtorrent: it only reports readiness via poll and leaves the read to libcurl. The write(fd, 7) -> EINVAL probe that immediately follows already identifies eventfds definitively, regardless of blocking mode, so the assertion is both redundant and wrong. Remove it.

Without this patch, rtorrent crashes immediately in all our test servers.

Env: Debian 13 using stock libcurl (as shipped by Debian).
