### PR TITLE
restore encryption_require as an independent bit (0.15.7 layout)

### DIFF
--- a/src/torrent/runtime/network_config.h
+++ b/src/torrent/runtime/network_config.h
@@ -22,14 +22,14 @@ public:
   static constexpr int      iptos_reliability           = IPTOS_RELIABILITY;
 
   static constexpr uint32_t encryption_none             = 0;
-  static constexpr uint32_t encryption_allow_incoming   = 0x1;
-  static constexpr uint32_t encryption_try_outgoing     = 0x2;
-  static constexpr uint32_t encryption_require          = 0x3;
-  static constexpr uint32_t encryption_require_RC4      = 0x4;
-  static constexpr uint32_t encryption_enable_retry     = 0x8;
-  static constexpr uint32_t encryption_prefer_plaintext = 0x10;
+  static constexpr uint32_t encryption_allow_incoming   = (1 << 0);
+  static constexpr uint32_t encryption_try_outgoing     = (1 << 1);
+  static constexpr uint32_t encryption_require          = (1 << 2);
+  static constexpr uint32_t encryption_require_RC4      = (1 << 3);
+  static constexpr uint32_t encryption_enable_retry     = (1 << 4);
+  static constexpr uint32_t encryption_prefer_plaintext = (1 << 5);
   // Internal to libtorrent.
-  static constexpr uint32_t encryption_retrying         = 0x40;
+  static constexpr uint32_t encryption_retrying         = (1 << 6);
 
   NetworkConfig();
 


### PR DESCRIPTION
This is the cleanest/simple fix to the encryption handshake.

In 644cb4db the encryption option flags were rewritten from (1 << n) to hex literals and encryption_require was set to 0x3. That value is identical to allow_incoming|try_outgoing (0x1|0x2), so the two flags are no longer independent:

  - allow_incoming,try_outgoing is treated as require
  - inbound plaintext is rejected (e_handshake_unencrypted_rejected) even when the user only asked for PE-first outbound
  - (opts & require) != 0 also matches allow_incoming alone (0x1), so extension handshake "e" and related checks over-report require

In 0.15.7, require was (1 << 2). Restore that independent layout. require alone still enables inbound MSE and forces outbound PE via the existing allow|require and try|require ORs in the handshake path.