### PR TITLE
fix: FileManager check if the file can be closed

### DIFF
--- a/src/torrent/data/file_manager.cc
+++ b/src/torrent/data/file_manager.cc
@@ -232,6 +232,11 @@ FileManager::evict_least_active_from_cache(unsigned int count) {
     if (pair.first->last_touched() != pair.second)
       continue;
 
+    if (!pair.first->is_open())
+      continue;
+
+    assert(!pair.first->is_padding());
+
     files.push_back(pair.first);
     count--;
   }


### PR DESCRIPTION
Ignore files that are not open, or are padding. In case some cached files are already closed, evict_least_active will receive a larger number of closed files than actually closed, resulting in "failed to evict enough files".