### PR TITLE
runtime: fix the argument count in the listen restart error log.

### DIFF
--- a/src/torrent/runtime/network_manager.cc
+++ b/src/torrent/runtime/network_manager.cc
@@ -264,7 +264,7 @@ NetworkManager::listen_restart_unsafe() {
     listen_open_unsafe(m_listen_port, m_listen_port);
 
   } catch (const base_error& e) {
-    LT_LOG_NOTICE("Could not restart listen socket: %" PRIu16 " : %s", e.what());
+    LT_LOG_NOTICE("Could not restart listen socket: %" PRIu16 " : %s", m_listen_port, e.what());
     return;
   }
 }


### PR DESCRIPTION
The line has two conversions and one argument, so %s reads a garbage vararg.