### PR TITLE
Refuse a files allocation outside what the file manager accepts.

### DIFF
--- a/src/torrent/runtime/socket_manager.cc
+++ b/src/torrent/runtime/socket_manager.cc
@@ -24,7 +24,18 @@ calculate_alloc_limit(torrent::runtime::socket_manager_category_t category) {
   if (category == torrent::runtime::category_http)
     return torrent::runtime::SocketManager::http_max_alloc;
 
+  if (category == torrent::runtime::category_files)
+    return torrent::runtime::SocketManager::files_max_alloc;
+
   return torrent::runtime::SocketManager::category_max_alloc;
+}
+
+uint32_t
+calculate_alloc_minimum(torrent::runtime::socket_manager_category_t category) {
+  if (category == torrent::runtime::category_files)
+    return torrent::runtime::SocketManager::files_min_alloc;
+
+  return 0;
 }
 
 uint32_t
@@ -140,6 +151,11 @@ SocketManager::category_alloc_limit(category_t category) {
 }
 
 uint32_t
+SocketManager::category_alloc_minimum(category_t category) {
+  return calculate_alloc_minimum(category);
+}
+
+uint32_t
 SocketManager::generic_min_allocation() {
   return calculate_min_generic(m_max_size);
 }
@@ -224,6 +240,10 @@ SocketManager::adjust_allocation_unsafe(uint32_t max_open) {
       if (allocation > calculate_alloc_limit(category))
         throw input_error("adjust_allocation: allocation exceeds the category limit : " +
                           std::to_string(allocation) + " > " + std::to_string(calculate_alloc_limit(category)));
+
+      if (allocation < calculate_alloc_minimum(category))
+        throw input_error("adjust_allocation: allocation below the category minimum : " +
+                          std::to_string(allocation) + " < " + std::to_string(calculate_alloc_minimum(category)));
 
       total_allocated                               += allocation;
       new_max_size[static_cast<uint32_t>(category)]  = allocation;

--- a/src/torrent/runtime/socket_manager.h
+++ b/src/torrent/runtime/socket_manager.h
@@ -54,6 +54,8 @@ public:
   static constexpr uint32_t category_count     = 5;
   static constexpr uint32_t category_max_alloc = 1000000;
   static constexpr uint32_t http_max_alloc     = 4096;
+  static constexpr uint32_t files_max_alloc    = 1 << 16;
+  static constexpr uint32_t files_min_alloc    = 4;
   static constexpr int      flag_inactive = (1 << 0);
 
   using category_t = socket_manager_category_t;
@@ -68,6 +70,7 @@ public:
   uint32_t            category_max_allocation(category_t category);
 
   uint32_t            category_alloc_limit(category_t category);
+  uint32_t            category_alloc_minimum(category_t category);
 
   uint32_t            generic_min_allocation();
   uint32_t            reserved_allocation();


### PR DESCRIPTION
TL;DR FileManager takes 4 to 2^16; outside that it threw from a callback and exited.

Setting the files socket allocation outside the range `FileManager` accepts kills the process.

  `adjust_allocation` has no lower bound and treats the files ceiling as `category_max_alloc`, so it accepts values the file manager will refuse. It then notifies subscribers, and `ThreadMain::set_max_connections()` passes the value on:

  ```cpp
  manager->file_manager()->set_max_open_files(max_open_files);
  ```

  ```cpp
  void
  FileManager::set_max_open_files(size_type s) {
    if (s < 4 || s > (1 << 16))
      throw input_error("Max open files must be between 4 and 2^16.");
  ```

  That throw happens in a callback on the main thread, outside the RPC try, so it is not turned into a fault — it propagates out of the event loop and the process exits.

  Reproducing on 0.16.20:

  ```
  system.sockets.files.min_alloc.set = "", 0
  system.sockets.files.max_alloc.set = "", 0
  system.sockets.adjust_alloc =
  ```

  The three calls return success and rtorrent is gone. It is reachable from a settings dialog: this was found by typing 0 into "maximum number of open files" in ruTorrent.

  This applies the same treatment the http category already has — refuse the value where the budget is refused, rather than letting a subscriber throw after the fact. It adds a per-category minimum next to the existing limit, sets the files range to the 4 and 2^16 that `FileManager`
  enforces, and reports both through `category_alloc_limit()` and `category_alloc_minimum()`.

  Note that `files.max_alloc.limit` previously reported 1000000, which was never achievable — anything above 65536 was refused by `FileManager`.

  Verified on a patched build:

  | files allocation | result |
  |---|---|
  | 0, 3 | `input_error`: allocation below the category minimum, process alive |
  | 4 | accepted |
  | 65536 | refused by the shared budget on this box, process alive |
  | 65537 | `input_error`: allocation exceeds the category limit, process alive |