### PR TITLE
Fix encryption_require bitmask overlap

### DIFF
--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -104,7 +104,7 @@ ProtocolExtension::generate_handshake_message() {
   // Add "e" key if encryption is enabled, set it to 1 if we require
   // encryption for incoming connections, or 0 otherwise.
   if ((runtime::network_config()->encryption_options() & runtime::NetworkConfig::encryption_allow_incoming) != 0)
-    message[key_e] = (runtime::network_config()->encryption_options() & runtime::NetworkConfig::encryption_require) != 0;
+    message[key_e] = (runtime::network_config()->encryption_options() & runtime::NetworkConfig::encryption_require) == runtime::NetworkConfig::encryption_require;
 
   message[key_p] = runtime::listen_port();
   message[key_v] = raw_string::from_c_str("libTorrent " VERSION);

--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -112,7 +112,7 @@ Handshake::initialize_incoming(HandshakeManager* handshake_manager, int fd, cons
   m_address    = sa_copy(sa);
   m_encryption = encryption_options;
 
-  if (m_encryption.options() & (runtime::NetworkConfig::encryption_allow_incoming | runtime::NetworkConfig::encryption_require))
+  if (m_encryption.options() & runtime::NetworkConfig::encryption_allow_incoming)
     m_state = READ_ENC_KEY;
   else
     m_state = READ_INFO;
@@ -287,7 +287,7 @@ Handshake::read_encryption_key() {
 
     if (m_readBuffer.peek_8() == 19 && std::memcmp(m_readBuffer.position() + 1, m_protocol, 19) == 0) {
       // got unencrypted BT handshake
-      if (m_encryption.options() & runtime::NetworkConfig::encryption_require)
+      if ((m_encryption.options() & runtime::NetworkConfig::encryption_require) == runtime::NetworkConfig::encryption_require)
         throw handshake_error(handshake_dropped, e_handshake_unencrypted_rejected);
 
       m_state = READ_INFO;
@@ -996,11 +996,11 @@ Handshake::event_write() {
 
       m_writeBuffer.reset();
 
-      if (m_encryption.options() & (runtime::NetworkConfig::encryption_try_outgoing | runtime::NetworkConfig::encryption_require)) {
+      if (m_encryption.options() & runtime::NetworkConfig::encryption_try_outgoing) {
         prepare_key_plus_pad();
 
         // if connection fails, peer probably closed it because it was encrypted, so retry encrypted if enabled
-        if (!(m_encryption.options() & runtime::NetworkConfig::encryption_require))
+        if ((m_encryption.options() & runtime::NetworkConfig::encryption_require) != runtime::NetworkConfig::encryption_require)
           m_encryption.set_retry(HandshakeEncryption::RETRY_PLAIN);
 
         m_state = READ_ENC_KEY;

--- a/src/protocol/handshake_manager.cc
+++ b/src/protocol/handshake_manager.cc
@@ -176,7 +176,7 @@ HandshakeManager::create_outgoing(const sockaddr* sa, DownloadMain* download, in
       auto type_fn = [&]() {
           if (encryption_options & runtime::NetworkConfig::encryption_try_outgoing)
             return "try encrypted";
-          else if (encryption_options & runtime::NetworkConfig::encryption_require)
+          else if ((encryption_options & runtime::NetworkConfig::encryption_require) == runtime::NetworkConfig::encryption_require)
             return "require encrypted";
           else
             return "plain";


### PR DESCRIPTION
This is only a small fix against the current encryption code to address the bit overlap.

encryption_require is 0x3 (allow_incoming | try_outgoing). Bitwise checks against it also matched allow_incoming alone, causing outgoing connections to use encrypted handshakes and rejecting plaintext incoming.