### PR TITLE
tracker: do not abort on a zero-length or failed datagram read.

### DIFF
--- a/src/tracker/udp_router.cc
+++ b/src/tracker/udp_router.cc
@@ -553,7 +553,7 @@ UdpRouter::event_read() {
     }
 
     if (bytes_read == 0)
-      throw internal_error("UdpRouter::event_read() read datagram of length 0");
+      continue;
 
     m_buffer.set_end(bytes_read);
 


### PR DESCRIPTION
A single zero-length UDP datagram sent to the tracker UDP router socket kills the process.

`recvfrom()` returns 0 for a legitimately received zero-length datagram, which reaches an unconditional `throw internal_error` in `UdpRouter::event_read()`. That runs on the tracker thread, where `Thread::event_loop()` rethrows `internal_error` and nothing above it catches, so the process aborts through `std::terminate()`.

The throw happens before `peek_transaction_id()`, before the transaction lookup and before the source-address comparison, so it needs no transaction id and no spoofing. `ThreadTracker::init_thread_post_local()` opens the UDP routers at startup regardless of configuration and they stay bound on the wildcard address for the process lifetime, so any tracker the client announces to learns a live target port.

**Repro**

```
rtorrent -n -o import=rc            # rc: network.scgi.open_local = /tmp/rt.sock
ss -lunp | grep rtorrent            # note a udp port
python3 -c "import socket;socket.socket(socket.AF_INET,socket.SOCK_DGRAM).sendto(b'',('127.0.0.1',PORT))"
```

Process gone in under a second:

```
Program terminated with signal SIGABRT, Aborted.
#5  std::terminate ()
#7  torrent::system::Thread::event_loop (this=0x…) at system/thread.cc:298
#8  torrent::system::Thread::enter_event_loop
```
`p *this` in frame 7 shows `vtable for torrent::ThreadTracker`.

**Fix**

A zero-length datagram is skipped with `continue`, matching how the loop already treats every other datagram that is not for us (unknown transaction id, unresolved or mismatched address). A failed read logs and leaves the loop instead of throwing; the socket stays polled and is read again on the next event.

`UdpRouter::event_error()` has the same unconditional throw, but is deliberately left alone here: `Poll::process()` throws if `event_error()` returns without clearing the event mask, so a correct fix there has to close or deregister the socket rather than just stop throwing. Separate change.

**Test**

Same build, before and after, at `ulimit -n 76000`:

| | stock 0.16.20 | patched |
|---|---|---|
| one empty datagram | process dies | alive |
| 50 empty datagrams + junk | process dies | alive, still answering RPC |
| real UDP announce against a local tracker | connect + announce, `t.success_counter` 1 | same |
| 20 empty datagrams, then re-announce | n/a | second announce completes, `t.success_counter` 2 |

The last row is the one that matters for regressions: the socket keeps working normally after hostile input rather than being left wedged.