### PR TITLE
Bind DHT tokens to infohashes and limit tracker allocation

### DIFF
--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -2,6 +2,7 @@
 
 #include "dht_router.h"
 
+#include <algorithm>
 #include <cassert>
 
 #include "dht_bucket.h"
@@ -141,7 +142,7 @@ DhtRouter::cancel_announce(const HashString& info_hash, std::weak_ptr<TrackerDht
 }
 
 DhtTracker*
-DhtRouter::get_tracker(const HashString& hash, bool create) {
+DhtRouter::get_tracker(const HashString& hash, bool create, uint32_t source) {
   auto itr = m_trackers.find(hash);
 
   if (itr != m_trackers.end())
@@ -150,7 +151,15 @@ DhtRouter::get_tracker(const HashString& hash, bool create) {
   if (!create)
     return NULL;
 
-  auto [tr, inserted] = m_trackers.emplace(hash, new DhtTracker());
+  if (m_trackers.size() >= max_trackers)
+    return NULL;
+
+  if (std::count_if(m_trackers.begin(), m_trackers.end(),
+                    [source](const auto& tracker) { return tracker.second->creator() == source; }) >=
+      max_trackers_per_peer)
+    return NULL;
+
+  auto [tr, inserted] = m_trackers.emplace(hash, new DhtTracker(source));
 
   if (!inserted)
     throw internal_error("DhtRouter::get_tracker did not actually insert tracker.");
@@ -485,7 +494,7 @@ DhtRouter::receive_timeout() {
 }
 
 char*
-DhtRouter::generate_token(const sockaddr* sa, int token, char buffer[20]) {
+DhtRouter::generate_token(const sockaddr* sa, const HashString& hash, int token, char buffer[20]) {
   if (!sa_is_inet(sa))
     throw internal_error("DhtRouter::generate_token called with non-inet address.");
 
@@ -495,13 +504,14 @@ DhtRouter::generate_token(const sockaddr* sa, int token, char buffer[20]) {
   sha.init();
   sha.update(&token, sizeof(token));
   sha.update(&key, 4);
+  sha.update(hash.data(), HashString::size_data);
   sha.final_c(buffer);
 
   return buffer;
 }
 
 bool
-DhtRouter::token_valid(raw_string token, const sockaddr* sa) const {
+DhtRouter::token_valid(raw_string token, const sockaddr* sa, const HashString& hash) const {
   if (token.size() != size_token)
     return false;
 
@@ -513,8 +523,8 @@ DhtRouter::token_valid(raw_string token, const sockaddr* sa) const {
   // Else if token recently changed, some clients may be using the older one.
   // That way a token is valid for 15-30 minutes, instead of 0-15.
   return
-    token == raw_string(generate_token(sa, m_curToken, reference), size_token) ||
-    token == raw_string(generate_token(sa, m_prevToken, reference), size_token);
+    token == raw_string(generate_token(sa, hash, m_curToken, reference), size_token) ||
+    token == raw_string(generate_token(sa, hash, m_prevToken, reference), size_token);
 }
 
 DhtNode*

--- a/src/dht/dht_router.h
+++ b/src/dht/dht_router.h
@@ -48,7 +48,7 @@ public:
   void                cancel_announce(const HashString& info_hash, std::weak_ptr<TrackerDht> tracker);
 
   // Returns NULL if not tracking the torrent unless create is true.
-  DhtTracker*         get_tracker(const HashString& hash, bool create);
+  DhtTracker*         get_tracker(const HashString& hash, bool create, uint32_t source = 0);
 
   // Check if we are interested in inserting a new node of the given ID
   // into our table (i.e. if we have space or bad nodes in the corresponding bucket).
@@ -84,8 +84,8 @@ public:
   Object*             store_cache(Object* container) const;
 
   // Create and verify a token. Tokens are valid between 15-30 minutes from creation.
-  raw_string          make_token(const sockaddr* sa, char* buffer) const;
-  bool                token_valid(raw_string token, const sockaddr* sa) const;
+  raw_string          make_token(const sockaddr* sa, const HashString& hash, char* buffer) const;
+  bool                token_valid(raw_string token, const sockaddr* sa, const HashString& hash) const;
 
   tracker::DhtController::statistics_type get_statistics() const;
   void                                    reset_statistics()  { m_server.reset_statistics(); }
@@ -99,6 +99,12 @@ private:
 
   // Maximum number of potential contacts to keep until bootstrap complete.
   static constexpr unsigned int num_bootstrap_contacts = 64;
+
+  // Maximum number of torrents for which remote peers are tracked.
+  static constexpr size_t max_trackers = 4096;
+
+  // Maximum number of torrents a remote peer can create.
+  static constexpr size_t max_trackers_per_peer = 64;
 
   using DhtBucketList = std::map<const HashString, DhtBucket*>;
 
@@ -118,7 +124,7 @@ private:
   void                receive_timeout_bootstrap();
 
   // buffer needs to hold an SHA1 hash (20 bytes), not just the token (8 bytes)
-  static char*        generate_token(const sockaddr* sa, int token, char buffer[20]);
+  static char*        generate_token(const sockaddr* sa, const HashString& hash, int token, char buffer[20]);
 
   utils::SchedulerEntry m_task_timeout;
 
@@ -142,8 +148,8 @@ private:
 };
 
 inline raw_string
-DhtRouter::make_token(const sockaddr* sa, char* buffer) const {
-  return raw_string(generate_token(sa, m_curToken, buffer), size_token);
+DhtRouter::make_token(const sockaddr* sa, const HashString& hash, char* buffer) const {
+  return raw_string(generate_token(sa, hash, m_curToken, buffer), size_token);
 }
 
 } // namespace torrent

--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -332,15 +332,15 @@ DhtServer::create_find_node_response(const DhtMessage& req, DhtMessage& reply) {
 
 void
 DhtServer::create_get_peers_response(const DhtMessage& req, const sockaddr* sa, DhtMessage& reply) {
-  reply[key_r_token] = m_router->make_token(sa, reply.data_end);
-  reply.data_end += reply[key_r_token].as_raw_string().size();
-
   raw_string info_hash_str = req[key_a_infoHash].as_raw_string();
 
   if (info_hash_str.size() < HashString::size_data)
     throw dht_error(dht_error_protocol, "info hash too short");
 
   const HashString* info_hash = HashString::cast_from(info_hash_str.data());
+
+  reply[key_r_token] = m_router->make_token(sa, *info_hash, reply.data_end);
+  reply.data_end += reply[key_r_token].as_raw_string().size();
 
   DhtTracker* tracker = m_router->get_tracker(*info_hash, false);
 
@@ -365,15 +365,21 @@ DhtServer::create_announce_peer_response(const DhtMessage& req, const sockaddr* 
   if (info_hash.size() < HashString::size_data)
     throw dht_error(dht_error_protocol, "info hash too short");
 
-  if (!m_router->token_valid(req[key_a_token].as_raw_string(), sa))
+  const HashString* hash = HashString::cast_from(info_hash.data());
+
+  if (!m_router->token_valid(req[key_a_token].as_raw_string(), sa, *hash))
     throw dht_error(dht_error_protocol, "Token invalid.");
 
   if (!sa_is_inet(sa))
     throw internal_error("DhtServer::create_announce_peer_response called with non-inet address.");
 
-  DhtTracker* tracker = m_router->get_tracker(*HashString::cast_from(info_hash.data()), true);
+  uint32_t source = reinterpret_cast<const sockaddr_in*>(sa)->sin_addr.s_addr;
+  DhtTracker* tracker = m_router->get_tracker(*hash, true, source);
 
-  tracker->add_peer(reinterpret_cast<const sockaddr_in*>(sa)->sin_addr.s_addr, req[key_a_port].as_value());
+  if (tracker == nullptr)
+    throw dht_error(dht_error_generic, "Too many tracked torrents.");
+
+  tracker->add_peer(source, req[key_a_port].as_value());
 }
 
 void

--- a/src/dht/dht_tracker.h
+++ b/src/dht/dht_tracker.h
@@ -23,8 +23,11 @@ public:
   // large peer tables for very active torrents.
   static constexpr unsigned int max_size = 128;
 
+  explicit            DhtTracker(uint32_t creator) : m_creator(creator) {}
+
   bool                empty() const                { return m_peers.empty(); }
   size_t              size() const                 { return m_peers.size(); }
+  uint32_t            creator() const              { return m_creator; }
 
   void                add_peer(uint32_t addr_n, uint16_t port);
   raw_list            get_peers(unsigned int maxPeers = max_peers);
@@ -48,6 +51,7 @@ private:
 
   using PeerList = std::vector<BencodeAddress>;
 
+  uint32_t               m_creator;
   PeerList               m_peers;
   std::vector<uint32_t>  m_lastSeen;
 };


### PR DESCRIPTION
DHT announce tokens are currently bound only to the source address. A remote peer can obtain one token and reuse it to announce arbitrary infohashes, creating a `DhtTracker` for each hash. The table has no global limit, so state grows until cleanup.

Bind tokens to their requested infohash, cap remote tracker entries at 4,096, and limit each source to 64 created entries. Existing tracker entries remain serviceable.