### PR TITLE
Fix typo in log group name: connection_handshake

### DIFF
--- a/src/torrent/utils/option_strings.cc
+++ b/src/torrent/utils/option_strings.cc
@@ -128,7 +128,7 @@ constexpr const char* option_list_log_group[] = {
   "connection_bind",
   "connection_fd",
   "connection_filter",
-  "connection_hanshake",
+  "connection_handshake",
   "connection_listen",
 
   "dht",


### PR DESCRIPTION
small standalone PR for hanshake->handshake typo
