### PR TITLE
storage: lazy open and skip create/resize for priority-off

### DIFF
--- a/src/download/download_main.cc
+++ b/src/download/download_main.cc
@@ -113,7 +113,7 @@ DownloadMain::open(int flags) {
     throw internal_error("Tried to open a download that is already open");
 
   // TODO: Move file_list open calls to DownloadMain.
-  file_list()->open(true, (flags & FileList::open_no_create));
+  file_list()->open(flags & FileList::open_no_create);
 
   m_chunkList->resize(file_list()->size_chunks());
   m_chunkStatistics->initialize(file_list()->size_chunks());
@@ -159,10 +159,9 @@ void DownloadMain::start(int flags) {
   // references go to zero.
   file_list()->close_all_files();
 
-  // If the FileList::open_no_create flag was not set, our new
-  // behavior is to create all zero-length files with
-  // flag_queued_create set.
-  file_list()->open(false, (flags & ~FileList::open_no_create));
+  // Re-open file list paths/dirs. Files open on demand in prepare().
+  // Zero-length entries are not materialized (no chunk I/O).
+  file_list()->open(flags & ~FileList::open_no_create);
 
   info()->set_flags(DownloadInfo::flag_active);
   chunk_list()->set_flags(ChunkList::flag_active);
@@ -195,6 +194,9 @@ DownloadMain::stop() {
 
   if (info()->upload_unchoked() != 0 || info()->download_unchoked() != 0)
     throw internal_error("DownloadMain::stop(): info()->upload_unchoked() != 0 || info()->download_unchoked() != 0.");
+
+  // Close all FDs here; prepare() reopens on demand.
+  file_list()->close_all_files();
 }
 
 bool

--- a/src/download/download_wrapper.cc
+++ b/src/download/download_wrapper.cc
@@ -8,6 +8,7 @@
 #include "download/chunk_selector.h"
 #include "protocol/handshake_manager.h"
 #include "protocol/peer_connection_base.h"
+#include "manager.h"
 #include "torrent/data/file.h"
 #include "torrent/data/file_list.h"
 #include "torrent/data/file_manager.h"
@@ -346,6 +347,17 @@ DownloadWrapper::receive_update_priorities() {
       this_thread::scheduler()->wait_for(&m_main->delay_partially_done(), 0us);
     else
       this_thread::scheduler()->wait_for(&m_main->delay_partially_restarted(), 0us);
+  }
+
+  // Bulk priority update: drop create/resize and FDs for off files.
+  for (auto& file : *m_main->file_list()) {
+    if (file->priority() != PRIORITY_OFF)
+      continue;
+
+    file->unset_flags(File::flag_create_queued | File::flag_resize_queued);
+
+    if (file->is_open())
+      manager->file_manager()->close(file.get());
   }
 }
 

--- a/src/torrent/data/file.cc
+++ b/src/torrent/data/file.cc
@@ -59,6 +59,22 @@ File::set_completed_chunks(uint32_t v) {
   m_completed = v;
 }
 
+void
+File::set_priority(priority_enum t) {
+  auto old = m_priority;
+  m_priority = t;
+
+  // Off: drop create/resize and close FD; leaving off: restore both flags.
+  if (t == PRIORITY_OFF) {
+    unset_flags(flag_create_queued | flag_resize_queued);
+
+    if (is_open() && !is_padding())
+      manager->file_manager()->close(this);
+  } else if (old == PRIORITY_OFF) {
+    set_flags(flag_create_queued | flag_resize_queued);
+  }
+}
+
 // At some point we should pass flags for deciding if the correct size
 // is necessary, etc.
 

--- a/src/torrent/data/file.h
+++ b/src/torrent/data/file.h
@@ -58,7 +58,7 @@ public:
   uint32_t            range_second() const                     { return m_range.second; }
 
   priority_enum       priority() const                         { return m_priority; }
-  void                set_priority(priority_enum t)            { m_priority = t; }
+  void                set_priority(priority_enum t);
 
   const Path*         path() const                             { return &m_path; }
   Path*               mutable_path()                           { return &m_path; }

--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -372,8 +372,12 @@ struct file_list_cstr_less {
   }
 };
 
+// Activate the file list: freeze paths, create directories, mark entries
+// active, and set is_open(). Does not open file descriptors; File::prepare()
+// opens FDs on demand for chunk I/O. setup_file_path() only does per-entry path/dir
+// setup. Off files are not create-queued (see Download::open / set_priority).
 void
-FileList::open(bool hashing, int flags) {
+FileList::open(int flags) {
   using path_set = std::set<const char*, file_list_cstr_less>;
 
   LT_LOG_FL(INFO, "Opening.", 0);
@@ -393,12 +397,8 @@ FileList::open(bool hashing, int flags) {
       throw storage_error("Could not create directory '" + m_root_dir + "': " + std::strerror(errno));
 
     for (auto& entry : *this) {
-      // We no longer consider it an error to open a previously opened
-      // FileList as we now use the same function to create
-      // non-existent files.
-      //
-      // Since m_is_open is set, we know root dir wasn't changed, thus
-      // we can keep the previously opened file.
+      // Re-opening an already open FileList is allowed (e.g. start after
+      // hashing). Keep any FD already held; prepare() opens the rest on demand.
       if (entry->is_open())
         continue;
 
@@ -421,12 +421,9 @@ FileList::open(bool hashing, int flags) {
       if (entry->path()->empty())
         throw storage_error("Empty filename is not allowed.");
 
-      // Handle directory creation outside of open_file, so we can do
-      // it here if necessary.
-
       entry->set_flags_protected(File::flag_active);
 
-      if (!open_file(&*entry, lastPath, hashing, flags)) {
+      if (!setup_file_path(&*entry, lastPath, flags)) {
         // This needs to check if the error was due to open_no_create
         // being set or not.
         if (!(flags & open_no_create))
@@ -534,7 +531,7 @@ FileList::make_directory(Path::const_iterator path_begin, Path::const_iterator p
 }
 
 bool
-FileList::open_file(File* file_node, const Path& lastPath, bool hashing, int flags) {
+FileList::setup_file_path(File* file_node, const Path& lastPath, int flags) {
   errno = 0;
 
   if (!(flags & open_no_create)) {
@@ -565,7 +562,8 @@ FileList::open_file(File* file_node, const Path& lastPath, bool hashing, int fla
     return false;
   }
 
-  return file_node->prepare(hashing, MemoryChunk::prot_read, 0);
+  // Path/dir validation only; FDs open in File::prepare() on demand.
+  return true;
 }
 
 MemoryChunk
@@ -580,6 +578,10 @@ FileList::create_chunk_part(FileList::iterator itr, uint64_t offset, uint32_t le
     throw internal_error("FileList::chunk_part(...) caught a negative offset", data()->hash());
 
   // Check that offset != length of file.
+
+  // Allow create/resize of off neighbors for boundary writes.
+  if ((*itr)->priority() == PRIORITY_OFF && (prot & MemoryChunk::prot_write))
+    (*itr)->set_flags(File::flag_create_queued | File::flag_resize_queued);
 
   if (!(*itr)->prepare(hashing, prot, 0))
     return MemoryChunk();
@@ -744,7 +746,7 @@ FileList::reset_filesize(int64_t size) {
   m_data.mutable_completed_bitfield()->allocate();
   m_data.mutable_completed_bitfield()->unset_all();
 
-  open(false, open_no_create);
+  open(open_no_create);
 }
 
 } // namespace torrent

--- a/src/torrent/data/file_list.h
+++ b/src/torrent/data/file_list.h
@@ -126,7 +126,7 @@ protected:
 
   void                initialize(uint64_t torrentSize, uint32_t chunkSize) LIBTORRENT_NO_EXPORT;
 
-  void                open(bool hashing, int flags) LIBTORRENT_NO_EXPORT;
+  void                open(int flags) LIBTORRENT_NO_EXPORT;
   void                close() LIBTORRENT_NO_EXPORT;
   void                close_all_files() LIBTORRENT_NO_EXPORT;
 
@@ -146,7 +146,7 @@ protected:
   void                reset_filesize(int64_t) LIBTORRENT_NO_EXPORT;
 
 private:
-  bool                open_file(File* node, const Path& lastPath, bool hashing, int flags) LIBTORRENT_NO_EXPORT;
+  bool                setup_file_path(File* node, const Path& lastPath, int flags) LIBTORRENT_NO_EXPORT;
   void                make_directory(Path::const_iterator pathBegin, Path::const_iterator pathEnd, Path::const_iterator startItr) LIBTORRENT_NO_EXPORT;
 
   Chunk*              create_chunk(uint64_t offset, uint32_t length, bool hashing, int prot) LIBTORRENT_NO_EXPORT;

--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -45,17 +45,20 @@ Download::open(int flags) {
   m_ptr->main()->open(FileList::open_no_create);
   m_ptr->hash_checker()->hashing_ranges().insert(0, m_ptr->main()->file_list()->size_chunks());
 
-  // Mark the files by default to be created and resized. The client
-  // should be allowed to pass a flag that will keep the old settings,
-  // although loading resume data should really handle everything
-  // properly.
+  // Mark non-off files by default to be created and resized. Off files are
+  // only created when a wanted boundary piece actually needs to write into
+  // them (see FileList::create_chunk_part). Resume may still adjust flags.
   int fileFlags = File::flag_create_queued | File::flag_resize_queued;
 
   if (flags & open_enable_fallocate)
     fileFlags |= File::flag_fallocate;
 
-  for (auto& file : *m_ptr->main()->file_list())
+  for (auto& file : *m_ptr->main()->file_list()) {
+    if (file->priority() == PRIORITY_OFF)
+      continue;
+
     file->set_flags(fileFlags);
+  }
 }
 
 void


### PR DESCRIPTION
This feature keeps the disk cleaner by creating the files at write time vs when opening file list, and also avoids completely creating priority OFF files on disk (unless needed for completion of a non-OFF file).

FileList::open sets up paths/dirs only; prepare() opens FDs on demand. Sync and close all FDs on download stop.

Do not queue create/resize for PRIORITY_OFF; restore when leaving off and close any open FD. Allow boundary writes into off neighbors by re-queuing create/resize in create_chunk_part.