### PR TITLE
Limit queued upload requests per peer

### DIFF
--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -115,7 +115,7 @@ ProtocolExtension::generate_handshake_message() {
 
   message[key_p] = runtime::listen_port();
   message[key_v] = raw_string::from_c_str("libTorrent " VERSION);
-  message[key_reqq] = 2048;  // maximum request queue size
+  message[key_reqq] = max_request_queue_size;
 
   if (!m_download->info()->is_meta_download())
     message[key_metadataSize] = m_download->info()->metadata_size();

--- a/src/protocol/extensions.h
+++ b/src/protocol/extensions.h
@@ -44,6 +44,9 @@ public:
   static constexpr size_t metadata_piece_shift = 14;
   static constexpr size_t metadata_piece_size  = 1 << metadata_piece_shift;
 
+  // Maximum number of upload requests accepted from one peer.
+  static constexpr size_t max_request_queue_size = 2048;
+
   ProtocolExtension();
   ~ProtocolExtension() { delete [] m_read; }
   ProtocolExtension(const ProtocolExtension&) = default;

--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -804,17 +804,27 @@ PeerConnectionBase::up_chunk_release() {
 
 void
 PeerConnectionBase::read_request_piece(const Piece& p) {
-  auto itr = std::find(m_peerChunks.upload_queue()->begin(),
-                       m_peerChunks.upload_queue()->end(),
-                       p);
+  auto upload_queue = m_peerChunks.upload_queue();
 
-  if (m_upChoke.choked() || itr != m_peerChunks.upload_queue()->end() || p.length() > (1 << 17)) {
+  if (m_upChoke.choked() ||
+      upload_queue->size() >= ProtocolExtension::max_request_queue_size ||
+      p.length() > (1 << 17)) {
     LT_LOG_PIECE_EVENTS("(up)   request_ignored  %" PRIu32 " %" PRIu32 " %" PRIu32,
                         p.index(), p.offset(), p.length());
     return;
   }
 
-  m_peerChunks.upload_queue()->push_back(p);
+  auto itr = std::find(upload_queue->begin(),
+                       upload_queue->end(),
+                       p);
+
+  if (itr != upload_queue->end()) {
+    LT_LOG_PIECE_EVENTS("(up)   request_ignored  %" PRIu32 " %" PRIu32 " %" PRIu32,
+                        p.index(), p.offset(), p.length());
+    return;
+  }
+
+  upload_queue->push_back(p);
   write_insert_poll_safe();
 
   LT_LOG_PIECE_EVENTS("(up)   request_added    %" PRIu32 " %" PRIu32 " %" PRIu32,


### PR DESCRIPTION
An unchoked peer can send an unbounded stream of distinct request messages while withholding reads. The per-peer queue grows without a limit and duplicate detection scans it linearly, allowing CPU and memory exhaustion.

Limit queued upload requests to the 2048 requests advertised through `reqq`. The limit is applied before duplicate detection and queue insertion.