### PR TITLE
net: do not throw when a start callback outlives its CurlGet

### DIFF
--- a/src/net/curl_get.cc
+++ b/src/net/curl_get.cc
@@ -179,8 +179,9 @@ CurlGet::start(const std::shared_ptr<CurlGet>& curl_get, CurlStack* stack) {
   if (self->m_was_started)
     throw torrent::internal_error("CurlGet::start() called on an already started object.");
 
-  self->m_was_started  = true;
-  self->m_stack_thread = stack->thread();
+  self->m_was_started   = true;
+  self->m_start_pending = true;
+  self->m_stack_thread  = stack->thread();
 
   stack->thread()->callback(self->m_callback_id, [stack, curl_get]() {
       stack->start_get(curl_get);
@@ -210,6 +211,7 @@ CurlGet::close_self(const std::shared_ptr<CurlGet>& curl_get, system::Thread* ca
   if (m_stack == nullptr) {
     if (m_was_started) {
       m_stack_thread     = nullptr;
+      m_start_pending    = false;
       m_was_started      = false;
       m_was_closed       = false;
       m_prepare_canceled = false;
@@ -236,6 +238,11 @@ bool
 CurlGet::prepare_start_unsafe(CurlStack* stack) {
   if (m_handle != nullptr)
     throw torrent::internal_error("CurlGet::prepare_start(...) called on a stacked object.");
+
+  if (!m_start_pending)
+    return false;
+
+  m_start_pending = false;
 
   if (m_stream == nullptr)
     throw torrent::internal_error("CurlGet::prepare_start(...) called with a null stream.");
@@ -378,6 +385,7 @@ CurlGet::cleanup_unsafe() {
   }
 
   m_stack_thread     = nullptr;
+  m_start_pending    = false;
   m_was_started      = false;
   m_was_closed       = false;
   m_prepare_canceled = false;

--- a/src/net/curl_get.h
+++ b/src/net/curl_get.h
@@ -130,6 +130,7 @@ private:
 
   bool                m_active{};
   bool                m_prepare_canceled{};
+  bool                m_start_pending{};
   bool                m_was_started{};
   bool                m_was_closed{};
   bool                m_was_cleaned_up{};

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -106,7 +106,9 @@ LibTorrent_Test_Data_SOURCES = $(LibTorrent_Test_Common) \
 	data/test_hash_queue.cc \
 	data/test_hash_queue.h
 
-LibTorrent_Test_Net_SOURCES = $(LibTorrent_Test_Common)
+LibTorrent_Test_Net_SOURCES = $(LibTorrent_Test_Common) \
+	net/test_curl_get.cc \
+	net/test_curl_get.h
 
 LibTorrent_Test_Tracker_SOURCES = $(LibTorrent_Test_Common) \
 	tracker/test_tracker_http.cc \

--- a/test/net/test_curl_get.cc
+++ b/test/net/test_curl_get.cc
@@ -1,0 +1,27 @@
+#include "config.h"
+
+#include "test/net/test_curl_get.h"
+
+#include <sstream>
+
+#include "net/curl_get.h"
+#include "net/curl_stack.h"
+#include "torrent/exceptions.h"
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_curl_get, "net");
+
+void
+test_curl_get::test_start_get_after_close() {
+  torrent::net::CurlStack stack(m_main_thread.get());
+
+  auto stream   = std::make_shared<std::stringstream>();
+  auto curl_get = std::make_shared<torrent::net::CurlGet>("http://127.0.0.1:1/announce", stream);
+
+  torrent::net::CurlGet::start(curl_get, &stack);
+  torrent::net::CurlGet::close_and_cancel_callbacks(curl_get, nullptr);
+
+  CPPUNIT_ASSERT_NO_THROW(stack.start_get(curl_get));
+  CPPUNIT_ASSERT(!curl_get->is_stacked());
+
+  stack.shutdown();
+}

--- a/test/net/test_curl_get.h
+++ b/test/net/test_curl_get.h
@@ -1,0 +1,17 @@
+#ifndef LIBTORRENT_TEST_NET_TEST_CURL_GET_H
+#define LIBTORRENT_TEST_NET_TEST_CURL_GET_H
+
+#include "helpers/test_main_thread.h"
+
+class test_curl_get : public TestFixtureWithMainThread {
+  CPPUNIT_TEST_SUITE(test_curl_get);
+
+  CPPUNIT_TEST(test_start_get_after_close);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void test_start_get_after_close();
+};
+
+#endif


### PR DESCRIPTION
CurlGet::start() queues start_get() on the stack thread, and close_self() on a get that was never stacked resets the object so it can be reused. Thread::cancel_callback() cannot stop a callback that has already been dispatched, so start_get() could run against a reset get and throw

  CurlGet::prepare_start(...) called on an object that was not started.

from the net thread. Thread::event_loop() rethrows internal_error, which terminates the process.

Seen in production with a tracker announce that is closed and re-armed in the same instant, e.g. when a stop event is followed immediately by a start event for the same download: the stopped announce is closed before the net thread has run its start callback, and the process aborts minutes later.

Track the pending start explicitly so a withdrawn start becomes a no-op rather than a fatal error. The added test reproduces the sequence and fails with the above exception without the fix.