### PR TITLE
net: throw the udns submit failure by value.

### DIFF
--- a/src/net/udns_resolver.cc
+++ b/src/net/udns_resolver.cc
@@ -160,7 +160,7 @@ UdnsResolver::resolve(void* requester, const std::string& hostname, int family, 
 
       // Unrecoverable errors, like ENOMEM.
       if (::dns_status(m_ctx) != DNS_E_BADQUERY)
-        throw new internal_error("dns_submit_a4 failed");
+        throw internal_error("dns_submit_a4 failed");
 
       // UDNS will fail immediately during submission of malformed domain names,
       // e.g., `..`. In order to maintain a clean interface, keep track of this
@@ -192,7 +192,7 @@ UdnsResolver::resolve(void* requester, const std::string& hostname, int family, 
       }
 
       if (::dns_status(m_ctx) != DNS_E_BADQUERY)
-        throw new internal_error("dns_submit_a6 failed");
+        throw internal_error("dns_submit_a6 failed");
 
       query->error_sin = EAI_NONAME;
 


### PR DESCRIPTION
Thrown as a pointer it matches no handler, so it terminates instead of being caught.

Note - I couldn't trigger this to actually test, so it's just code analysis.
