### PR TITLE
net: always dual-bind IPv4 and IPv6 when binds are unset

### DIFF
--- a/src/torrent/runtime/network_config.cc
+++ b/src/torrent/runtime/network_config.cc
@@ -456,10 +456,10 @@ NetworkConfig::listen_addresses_unsafe() const {
   }
 
   if (inet_address->sa_family == AF_UNSPEC && inet6_address->sa_family == AF_UNSPEC) {
-    if (m_block_ipv4in6)
-      return {inet_any_value, inet6_any_value, true};
-
-    return {nullptr, inet6_any_value, false};
+    // Always open separate 0.0.0.0 and :: sockets with IPV6_V6ONLY. Relying on a
+    // single dual-stack IPv6 socket (when block_ipv4in6 is false) fails when
+    // net.ipv6.bindv6only=1: only tcp6 appears and IPv4 inbound never works.
+    return {inet_any_value, inet6_any_value, true};
   }
 
   if (inet_address->sa_family != AF_UNSPEC && inet6_address->sa_family != AF_UNSPEC)


### PR DESCRIPTION
- Default listen (both IPv4/IPv6 bind addresses unset) opened only a single `::` socket without `IPV6_V6ONLY`.
- On systems with `net.ipv6.bindv6only=1`, that appears as **tcp6-only** and **IPv4 inbound never works**.
- Always open separate `0.0.0.0` and `::` listeners with V6ONLY on the IPv6 socket (same as the existing `block_ipv4in6` dual-socket path).

Introduced in `a4c7bb9d` (“Added dual listening ports…”, first in **v0.16.2**). Still present through **v0.16.17**
