### PR TITLE
fix: implement ChunkSelector::advance_position

### DIFF
--- a/src/download/chunk_selector.cc
+++ b/src/download/chunk_selector.cc
@@ -245,13 +245,13 @@ next_wanted_in_ranges(const Bitfield* untouched,
     return ChunkSelector::invalid_chunk;
 
   for (auto itr = ranges->find(first); itr != ranges->end() && itr->first < last; ++itr) {
-    uint32_t f = std::max(first, itr->first);
-    uint32_t l = std::min(last, itr->second);
+    uint32_t range_first = std::max(first, itr->first);
+    uint32_t range_last  = std::min(last, itr->second);
 
-    for (uint32_t i = f; i < l; ++i) {
-      if (untouched->get(i))
-        return i;
-    }
+    uint32_t chunk = untouched->find_first_set(range_first, range_last);
+
+    if (chunk != range_last)
+      return chunk;
   }
 
   return ChunkSelector::invalid_chunk;

--- a/src/download/chunk_selector.cc
+++ b/src/download/chunk_selector.cc
@@ -235,18 +235,58 @@ ChunkSelector::search_linear_byte(utils::PartialQueue* pq, uint32_t index, Bitfi
   return true;
 }
 
+// First untouched index in [first, last) that lies in priority ranges.
+static uint32_t
+next_wanted_in_ranges(const Bitfield* untouched,
+                      const download_data::priority_ranges* ranges,
+                      uint32_t first,
+                      uint32_t last) {
+  if (first >= last)
+    return ChunkSelector::invalid_chunk;
+
+  for (auto itr = ranges->find(first); itr != ranges->end() && itr->first < last; ++itr) {
+    uint32_t f = std::max(first, itr->first);
+    uint32_t l = std::min(last, itr->second);
+
+    for (uint32_t i = f; i < l; ++i) {
+      if (untouched->get(i))
+        return i;
+    }
+  }
+
+  return ChunkSelector::invalid_chunk;
+}
+
 void
 ChunkSelector::advance_position() {
+  if (empty()) {
+    m_position = invalid_chunk;
+    return;
+  }
 
-  // Need to replace with a special-purpose function for finding the
-  // next position.
+  // Start from the current cursor (inclusive). Callers either leave a random /
+  // sticky index that may still be wanted, or have just cleared m_position via
+  // using_index so this index is no longer untouched and we move past it.
+  uint32_t start = m_position;
 
-//   int position = m_position;
+  if (start == invalid_chunk || start >= size())
+    start = 0;
 
-//   ((m_position = search_linear(&m_bitfield, &m_highPriority, position, size())) == invalid_chunk &&
-//    (m_position = search_linear(&m_bitfield, &m_highPriority, 0, position)) == invalid_chunk &&
-//    (m_position = search_linear(&m_bitfield, &m_normalPriority, position, size())) == invalid_chunk &&
-//    (m_position = search_linear(&m_bitfield, &m_normalPriority, 0, position)) == invalid_chunk);
+  const Bitfield* untouched = m_data->untouched_bitfield();
+  const auto*     high      = m_data->high_priority();
+  const auto*     normal    = m_data->normal_priority();
+
+  // Prefer high priority, then normal; wrap [start, size) then [0, start).
+  uint32_t pos = next_wanted_in_ranges(untouched, high, start, size());
+
+  if (pos == invalid_chunk)
+    pos = next_wanted_in_ranges(untouched, high, 0, start);
+  if (pos == invalid_chunk)
+    pos = next_wanted_in_ranges(untouched, normal, start, size());
+  if (pos == invalid_chunk)
+    pos = next_wanted_in_ranges(untouched, normal, 0, start);
+
+  m_position = pos;
 }
 
 } // namespace torrent

--- a/src/torrent/bitfield.cc
+++ b/src/torrent/bitfield.cc
@@ -131,4 +131,16 @@ Bitfield::unset_range(size_type first, size_type last) {
     unset(first++);
 }
 
+Bitfield::size_type
+Bitfield::find_first_set(size_type first, size_type last) const {
+  while (first < last) {
+    if (get(first))
+      return first;
+
+    ++first;
+  }
+
+  return last;
+}
+
 } // namespace torrent

--- a/src/torrent/bitfield.h
+++ b/src/torrent/bitfield.h
@@ -58,6 +58,9 @@ public:
 
   bool                get(size_type idx) const      { return m_data[idx / 8] & mask_at(idx % 8); }
 
+  // First set index in [first, last), or last if none.
+  size_type           find_first_set(size_type first, size_type last) const;
+
   void                set(size_type idx)            { m_set += !get(idx); m_data[idx / 8] |=  mask_at(idx % 8); }
   void                unset(size_type idx)          { m_set -=  get(idx); m_data[idx / 8] &= ~mask_at(idx % 8); }
 


### PR DESCRIPTION
The cursor was never moved after finishing the piece at m_position or when refreshing priorities, so searches kept restarting from a stale index. Find the next untouched high- then normal-priority index, wrapping the bitfield, matching the old intended behavior.