### PR TITLE
Bound DHT packet processing

### DIFF
--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -174,6 +174,9 @@ DhtServer::reset_statistics() {
 // Ping a node whose ID we know.
 void
 DhtServer::ping(const HashString& id, const sockaddr* sa) {
+  if (m_transactions.size() >= max_transactions)
+    return;
+
   // No point pinging a node that we're already contacting otherwise.
   auto itr = m_transactions.lower_bound(DhtTransaction::key(sa, 0));
 
@@ -547,7 +550,8 @@ DhtServer::add_packet(std::shared_ptr<DhtTransactionPacket> packet, int priority
 
     // Reply packets will be processed after all of our own packets have been send.
     case packet_prio_reply:
-      m_lowQueue.push_back(std::move(packet));
+      if (m_lowQueue.size() < max_reply_packets)
+        m_lowQueue.push_back(std::move(packet));
       break;
 
     default:
@@ -732,7 +736,7 @@ DhtServer::clear_transactions() {
 
 void
 DhtServer::event_read() {
-  while (true) {
+  for (unsigned int count = 0; count < max_read_datagrams; ++count) {
     Object request;
     int type = '?';
     DhtMessage message;

--- a/src/dht/dht_server.h
+++ b/src/dht/dht_server.h
@@ -76,6 +76,11 @@ private:
   static constexpr int dht_error_protocol   = 203;
   static constexpr int dht_error_bad_method = 204;
 
+  // Bound work and state created from a single readable socket event.
+  static constexpr unsigned int max_read_datagrams = 64;
+  static constexpr size_t       max_reply_packets  = 1024;
+  static constexpr size_t       max_transactions   = 1024;
+
   struct [[gnu::packed]] compact_node_info {
     char                 _id[20];
     SocketAddressCompact _addr;


### PR DESCRIPTION
`DhtServer::event_read()` drains the UDP socket until it would block.
Each valid query reaches `process_query()`, which queues a response in
`m_lowQueue`. If sending is blocked, a peer can keep the socket readable
with valid queries and grow that queue without bound. Queries from
unknown node IDs can also schedule outstanding ping transactions.

Limit each read dispatch to 64 datagrams, cap queued replies, and stop
scheduling new pings once the pending transaction limit is reached.
This bounds work and retained state from unsolicited DHT traffic.
