### PR TITLE
data: do not close unopened files when FileList::open() fails

### DIFF
--- a/src/torrent/data/file_list.cc
+++ b/src/torrent/data/file_list.cc
@@ -441,10 +441,15 @@ FileList::open(bool hashing, int flags) {
     }
 
   } catch (const local_error& e) {
+    std::vector<File*> files;
+    files.reserve(size());
+
     for (auto& entry : *this) {
       entry->unset_flags_protected(File::flag_active);
-      manager->file_manager()->close(entry.get());
+      files.push_back(entry.get());
     }
+
+    manager->file_manager()->close_files(files);
 
     if (itr == end()) {
       LT_LOG_FL(ERROR, "Failed to prepare file list: %s", e.what());


### PR DESCRIPTION
FileList::open() hands every entry to FileManager::close() from its error handler, including entries it never opened. FileManager::close() calls detach(), which asserts the file is open and not padding, so any storage_error during open aborts the process:

  rtorrent: data/file_manager.cc:99: int torrent::FileManager::detach(torrent::File*):
            Assertion `file->is_open() && !file->is_padding()' failed.

Reproduced in production: a download was started with its data removed outside the client, so open_file failed with ENOENT while creating, and the client aborted on every start instead of reporting the error and leaving the download stopped.

FileList::close() already uses FileManager::close_files(), which skips entries that are not open and padding entries. Use it in the error handler too, so both paths close the same way.