### PR TITLE
Limit tracker peer insertion to available-list capacity

### DIFF
--- a/src/torrent/peer/peer_list.cc
+++ b/src/torrent/peer/peer_list.cc
@@ -101,13 +101,19 @@ uint32_t
 PeerList::insert_available(const void* al) {
   auto address_list = static_cast<const AddressList*>(al);
 
+  if (m_available_list->size() >= m_available_list->max_size())
+    return 0;
+
   uint32_t inserted = 0;
   uint32_t invalid = 0;
   uint32_t unneeded = 0;
   uint32_t updated = 0;
 
-  if (m_available_list->size() + address_list->size() > m_available_list->capacity())
-    m_available_list->reserve(m_available_list->size() + address_list->size() + 128);
+  auto remaining = m_available_list->max_size() - m_available_list->size();
+  auto reserve_size = m_available_list->size() + std::min(remaining, address_list->size());
+
+  if (reserve_size > m_available_list->capacity())
+    m_available_list->reserve(reserve_size);
 
   // Optimize this so that we don't traverse the tree for every
   // insert, since we know 'al' is sorted.
@@ -115,7 +121,12 @@ PeerList::insert_available(const void* al) {
   auto avail_itr  = m_available_list->begin();
   auto avail_last = m_available_list->end();
 
-  for (const auto& addr : *address_list) {
+  auto addr_itr  = address_list->begin();
+  auto addr_last = address_list->end();
+
+  while (addr_itr != addr_last &&
+         m_available_list->size() < m_available_list->max_size()) {
+    const auto& addr = *addr_itr++;
     auto addr_str = sa_addr_str(&addr.sa);
     auto port = sa_port(&addr.sa);
 


### PR DESCRIPTION
A tracker announce response can contain a large compact peer list. `PeerList::insert_available` reserves and processes every endpoint, bypassing `AvailableList`'s configured limit. Because duplicate checks are linear, a configured malicious tracker can cause excessive CPU work and retain far more peer entries than intended.

Reserve only the remaining available-list capacity and stop processing entries once the limit is reached.