### PR TITLE
Bound HTTP tracker scrape responses

### DIFF
--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -199,6 +199,9 @@ TrackerHttp::send_scrape_unsafe() {
   m_get.reset(request_url, m_data);
   m_get.use_family(m_current_family);
 
+  m_get.set_max_file_size(1 << 20);
+  m_get.set_redirect_only_http_https();
+
   m_get.add_done_slot(tracker_thread::thread(), [this] { receive_done(); });
   m_get.add_failed_slot(tracker_thread::thread(), [this](const auto& str) { receive_signal_failed(str); });
 


### PR DESCRIPTION
`TrackerHttp::send_event_unsafe()` limits announce responses to 1 MiB
and restricts redirects to HTTP/HTTPS before starting the request.
`send_scrape_unsafe()` also resets the `HttpGet`, but did not restore
either setting. Since `HttpGet::reset()` creates a fresh `CurlGet`, an
attacker-controlled tracker could return an oversized scrape response
that would be buffered in the scrape `stringstream`.

This applies the existing announce response limit and redirect policy to
scrape requests as well.
