### PR TITLE
storage: lazy open, idle FD close, and short-file resize

### DIFF
--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -113,7 +113,7 @@ DownloadMain::open(int flags) {
     throw internal_error("Tried to open a download that is already open");
 
   // TODO: Move file_list open calls to DownloadMain.
-  file_list()->open(true, (flags & FileList::open_no_create));
+  file_list()->open(flags & FileList::open_no_create);
 
   m_chunkList->resize(file_list()->size_chunks());
   m_chunkStatistics->initialize(file_list()->size_chunks());
@@ -159,10 +159,9 @@ void DownloadMain::start(int flags) {
   // references go to zero.
   file_list()->close_all_files();
 
-  // If the FileList::open_no_create flag was not set, our new
-  // behavior is to create all zero-length files with
-  // flag_queued_create set.
-  file_list()->open(false, (flags & ~FileList::open_no_create));
+  // Re-open file list paths/dirs. Files open on demand in prepare().
+  // Zero-length entries are not materialized (no chunk I/O).
+  file_list()->open(flags & ~FileList::open_no_create);
 
   info()->set_flags(DownloadInfo::flag_active);
   chunk_list()->set_flags(ChunkList::flag_active);
@@ -195,6 +194,11 @@ DownloadMain::stop() {
 
   if (info()->upload_unchoked() != 0 || info()->download_unchoked() != 0)
     throw internal_error("DownloadMain::stop(): info()->upload_unchoked() != 0 || info()->download_unchoked() != 0.");
+
+  // Sync dirty chunks and release FDs; prepare() reopens on demand.
+  chunk_list()->sync_chunks(static_cast<ChunkList::sync_flags>(
+      ChunkList::sync_all | ChunkList::sync_force | ChunkList::sync_ignore_error));
+  file_list()->close_all_files();
 }
 
 bool

--- a/src/download/download_wrapper.cc
+++ b/src/download/download_wrapper.cc
@@ -8,6 +8,7 @@
 #include "download/chunk_selector.h"
 #include "protocol/handshake_manager.h"
 #include "protocol/peer_connection_base.h"
+#include "manager.h"
 #include "torrent/data/file.h"
 #include "torrent/data/file_list.h"
 #include "torrent/data/file_manager.h"
@@ -346,6 +347,17 @@ DownloadWrapper::receive_update_priorities() {
       this_thread::scheduler()->wait_for(&m_main->delay_partially_done(), 0us);
     else
       this_thread::scheduler()->wait_for(&m_main->delay_partially_restarted(), 0us);
+  }
+
+  // Bulk priority update: drop create/resize and FDs for off files.
+  for (auto& file : *m_main->file_list()) {
+    if (file->priority() != PRIORITY_OFF)
+      continue;
+
+    file->unset_flags(File::flag_create_queued | File::flag_resize_queued);
+
+    if (file->is_open())
+      manager->file_manager()->close(file.get());
   }
 }
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -110,6 +110,7 @@ Manager::receive_tick() {
 
   m_resource_manager->receive_tick();
   m_chunk_manager->periodic_sync();
+  m_file_manager->periodic_close_idle();
 
   // To ensure the downloads get equal chance over time at using
   // various limited resources, like sockets for handshakes, cycle the

--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -59,9 +59,36 @@ File::set_completed_chunks(uint32_t v) {
   m_completed = v;
 }
 
+void
+File::set_priority(priority_enum t) {
+  auto old = m_priority;
+  m_priority = t;
+
+  // Off: drop create/resize and close FD; leaving off: restore both flags.
+  if (t == PRIORITY_OFF) {
+    unset_flags(flag_create_queued | flag_resize_queued);
+
+    if (is_open() && !is_padding())
+      manager->file_manager()->close(this);
+  } else if (old == PRIORITY_OFF) {
+    set_flags(flag_create_queued | flag_resize_queued);
+  }
+}
+
+// Grow on write whenever on-disk size is wrong (e.g. 0-byte stub after
+// create without resize, or resize_queued lost). create_chunk refuses maps
+// past EOF, so a short file can never receive pieces until resized.
+bool
+File::ensure_size_for_write() {
+  if (!has_permissions(PROT_WRITE))
+    return true;
+
+  m_flags &= ~flag_resize_queued;
+  return resize_file();
+}
+
 // At some point we should pass flags for deciding if the correct size
 // is necessary, etc.
-
 bool
 File::prepare(bool hashing, int prot, int flags) {
   if (is_padding())
@@ -69,12 +96,8 @@ File::prepare(bool hashing, int prot, int flags) {
 
   m_last_touched = this_thread::cached_time().count();
 
-  // Check if we got write protection and flag_resize_queued is
-  // set. If so don't quit as we need to try re-sizing, instead call
-  // resize_file.
-
   if (is_open() && has_permissions(prot))
-    return true;
+    return ensure_size_for_write();
 
   // For now don't allow overridding this check in prepare.
   if (m_flags & flag_create_queued)
@@ -88,13 +111,7 @@ File::prepare(bool hashing, int prot, int flags) {
   m_flags |= flag_previously_created;
   m_flags &= ~flag_create_queued;
 
-  // Replace PROT_WRITE with something prettier.
-  if ((m_flags & flag_resize_queued) && has_permissions(PROT_WRITE)) {
-    m_flags &= ~flag_resize_queued;
-    return resize_file();
-  }
-
-  return true;
+  return ensure_size_for_write();
 }
 
 void

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -58,7 +58,7 @@ public:
   uint32_t            range_second() const                     { return m_range.second; }
 
   priority_enum       priority() const                         { return m_priority; }
-  void                set_priority(priority_enum t)            { m_priority = t; }
+  void                set_priority(priority_enum t);
 
   const Path*         path() const                             { return &m_path; }
   Path*               mutable_path()                           { return &m_path; }
@@ -106,6 +106,7 @@ private:
   File(const File&) = delete;
   File& operator=(const File&) = delete;
 
+  bool                ensure_size_for_write();
   bool                resize_file() const;
 
   int                 m_fd{-1};

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -373,7 +373,7 @@ struct file_list_cstr_less {
 };
 
 void
-FileList::open(bool hashing, int flags) {
+FileList::open(int flags) {
   using path_set = std::set<const char*, file_list_cstr_less>;
 
   LT_LOG_FL(INFO, "Opening.", 0);
@@ -421,12 +421,13 @@ FileList::open(bool hashing, int flags) {
       if (entry->path()->empty())
         throw storage_error("Empty filename is not allowed.");
 
-      // Handle directory creation outside of open_file, so we can do
-      // it here if necessary.
+      // Path/dir setup for all files (including priority-off). open_file does
+      // not open FDs; prepare() opens on demand. Off files are not create-queued
+      // (see Download::open / File::set_priority).
 
       entry->set_flags_protected(File::flag_active);
 
-      if (!open_file(&*entry, lastPath, hashing, flags)) {
+      if (!open_file(&*entry, lastPath, flags)) {
         // This needs to check if the error was due to open_no_create
         // being set or not.
         if (!(flags & open_no_create))
@@ -534,7 +535,7 @@ FileList::make_directory(Path::const_iterator path_begin, Path::const_iterator p
 }
 
 bool
-FileList::open_file(File* file_node, const Path& lastPath, bool hashing, int flags) {
+FileList::open_file(File* file_node, const Path& lastPath, int flags) {
   errno = 0;
 
   if (!(flags & open_no_create)) {
@@ -565,7 +566,8 @@ FileList::open_file(File* file_node, const Path& lastPath, bool hashing, int fla
     return false;
   }
 
-  return file_node->prepare(hashing, MemoryChunk::prot_read, 0);
+  // Paths/dirs only; prepare() creates/opens on demand.
+  return true;
 }
 
 MemoryChunk
@@ -580,6 +582,10 @@ FileList::create_chunk_part(FileList::iterator itr, uint64_t offset, uint32_t le
     throw internal_error("FileList::chunk_part(...) caught a negative offset", data()->hash());
 
   // Check that offset != length of file.
+
+  // Allow create/resize of off neighbors for boundary writes.
+  if ((*itr)->priority() == PRIORITY_OFF && (prot & MemoryChunk::prot_write))
+    (*itr)->set_flags(File::flag_create_queued | File::flag_resize_queued);
 
   if (!(*itr)->prepare(hashing, prot, 0))
     return MemoryChunk();
@@ -744,7 +750,7 @@ FileList::reset_filesize(int64_t size) {
   m_data.mutable_completed_bitfield()->allocate();
   m_data.mutable_completed_bitfield()->unset_all();
 
-  open(false, open_no_create);
+  open(open_no_create);
 }
 
 } // namespace torrent

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -126,7 +126,7 @@ protected:
 
   void                initialize(uint64_t torrentSize, uint32_t chunkSize) LIBTORRENT_NO_EXPORT;
 
-  void                open(bool hashing, int flags) LIBTORRENT_NO_EXPORT;
+  void                open(int flags) LIBTORRENT_NO_EXPORT;
   void                close() LIBTORRENT_NO_EXPORT;
   void                close_all_files() LIBTORRENT_NO_EXPORT;
 
@@ -146,7 +146,7 @@ protected:
   void                reset_filesize(int64_t) LIBTORRENT_NO_EXPORT;
 
 private:
-  bool                open_file(File* node, const Path& lastPath, bool hashing, int flags) LIBTORRENT_NO_EXPORT;
+  bool                open_file(File* node, const Path& lastPath, int flags) LIBTORRENT_NO_EXPORT;
   void                make_directory(Path::const_iterator pathBegin, Path::const_iterator pathEnd, Path::const_iterator startItr) LIBTORRENT_NO_EXPORT;
 
   Chunk*              create_chunk(uint64_t offset, uint32_t length, bool hashing, int prot) LIBTORRENT_NO_EXPORT;

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -111,4 +111,28 @@ FileManager::close_least_active() {
     close(least);
 }
 
+void
+FileManager::periodic_close_idle() {
+  if (m_close_idle == 0 || empty())
+    return;
+
+  const uint64_t now = this_thread::cached_time().count();
+  const uint64_t limit = static_cast<uint64_t>(m_close_idle) * 1'000'000ull;
+
+  size_type i = 0;
+  while (i < size()) {
+    File* f = base_type::operator[](i);
+
+    if (!f->is_open() || f->last_touched() > now) {
+      ++i;
+      continue;
+    }
+
+    if (now - f->last_touched() >= limit)
+      close(f);
+    else
+      ++i;
+  }
+}
+
 } // namespace torrent

--- a/src/torrent/data/file_manager.h
+++ b/src/torrent/data/file_manager.h
@@ -36,12 +36,15 @@ public:
   bool                advise_random_hashing() const         { return m_advise_random_hashing; }
   void                set_advise_random_hashing(bool state) { m_advise_random_hashing = state; }
 
+  // Idle seconds before closing open FDs; 0 disables.
+  uint32_t            close_idle() const                    { return m_close_idle; }
+  void                set_close_idle(uint32_t seconds)      { m_close_idle = seconds; }
+
   bool                open(value_type file, bool hashing, int prot, int flags);
   void                close(value_type file);
 
-  // TODO: Close all files held by a download after hashing. Also flush all memory chunks.
-
   void                close_least_active();
+  void                periodic_close_idle();
 
   // Statistics:
   uint64_t            files_opened_counter() const { return m_files_opened_counter; }
@@ -53,6 +56,7 @@ private:
   FileManager& operator=(const FileManager&) = delete;
 
   size_type           m_max_open_files{0};
+  uint32_t            m_close_idle{60};
   bool                m_advise_random{false};
   bool                m_advise_random_hashing{false};
 

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -45,17 +45,20 @@ Download::open(int flags) {
   m_ptr->main()->open(FileList::open_no_create);
   m_ptr->hash_checker()->hashing_ranges().insert(0, m_ptr->main()->file_list()->size_chunks());
 
-  // Mark the files by default to be created and resized. The client
-  // should be allowed to pass a flag that will keep the old settings,
-  // although loading resume data should really handle everything
-  // properly.
+  // Mark non-off files by default to be created and resized. Off files are
+  // only created when a wanted boundary piece actually needs to write into
+  // them (see FileList::create_chunk_part). Resume may still adjust flags.
   int fileFlags = File::flag_create_queued | File::flag_resize_queued;
 
   if (flags & open_enable_fallocate)
     fileFlags |= File::flag_fallocate;
 
-  for (auto& file : *m_ptr->main()->file_list())
+  for (auto& file : *m_ptr->main()->file_list()) {
+    if (file->priority() == PRIORITY_OFF)
+      continue;
+
     file->set_flags(fileFlags);
+  }
 }
 
 void


### PR DESCRIPTION
Adds a close_idle time, files not used within this time period will be closed.

Does a lazy open avoid creating 0-byte, or priority off files.

Do not bulk-open FDs in FileList::open; prepare() opens on demand. Skip create/resize for priority-off files (restore when leaving off); allow boundary writes into off neighbors. Grow short files on write prepare so maps are not past EOF. Sync and close FDs on stop. Close idle open FDs via FileManager::close_idle (default 60s, 0 disables) on the manager tick.