### PR TITLE
Reject truncated integers in bencode skip parser

### DIFF
--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -292,8 +292,11 @@ object_read_bencode_skip_c(const char* first, const char* last) {
 
     switch (*first) {
     case 'i':
-      if (first != last && *++first == '-') {
-        if (first != last && *++first == '0')
+      if (++first == last)
+        throw torrent::bencode_error("Invalid bencode data.");
+
+      if (*first == '-') {
+        if (++first == last || *first == '0')
           throw torrent::bencode_error("Invalid bencode data.");
       }
 

--- a/test/torrent/object_static_map_test.cc
+++ b/test/torrent/object_static_map_test.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <array>
+
 #include <torrent/object.h>
 #include <torrent/object_stream.h>
 #include "torrent/object_static_map.h"
@@ -268,6 +270,15 @@ ObjectStaticMapTest::test_read_single() {
   CPPUNIT_ASSERT(static_map_read_bencode_exception(map_incomplete, "d1:b"));
   CPPUNIT_ASSERT(static_map_read_bencode_exception(map_incomplete, "d1:bi1"));
   CPPUNIT_ASSERT(static_map_read_bencode_exception(map_incomplete, "d1:bi1e"));
+}
+
+void
+ObjectStaticMapTest::test_read_unknown_truncated_value() {
+  test_single_type map;
+  const std::array<char, 8> input = {'d', '1', ':', 'x', 'l', 'l', 'l', 'i'};
+
+  CPPUNIT_ASSERT_THROW(torrent::static_map_read_bencode(input.data(), input.data() + input.size(), map),
+                       torrent::bencode_error);
 }
 
 void

--- a/test/torrent/object_static_map_test.h
+++ b/test/torrent/object_static_map_test.h
@@ -11,6 +11,7 @@ class ObjectStaticMapTest : public CppUnit::TestFixture {
 
   CPPUNIT_TEST(test_read_empty);
   CPPUNIT_TEST(test_read_single);
+  CPPUNIT_TEST(test_read_unknown_truncated_value);
   CPPUNIT_TEST(test_read_single_raw);
   CPPUNIT_TEST(test_read_raw_types);
   CPPUNIT_TEST(test_read_multiple);
@@ -32,6 +33,7 @@ public:
   // Proper unit tests:
   void test_read_empty();
   void test_read_single();
+  void test_read_unknown_truncated_value();
   void test_read_single_raw();
   void test_read_raw_types();
   void test_read_multiple();
@@ -41,4 +43,3 @@ public:
   void test_write_single();
   void test_write_multiple();
 };
-


### PR DESCRIPTION
A truncated integer in an unknown bencoded dictionary value advances the
skip parser past the input boundary before validation. A connected peer can
trigger an out-of-bounds read while processing an extension message.

Check the cursor after each increment and add a regression test for an
exact-length truncated input.