### PR TITLE
net: break the CurlGet self-reference cycle in HttpGet slots

### DIFF
--- a/src/torrent/net/http_get.cc
+++ b/src/torrent/net/http_get.cc
@@ -140,8 +140,8 @@ HttpGet::add_done_slot(system::Thread* thread, const std::function<void()>& fn) 
   if (m_curl_get == nullptr)
     throw torrent::internal_error("HttpGet::add_done_slot() called on an invalid HttpGet object.");
 
-  m_curl_get->add_done_slot([thread, fn, curl_get = m_curl_get]() {
-      thread->callback(curl_get->callback_id(), [fn]() {
+  m_curl_get->add_done_slot([thread, fn, callback_id = m_curl_get->callback_id()]() mutable {
+      thread->callback(callback_id, [fn]() {
           fn();
         });
     });
@@ -152,8 +152,8 @@ HttpGet::add_failed_slot(system::Thread* thread, const std::function<void(const 
   if (m_curl_get == nullptr)
     throw torrent::internal_error("HttpGet::add_failed_slot() called on an invalid HttpGet object.");
 
-  m_curl_get->add_failed_slot([thread, fn, curl_get = m_curl_get](const std::string& error) {
-      thread->callback(curl_get->callback_id(), [fn, error]() {
+  m_curl_get->add_failed_slot([thread, fn, callback_id = m_curl_get->callback_id()](const std::string& error) mutable {
+      thread->callback(callback_id, [fn, error]() {
           fn(error);
         });
     });

--- a/test/net/test_curl_get.cc
+++ b/test/net/test_curl_get.cc
@@ -2,11 +2,13 @@
 
 #include "test/net/test_curl_get.h"
 
+#include <memory>
 #include <sstream>
 
 #include "net/curl_get.h"
 #include "net/curl_stack.h"
 #include "torrent/exceptions.h"
+#include "torrent/net/http_get.h"
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_curl_get, "net");
 
@@ -24,4 +26,26 @@ test_curl_get::test_start_get_after_close() {
   CPPUNIT_ASSERT(!curl_get->is_stacked());
 
   stack.shutdown();
+}
+
+// Adding slots must not make the CurlGet hold a reference to itself, as that would keep its url and
+// its response stream alive for the lifetime of the process.
+void
+test_curl_get::test_slots_do_not_retain_stream() {
+  std::weak_ptr<std::stringstream> weak_stream;
+
+  {
+    auto stream = std::make_shared<std::stringstream>();
+    weak_stream = stream;
+
+    torrent::net::HttpGet http_get;
+    http_get.reset("http://127.0.0.1:1/announce", stream);
+
+    http_get.add_done_slot(m_main_thread.get(), []() {});
+    http_get.add_failed_slot(m_main_thread.get(), [](const std::string&) {});
+
+    CPPUNIT_ASSERT(!weak_stream.expired());
+  }
+
+  CPPUNIT_ASSERT(weak_stream.expired());
 }

--- a/test/net/test_curl_get.h
+++ b/test/net/test_curl_get.h
@@ -7,11 +7,13 @@ class test_curl_get : public TestFixtureWithMainThread {
   CPPUNIT_TEST_SUITE(test_curl_get);
 
   CPPUNIT_TEST(test_start_get_after_close);
+  CPPUNIT_TEST(test_slots_do_not_retain_stream);
 
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void test_start_get_after_close();
+  void test_slots_do_not_retain_stream();
 };
 
 #endif


### PR DESCRIPTION
`HttpGet::add_done_slot()` and `HttpGet::add_failed_slot()` store a lambda in the
CurlGet's own `m_signal_done` / `m_signal_failed` list while capturing a
`std::shared_ptr` to that same CurlGet:

```cpp
m_curl_get->add_done_slot([thread, fn, curl_get = m_curl_get]() {
    thread->callback(curl_get->callback_id(), [fn]() {
        fn();
      });
  });
```

The object therefore holds a strong reference to itself. Its use count can never
reach zero, so it is never destroyed.

Nothing breaks the cycle afterwards. `m_signal_done` and `m_signal_failed` are only
ever appended to, by `add_done_slot()` / `add_failed_slot()`, and invoked, by
`utils::slot_list_call()` — which takes the container by const reference and so
cannot clear it. `CurlGet::cleanup_unsafe()` calls `curl_easy_cleanup()` on
`m_handle` and resets the state flags, but does not touch the slot lists, so the
captured `shared_ptr` survives it. The retention is therefore not visible in file
descriptor or socket counts.

Each retained CurlGet also keeps `m_url` and `m_stream` alive. For tracker requests
`m_stream` aliases `TrackerHttp::m_data`, the `std::stringstream` holding the full
response body. `TrackerHttp::close_directly()` calls `m_data.reset()`, but the
CurlGet's copy of the shared_ptr keeps the buffer alive regardless, so the response
is retained for the process lifetime along with the request URL.

The cycle predates 42583e54, but it was bounded before it. `HttpGet::reset()` only
allocated a CurlGet when `m_curl_get` was null, and `TrackerHttp` attached both slots
once in its constructor, so at most one CurlGet per tracker became immortal. That
commit made `reset()` allocate unconditionally and moved the slot attachments out of
the constructor into `send_event_unsafe()` and `send_scrape_unsafe()`, which both
call `reset()` and then attach the slots on every request. One CurlGet is now
retained per announce and per scrape, so the growth is linear in request rate rather
than bounded by the number of trackers.

The captured CurlGet is only used to read `callback_id()`. `system::callback_id` is a
`std::shared_ptr<std::atomic<uint32_t>>`, `m_callback_id` is set once in the CurlGet
constructor and never reassigned, and `Thread::callback()` mutates it through the
pointer rather than rebinding it. Capturing the id by value therefore leaves the copy
and the member referring to the same atomic, so the cancellation semantics are
unchanged while the reference to the CurlGet itself is dropped. `mutable` is required
because `Thread::callback()` takes `system::callback_id&`.

The slot payload and the cancellation path are otherwise unchanged.

`test_curl_get::test_slots_do_not_retain_stream` covers the lifetime: it attaches
both slots and asserts that the response stream is released once the HttpGet goes
out of scope. It fails on current master and passes with this change.
