### PR TITLE
dht: restrict the length of tokens we echo back.

### DIFF
--- a/src/dht/dht_server.cc
+++ b/src/dht/dht_server.cc
@@ -490,6 +490,11 @@ DhtServer::parse_get_peers_reply(DhtTransactionGetPeers* transaction, const DhtM
   if (response[key_r_values].is_raw_list())
     announce->receive_peers(response[key_r_values].as_raw_list());
 
+  // Restrict the length of tokens. We echo them back in announce_peer, and the
+  // query has to fit in a single packet.
+  if (response[key_r_token].is_raw_string() && response[key_r_token].as_raw_string().size() > 64)
+    throw dht_error(dht_error_protocol, "Token length too long");
+
   if (response[key_r_token].is_raw_string())
     add_transaction(std::unique_ptr<DhtTransaction>(new DhtTransactionAnnouncePeer(transaction->id(),
                                                                                    transaction->address(),


### PR DESCRIPTION
TL;DR A long token in a get_peers reply overflows the announce_peer packet buffer.


  A node that answers our `get_peers` with a long token kills the client.

  The token from the reply is stored as-is and echoed back in the follow-up `announce_peer` (`dht_server.cc:493`), which `DhtTransactionPacket::build_buffer` renders into a fixed buffer:

  ```cpp
  char buffer[1500];  // If the message would exceed an Ethernet frame, something went very wrong.
  ```

  Around 1370 bytes of token pushes the query past that, `object_write_to_buffer` throws `internal_error`, and the DHT read path only catches `bencode_error`, `dht_error` and `network_error` — so it propagates out and the process exits.

  The comment is the point: the buffer size encodes an invariant that a DHT message fits in one frame, and treats a violation as a programming error. That holds only as long as nothing remote decides the size of a field we echo. The transaction ID already has exactly this bound a  few hundred lines up, for exactly this reason:

  ```cpp
  // Restrict the length of Transaction IDs. We echo them in our replies.
  if (message[key_t].as_raw_string().size() > 20) {
      throw dht_error(dht_error_protocol, "Transaction ID length too long");
  }
  ```

  This does the same for the reply token, so the invariant is restored at the input boundary rather than the assertion softened at the output. `dht_error` is already handled, so the reply is rejected as a protocol error and the node stays usable.

  Reproduced against 0.16.20 with a fake node that answers `get_peers` with an oversized token:

  | token length | 0.16.20 | patched |
  |---|---|---|
  | 8 (typical) | `announce_peer` sent | `announce_peer` sent |
  | 64 | `announce_peer` sent | `announce_peer` sent |
  | 65 | `announce_peer` sent | rejected as a protocol error, node kept |
  | 1400 | `caught torrent::internal_error: object_write_to_buffer(...) buffer overflow`, exit 255 | alive, `errors_caught: 1`, DHT keeps running |