### PR TITLE
Reject over-budget socket allocations with input_error instead of internal_error

### DIFF
--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -3,6 +3,7 @@
 #include "torrent/runtime/socket_manager.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 
 #include "torrent/exceptions.h"
@@ -164,45 +165,49 @@ SocketManager::set_max_size_and_adjust(uint32_t max_open) {
 
   auto guard = lock_guard();
 
-  m_max_size = max_open;
-  adjust_allocation_unsafe();
+  adjust_allocation_unsafe(max_open);
 }
 
 void
 SocketManager::adjust_allocation() {
   auto guard = lock_guard();
 
-  adjust_allocation_unsafe();
+  adjust_allocation_unsafe(m_max_size.load());
 }
 
 void
-SocketManager::adjust_allocation_unsafe() {
-  auto max_open = m_max_size.load();
-
+SocketManager::adjust_allocation_unsafe(uint32_t max_open) {
   uint32_t total_allocated{};
 
-  auto set_category = [this, &total_allocated](category_t category, uint32_t allocation) {
+  std::array<uint32_t, category_count> new_max_size{};
+
+  auto calculate_category = [this, &total_allocated, &new_max_size](category_t category, uint32_t allocation) {
       allocation = std::max(allocation, m_category_min_alloc[static_cast<uint32_t>(category)].load());
       allocation = std::min(allocation, m_category_max_alloc[static_cast<uint32_t>(category)].load());
 
-      total_allocated           += allocation;
-      max_size_unsafe(category)  = allocation;
+      total_allocated                               += allocation;
+      new_max_size[static_cast<uint32_t>(category)]  = allocation;
     };
 
-  set_category(category_internal, calculate_internal(max_open));
-  set_category(category_http,     calculate_http(max_open));
-  set_category(category_rpc,      calculate_rpc(max_open));
-  set_category(category_files,    calculate_files(max_open));
+  calculate_category(category_internal, calculate_internal(max_open));
+  calculate_category(category_http,     calculate_http(max_open));
+  calculate_category(category_rpc,      calculate_rpc(max_open));
+  calculate_category(category_files,    calculate_files(max_open));
 
   total_allocated += calculate_reserved(max_open);
 
   auto min_generic = calculate_min_generic(max_open);
 
   if (total_allocated + min_generic + 8 > max_open)
-    throw internal_error("set_max_size_and_adjust: total + min_generic + 8 reserve exceeds max_open : " +
-                         std::to_string(total_allocated) + " + " + std::to_string(min_generic) + " + 8 > " + std::to_string(max_open));
+    throw input_error("adjust_allocation: total + min_generic + 8 reserve exceeds max_open : " +
+                      std::to_string(total_allocated) + " + " + std::to_string(min_generic) + " + 8 > " + std::to_string(max_open));
 
-  max_size_unsafe(category_generic) = max_open - total_allocated;
+  new_max_size[static_cast<uint32_t>(category_generic)] = max_open - total_allocated;
+
+  m_max_size = max_open;
+
+  for (uint32_t i = 0; i < category_count; i++)
+    max_size_unsafe(static_cast<category_t>(i)) = new_max_size[i];
 
   notify_changes_unsafe();
 }

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -129,7 +129,7 @@ private:
   auto&               managed_size_unsafe(category_t category);
   auto&               max_size_unsafe(category_t category);
 
-  void                adjust_allocation_unsafe();
+  void                adjust_allocation_unsafe(uint32_t max_open);
 
   void                notify_changes_unsafe() const;
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 TESTS = \
 	LibTorrent_Test_Torrent_Net \
+	LibTorrent_Test_Torrent_Runtime \
 	LibTorrent_Test_Torrent_Utils \
 	LibTorrent_Test_Torrent \
 	LibTorrent_Test_Data \
@@ -20,6 +21,7 @@ LibTorrent_Test_LDADD = \
 	../src/torrent/libtorrent_torrent.la
 
 LibTorrent_Test_Torrent_Net_LDADD = $(LibTorrent_Test_LDADD)
+LibTorrent_Test_Torrent_Runtime_LDADD = $(LibTorrent_Test_LDADD)
 LibTorrent_Test_Torrent_Utils_LDADD = $(LibTorrent_Test_LDADD)
 LibTorrent_Test_Torrent_LDADD = $(LibTorrent_Test_LDADD)
 LibTorrent_Test_Data_LDADD = $(LibTorrent_Test_LDADD)
@@ -57,6 +59,10 @@ LibTorrent_Test_Torrent_Net_SOURCES = $(LibTorrent_Test_Common) \
 	torrent/net/test_fd.h \
 	torrent/net/test_socket_address.cc \
 	torrent/net/test_socket_address.h
+
+LibTorrent_Test_Torrent_Runtime_SOURCES = $(LibTorrent_Test_Common) \
+	torrent/runtime/test_socket_manager.cc \
+	torrent/runtime/test_socket_manager.h
 
 LibTorrent_Test_Torrent_Utils_SOURCES = $(LibTorrent_Test_Common) \
 	torrent/utils/test_extents.cc \
@@ -124,6 +130,8 @@ LibTorrent_Test_SOURCES = $(LibTorrent_Test_Common) \
 
 LibTorrent_Test_Torrent_Net_CXXFLAGS = $(CPPUNIT_CFLAGS)
 LibTorrent_Test_Torrent_Net_LDFLAGS = $(CPPUNIT_LIBS)
+LibTorrent_Test_Torrent_Runtime_CXXFLAGS = $(CPPUNIT_CFLAGS)
+LibTorrent_Test_Torrent_Runtime_LDFLAGS = $(CPPUNIT_LIBS)
 LibTorrent_Test_Torrent_Utils_CXXFLAGS = $(CPPUNIT_CFLAGS)
 LibTorrent_Test_Torrent_Utils_LDFLAGS = $(CPPUNIT_LIBS)
 LibTorrent_Test_Torrent_CXXFLAGS = $(CPPUNIT_CFLAGS)

--- a/test/main.cc
+++ b/test/main.cc
@@ -21,6 +21,7 @@
 #include "helpers/utils.h"
 
 CPPUNIT_REGISTRY_ADD_TO_DEFAULT("torrent/net");
+CPPUNIT_REGISTRY_ADD_TO_DEFAULT("torrent/runtime");
 CPPUNIT_REGISTRY_ADD_TO_DEFAULT("torrent/utils");
 CPPUNIT_REGISTRY_ADD_TO_DEFAULT("torrent");
 CPPUNIT_REGISTRY_ADD_TO_DEFAULT("data");

--- a/test/torrent/runtime/test_socket_manager.cc
+++ b/test/torrent/runtime/test_socket_manager.cc
@@ -1,0 +1,112 @@
+#include "config.h"
+
+#include "test_socket_manager.h"
+
+#include <array>
+
+#include "runtime_manager.h"
+#include "torrent/exceptions.h"
+#include "torrent/runtime/socket_manager.h"
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_socket_manager, "torrent/runtime");
+
+namespace {
+
+using category_array = std::array<uint32_t, torrent::runtime::SocketManager::category_count>;
+
+category_array
+current_max_sizes() {
+  category_array result{};
+
+  for (uint32_t i = 0; i < result.size(); i++)
+    result[i] = torrent::runtime::socket_manager()->category_max_size(static_cast<torrent::runtime::socket_manager_category_t>(i));
+
+  return result;
+}
+
+} // namespace
+
+void
+test_socket_manager::setUp() {
+  test_fixture::setUp();
+
+  torrent::RuntimeManager::initialize();
+}
+
+void
+test_socket_manager::tearDown() {
+  torrent::RuntimeManager::destroy();
+
+  test_fixture::tearDown();
+}
+
+void
+test_socket_manager::test_basic() {
+  auto socket_manager = torrent::runtime::socket_manager();
+
+  socket_manager->set_max_size_and_adjust(1024);
+
+  CPPUNIT_ASSERT_EQUAL(uint32_t{1024}, socket_manager->max_size());
+  CPPUNIT_ASSERT_EQUAL(uint32_t{32},   socket_manager->category_max_size(torrent::runtime::category_internal));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{32},   socket_manager->category_max_size(torrent::runtime::category_http));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{32},   socket_manager->category_max_size(torrent::runtime::category_rpc));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{128},  socket_manager->category_max_size(torrent::runtime::category_files));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{672},  socket_manager->category_max_size(torrent::runtime::category_generic));
+
+  CPPUNIT_ASSERT_THROW(socket_manager->set_max_size_and_adjust(511), torrent::input_error);
+}
+
+void
+test_socket_manager::test_adjust_allocation_over_budget() {
+  auto socket_manager = torrent::runtime::socket_manager();
+
+  socket_manager->set_max_size_and_adjust(1024);
+
+  auto expected_max_sizes = current_max_sizes();
+
+  socket_manager->set_category_min_allocation(torrent::runtime::category_files, 1000000);
+
+  CPPUNIT_ASSERT_THROW(socket_manager->adjust_allocation(), torrent::input_error);
+
+  CPPUNIT_ASSERT(current_max_sizes() == expected_max_sizes);
+  CPPUNIT_ASSERT_EQUAL(uint32_t{1024}, socket_manager->max_size());
+
+  CPPUNIT_ASSERT_THROW(socket_manager->set_max_size_and_adjust(2048), torrent::input_error);
+
+  CPPUNIT_ASSERT(current_max_sizes() == expected_max_sizes);
+  CPPUNIT_ASSERT_EQUAL(uint32_t{1024}, socket_manager->max_size());
+}
+
+void
+test_socket_manager::test_adjust_allocation_staged_min_alloc() {
+  auto socket_manager = torrent::runtime::socket_manager();
+
+  socket_manager->set_max_size_and_adjust(8096);
+
+  CPPUNIT_ASSERT_EQUAL(uint32_t{64},   socket_manager->category_max_size(torrent::runtime::category_http));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{48},   socket_manager->category_max_size(torrent::runtime::category_rpc));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{6672}, socket_manager->category_max_size(torrent::runtime::category_generic));
+
+  socket_manager->set_category_min_allocation(torrent::runtime::category_http, 400);
+  socket_manager->set_category_min_allocation(torrent::runtime::category_rpc, 64);
+  socket_manager->adjust_allocation();
+
+  CPPUNIT_ASSERT_EQUAL(uint32_t{400},  socket_manager->category_max_size(torrent::runtime::category_http));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{64},   socket_manager->category_max_size(torrent::runtime::category_rpc));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{6320}, socket_manager->category_max_size(torrent::runtime::category_generic));
+
+  socket_manager->set_category_min_allocation(torrent::runtime::category_rpc, 400);
+
+  CPPUNIT_ASSERT_THROW(socket_manager->adjust_allocation(), torrent::input_error);
+
+  CPPUNIT_ASSERT_EQUAL(uint32_t{400},  socket_manager->category_max_size(torrent::runtime::category_http));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{64},   socket_manager->category_max_size(torrent::runtime::category_rpc));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{6320}, socket_manager->category_max_size(torrent::runtime::category_generic));
+
+  socket_manager->set_category_min_allocation(torrent::runtime::category_http, 64);
+  socket_manager->adjust_allocation();
+
+  CPPUNIT_ASSERT_EQUAL(uint32_t{64},   socket_manager->category_max_size(torrent::runtime::category_http));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{400},  socket_manager->category_max_size(torrent::runtime::category_rpc));
+  CPPUNIT_ASSERT_EQUAL(uint32_t{6320}, socket_manager->category_max_size(torrent::runtime::category_generic));
+}

--- a/test/torrent/runtime/test_socket_manager.h
+++ b/test/torrent/runtime/test_socket_manager.h
@@ -1,0 +1,19 @@
+#include "helpers/test_fixture.h"
+
+class test_socket_manager : public test_fixture {
+  CPPUNIT_TEST_SUITE(test_socket_manager);
+
+  CPPUNIT_TEST(test_basic);
+  CPPUNIT_TEST(test_adjust_allocation_over_budget);
+  CPPUNIT_TEST(test_adjust_allocation_staged_min_alloc);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override;
+  void tearDown() override;
+
+  void test_basic();
+  void test_adjust_allocation_over_budget();
+  void test_adjust_allocation_staged_min_alloc();
+};


### PR DESCRIPTION
 `SocketManager::adjust_allocation_unsafe()` throws `internal_error` when the configured category floors do not fit `max_open`. `internal_error` is a sibling of `local_error`,  which is what rtorrent's XMLRPC layer catches, so the throw is not caught and the process  terminates. The condition is reachable purely from RPC input:

  ```
  system.sockets.files.min_alloc.set = 1000000    -> returns 0, accepted
  system.sockets.adjust_alloc                     -> process gone
  rtorrent: caught torrent::internal_error: set_max_size_and_adjust: total + min_generic + 8 reserve exceeds max_open : 1000224 + 512 + 8 > 1024
  ```

That makes it an input error, not a broken invariant — and `set_max_size_and_adjust()` already throws `input_error` for its other caller-value failure ("max_open too low"). With `input_error` the caller gets an XMLRPC fault and can re-read `system.sockets.*`.

The commit was also not atomic: the four `set_category()` calls wrote  `max_size_unsafe(cat)` before the guard ran, and `generic` was assigned only after it, so  the throw path left an over-committed, inconsistent allocation. `set_max_size_and_adjust()`  likewise stored `m_max_size` before validating. This was masked while the process died.  Allocations are now computed into locals, validated, then applied all-or-nothing together  with `m_max_size`; `notify_changes_unsafe()` no longer fires on the rejection path.

Validation stays at the commit point rather than in the setters, since `min_alloc.set` is a staging write and `adjust_alloc` is the commit — legal sequences pass through over-budget  intermediate states (swapping two categories' floors must pass through both being high).

The guard's arithmetic and message are unchanged, except that the message prefix is now  `adjust_allocation:` — it previously read `set_max_size_and_adjust:` even when reached via  `adjust_allocation()`.

Adds `test/torrent/runtime/test_socket_manager.cc` (new `LibTorrent_Test_Torrent_Runtime` suite) covering the default split, rejection with no mutation of any of the five categories or `m_max_size`, and the staged-floor swap through an over-budget intermediate. It fails before the change and passes after; `make check` is green on all 8 suites.