### PR TITLE
Refuse a category allocation above its limit instead of aborting.

### DIFF
--- a/src/net/curl_stack.cc
+++ b/src/net/curl_stack.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include "torrent/runtime/socket_manager.h"
+
 #include "curl_stack.h"
 
 #include <algorithm>
@@ -77,8 +79,9 @@ CurlStack::set_max_host_connections(unsigned int value) {
 
 void
 CurlStack::set_max_total_connections(unsigned int value) {
-  if (value > 4096)
-    throw torrent::internal_error("CurlStack::set_max_total_connections() called with a value greater than 4096.");
+  if (value > torrent::runtime::SocketManager::http_max_alloc)
+    throw torrent::internal_error("CurlStack::set_max_total_connections() called with a value greater than " +
+                                  std::to_string(torrent::runtime::SocketManager::http_max_alloc) + ".");
 
   auto guard = lock_guard();
 

--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -20,6 +20,14 @@ namespace {
 constexpr uint32_t allocation_headroom = 8;
 
 uint32_t
+calculate_alloc_limit(torrent::runtime::socket_manager_category_t category) {
+  if (category == torrent::runtime::category_http)
+    return torrent::runtime::SocketManager::http_max_alloc;
+
+  return torrent::runtime::SocketManager::category_max_alloc;
+}
+
+uint32_t
 calculate_min_generic(uint32_t open_max) {
   if (open_max >= 16384)
     return 12288;
@@ -127,6 +135,11 @@ SocketManager::category_max_size(category_t category) {
 }
 
 uint32_t
+SocketManager::category_alloc_limit(category_t category) {
+  return calculate_alloc_limit(category);
+}
+
+uint32_t
 SocketManager::generic_min_allocation() {
   return calculate_min_generic(m_max_size);
 }
@@ -207,6 +220,10 @@ SocketManager::adjust_allocation_unsafe(uint32_t max_open) {
   auto calculate_category = [this, &total_allocated, &new_max_size](category_t category, uint32_t allocation) {
       allocation = std::max(allocation, m_category_min_alloc[static_cast<uint32_t>(category)].load());
       allocation = std::min(allocation, m_category_max_alloc[static_cast<uint32_t>(category)].load());
+
+      if (allocation > calculate_alloc_limit(category))
+        throw input_error("adjust_allocation: allocation exceeds the category limit : " +
+                          std::to_string(allocation) + " > " + std::to_string(calculate_alloc_limit(category)));
 
       total_allocated                               += allocation;
       new_max_size[static_cast<uint32_t>(category)]  = allocation;

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -53,6 +53,7 @@ class LIBTORRENT_EXPORT SocketManager {
 public:
   static constexpr uint32_t category_count     = 5;
   static constexpr uint32_t category_max_alloc = 1000000;
+  static constexpr uint32_t http_max_alloc     = 4096;
   static constexpr int      flag_inactive = (1 << 0);
 
   using category_t = socket_manager_category_t;
@@ -65,6 +66,8 @@ public:
 
   uint32_t            category_min_allocation(category_t category);
   uint32_t            category_max_allocation(category_t category);
+
+  uint32_t            category_alloc_limit(category_t category);
 
   uint32_t            generic_min_allocation();
   uint32_t            reserved_allocation();


### PR DESCRIPTION
Raising the http socket allocation above 4096 aborts the process.

  `adjust_allocation` accepts any category allocation that fits the shared budget, then notifies subscribers. The net thread's subscriber passes the http allocation to `CurlStack::set_max_total_connections()`, which throws `internal_error` above 4096. Nothing catches it there, so the exception escapes `Thread::event_loop()` and `std::terminate()` runs. Two limits disagree, and the one that loses kills the daemon.

  ### Reproducing

The process fd limit has to be high enough that the value fits the shared budget, otherwise the budget check refuses it first and the curl limit is never reached — at `ulimit -n 16384` the budget is only 3576, so this needs a larger limit (76000 below, 32768 is enough).

  ```
  ulimit -n 76000
  rtorrent -n -o import=rc          # rc: network.scgi.open_local = /tmp/rt.sock
  ```

  then over SCGI:

  ```
  system.sockets.http.min_alloc.set = "", 5125
  system.sockets.http.max_alloc.set = "", 5125
  system.sockets.adjust_alloc =
  ```

The three calls all return success and the process is gone. It is also reachable from a settings UI: this was found when a user set "maximum number of open HTTP connections" to 5125 in ruTorrent.

  ```
Program terminated with signal SIGABRT, Aborted.
  #5  std::terminate ()
  #7  torrent::system::Thread::event_loop (this=0x...) at system/thread.cc:298
  #8  torrent::system::Thread::enter_event_loop (thread=0x...) at system/thread.cc:260
  ```

  ### The change

  Refuse the allocation where the budget is already refused, rather than letting a subscriber throw after the fact. `adjust_allocation_unsafe()` checks each category against `calculate_alloc_limit()` and throws `input_error`, so the caller gets a fault and the reported allocation stays truthful. Clamping silently was the other option, but then `system.sockets.http.max_size` reports a number that is not in effect.

  The three curl limits move to the public header as `HttpStack::max_{cache,host,total}_connections_limit`, so the check and its message share one constant, and rtorrent can report the ceiling to clients (rakshasa/rtorrent#1915).

  ### Verified

  | | |
  |---|---|
  | `http` → 5125 | `input_error`: `allocation exceeds the category limit : 5125 > 4096`, process alive, `max_size` unchanged |
  | `http` → 4096 | accepted |
  | `http` → 4097 | refused, `max_size` stays 4096 |
  | `files` → 30000 | accepted — the ceiling is per category, not global |