### PR TITLE
system: keep the pipe fds SpawnProcess::execute() creates for capture

### DIFF
--- a/src/torrent/system/spawn_process.cc
+++ b/src/torrent/system/spawn_process.cc
@@ -88,7 +88,7 @@ SpawnProcess::execute(const char* path, char* const argv[]) {
 
   auto [actions, attr] = make_spawn_actions();
 
-  add_redirects(&actions, m_log_fd, m_capture_output);
+  std::tie(m_parent_fd, m_child_fd) = add_redirects(&actions, m_log_fd, m_capture_output);
 
   short spawn_flags = 0;
 


### PR DESCRIPTION
add_redirects() returns the pipe it opens, but execute() discarded the pair, so m_parent_fd and m_child_fd stayed -1: capture_child_output() read from -1 and returned an empty string, and neither end was ever closed in the parent.

execute.capture returned "" for every command, and each call leaked both pipe fds. 

Verified on master: 50 captures grew the process from 26 to 126 open fds; with the fds assigned, capture returns the output and the count stays flat.