### PR TITLE
dht: skip a node with an any address instead of throwing.

### DIFF
--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -231,8 +231,10 @@ DhtRouter::contact(const sockaddr* sa, int port) {
   if (sa_tmp->sa_family != AF_INET)
     return;
 
-  if (sap_is_any(sa_tmp))
-    throw input_error("DhtRouter::contact() called with any address.");
+  if (sap_is_any(sa_tmp)) {
+    LT_LOG_THIS("not contacting node, any address : %s", sa_addr_str(sa_tmp.get()).c_str());
+    return;
+  }
 
   sap_set_port(sa_tmp, port);
 


### PR DESCRIPTION
TL;DR contact() runs from the bootstrap cycle, where the throw exits the client.


  `dht.add_node` with a host that resolves to the any address kills the client about a minute later.

  `DhtRouter::contact()` throws for an any address:

  ```cpp
  if (sap_is_any(sa_tmp))
    throw input_error("DhtRouter::contact() called with any address.");
  ```

  It is not called from the command, though. `dht.add_node` only stores a bootstrap contact; `contact()` runs later from the bootstrap cycle, which is not inside any handler, so the throw leaves the event loop and the process exits:

  ```
  1786204318  dht.add_node : 0
  1786204318  dht_router: added bootstrap contact : 0:6881
  1786204376  C Caught exception: 'DhtRouter::contact() called with any address.'
  ```

  Exit −1, no core, 58 seconds after the command returned success — so the command that caused it is well out of sight by then.

  Reproducing on 0.16.20, with DHT actually bootstrapping (`dht.mode.set = auto` plus a public torrent, or `dht.mode.set = on`):

  ```
  dht.add_node = "0"          # also 0.0.0.0, or 0.0.0.0:6881
  ```

  The other unusable-address case immediately above it already returns rather than throwing — an address family we do not support is not treated as a fatal error, and an any address is the same kind of thing. This makes it a skip with a log line, matching that.

  Verified: with the change, all three forms are accepted by the command, logged as skipped when the bootstrap cycle reaches them, and the client stays up with DHT still active.

  ```
  1786204582  added bootstrap contact : 0:6881
  1786204640  not contacting node, any address : 0.0.0.0
  ```