### PR TITLE
storage: close idle open FDs via FileManager

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -110,6 +110,7 @@ Manager::receive_tick() {
 
   m_resource_manager->receive_tick();
   m_chunk_manager->periodic_sync();
+  m_file_manager->periodic_close_idle();
 
   // To ensure the downloads get equal chance over time at using
   // various limited resources, like sockets for handshakes, cycle the

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -227,4 +227,30 @@ FileManager::evict_least_active_from_cache(unsigned int count) {
   return count;
 }
 
+void
+FileManager::periodic_close_idle() {
+  if (m_close_idle == 0 || empty())
+    return;
+
+  auto now  = this_thread::cached_time();
+  auto idle = std::chrono::seconds(m_close_idle);
+
+  size_type i = 0;
+  while (i < size()) {
+    File* f = base_type::operator[](i);
+
+    if (!f->is_open()) {
+      ++i;
+      continue;
+    }
+
+    auto touched = std::chrono::microseconds(f->last_touched());
+
+    if (touched <= now && now - touched >= idle)
+      close(f);
+    else
+      ++i;
+  }
+}
+
 } // namespace torrent

--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -235,22 +235,22 @@ FileManager::periodic_close_idle() {
   auto now  = this_thread::cached_time();
   auto idle = std::chrono::seconds(m_close_idle);
 
-  size_type i = 0;
-  while (i < size()) {
-    File* f = base_type::operator[](i);
+  std::vector<File*> files;
 
-    if (!f->is_open()) {
-      ++i;
+  for (auto* file : *this) {
+    if (!file->is_open())
       continue;
-    }
 
-    auto touched = std::chrono::microseconds(f->last_touched());
+    auto touched = std::chrono::microseconds(file->last_touched());
 
     if (touched <= now && now - touched >= idle)
-      close(f);
-    else
-      ++i;
+      files.push_back(file);
   }
+
+  if (files.empty())
+    return;
+
+  close_files(files);
 }
 
 } // namespace torrent

--- a/src/torrent/data/file_manager.h
+++ b/src/torrent/data/file_manager.h
@@ -42,6 +42,10 @@ public:
   bool                advise_random_hashing() const         { return m_advise_random_hashing; }
   void                set_advise_random_hashing(bool state) { m_advise_random_hashing = state; }
 
+  // Idle seconds before closing open FDs; 0 disables.
+  uint32_t            close_idle() const                    { return m_close_idle; }
+  void                set_close_idle(uint32_t seconds)      { m_close_idle = seconds; }
+
   bool                open(File* file, bool hashing, int prot, int flags);
   void                close(File* file);
 
@@ -51,6 +55,8 @@ public:
   // TODO: Close all files held by a download after hashing. Also flush all memory chunks.
 
   // void                close_least_active();
+
+  void                periodic_close_idle();
 
   // Statistics:
   uint64_t            files_opened_counter() const { return m_files_opened_counter; }
@@ -74,6 +80,7 @@ private:
   unsigned int        evict_least_active_from_cache(unsigned int count);
 
   size_type           m_max_open_files{};
+  uint32_t            m_close_idle{60};
   bool                m_advise_random{};
   bool                m_advise_random_hashing{};
 


### PR DESCRIPTION
This helps a lot for memory usage as the OS free's associated buffers/pages wired to the idle files that used to remain open until max files eviction.

Feature closes idle file FDs after a configurable amount of time rather than leaving them open until eviction presure. Default 60s, 0 disables.

rtorrent:

https://github.com/rakshasa/rtorrent/pull/1888