### PR TITLE
fix: use optional for request-list piece affinity

### DIFF
--- a/src/download/delegator.cc
+++ b/src/download/delegator.cc
@@ -11,7 +11,7 @@
 namespace torrent {
 
 std::vector<BlockTransfer*>
-Delegator::delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPieces) {
+Delegator::delegate(PeerChunks* peerChunks, std::optional<uint32_t> affinity, uint32_t maxPieces) {
   // TODO: Make sure we don't queue the same piece several time on the same peer when
   // it timeout cancels them.
   std::vector<BlockTransfer*> new_transfers;
@@ -22,12 +22,12 @@ Delegator::delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPiece
   // in progress.
 
   // TODO: What if the hash failed? Don't want data from that peer again.
-  if (affinity >= 0) {
+  if (affinity) {
     for (BlockList* itr : m_transfers) {
       if (new_transfers.size() >= maxPieces)
         return new_transfers;
 
-      if (affinity == itr->index())
+      if (*affinity == itr->index())
         delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
     }
   }

--- a/src/download/delegator.h
+++ b/src/download/delegator.h
@@ -2,6 +2,7 @@
 #define LIBTORRENT_DELEGATOR_H
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -26,7 +27,7 @@ public:
   TransferList*       transfer_list()                     { return &m_transfers; }
   const TransferList* transfer_list() const               { return &m_transfers; }
 
-  std::vector<BlockTransfer*> delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPieces);
+  std::vector<BlockTransfer*> delegate(PeerChunks* peerChunks, std::optional<uint32_t> affinity, uint32_t maxPieces);
 
   bool               get_aggressive() const               { return m_aggressive; }
   void               set_aggressive(bool a)               { m_aggressive = a; }

--- a/src/protocol/request_list.h
+++ b/src/protocol/request_list.h
@@ -2,6 +2,7 @@
 #define LIBTORRENT_REQUEST_LIST_H
 
 #include <deque>
+#include <optional>
 #include <vector>
 
 #include "torrent/data/block_transfer.h"
@@ -103,7 +104,7 @@ private:
 
   queues_type          m_queues;
 
-  int32_t              m_affinity{-1};
+  std::optional<uint32_t> m_affinity;
 
   std::chrono::microseconds m_last_choke{};
   std::chrono::microseconds m_last_unchoke{};


### PR DESCRIPTION
Passing int32_t -1 as uint32_t made affinity >= 0 always true, so the affinity scan always ran with a sentinel of 0xffffffff.