### PR TITLE
Do not abort on values and state an RPC caller controls.

### DIFF
--- a/src/net/curl_stack.cc
+++ b/src/net/curl_stack.cc
@@ -56,7 +56,7 @@ CurlStack::~CurlStack() {
 void
 CurlStack::set_max_cache_connections(unsigned int value) {
   if (value > 1024)
-    throw torrent::internal_error("CurlStack::set_max_cache_connections() called with a value greater than 1024.");
+    throw torrent::input_error("CurlStack::set_max_cache_connections() called with a value greater than 1024.");
 
   auto guard = lock_guard();
 
@@ -68,7 +68,7 @@ CurlStack::set_max_cache_connections(unsigned int value) {
 void
 CurlStack::set_max_host_connections(unsigned int value) {
   if (value > 1024)
-    throw torrent::internal_error("CurlStack::set_max_host_connections() called with a value greater than 1024.");
+    throw torrent::input_error("CurlStack::set_max_host_connections() called with a value greater than 1024.");
 
   auto guard = lock_guard();
 

--- a/src/torrent/download/choke_queue.cc
+++ b/src/torrent/download/choke_queue.cc
@@ -156,6 +156,11 @@ choke_queue::rebuild_containers(container_type* queued, container_type* unchoked
 
 void
 choke_queue::balance() {
+  // A group that was never given its slots cannot be balanced; calling through
+  // an empty std::function would terminate the client.
+  if (!m_slotCanUnchoke)
+    return;
+
   LT_LOG_THIS("balancing queue: heuristics:%i currently_unchoked:%" PRIu32 " max_unchoked:%" PRIu32,
               m_heuristics,
               m_currently_unchoked,


### PR DESCRIPTION
TL;DR An unwired choke queue and an out of range curl limit both exited the client.

  Three RPC-reachable commands abort the client. All three are the same shape: a value or a state that comes from outside is treated as a programming error.

  **`choke_group.all.{up,down}.update_balance`** throws `std::bad_function_call`, immediately. Groups created through rtorrent's `choke_group.insert` get their name and heuristics but never their slots, unlike the ones `ResourceManager::push_group()` builds, so
  `choke_queue::balance()` calls through an empty `std::function`. A queue that was never wired cannot be balanced, so it now returns instead of calling into nothing.

  **`network.http.max_cache_connections.set`** and **`network.http.max_host_connections.set`** throw `internal_error` above 1024. That is not a `local_error`, so the RPC layer does not catch it and the process exits. The value comes straight from the caller, which makes it an input
  error rather than an invariant — the same distinction `set_max_total_connections` now relies on. `-1` arrives as 4294967295 through the int64 to `unsigned int` conversion; 2000 gets there honestly.

  Verified against master, each from a clean instance:

  | call | before | after |
  |---|---|---|
  | `choke_group.all.up.update_balance` | `std::bad_function_call`, exit | no-op, client alive |
  | `choke_group.all.down.update_balance` | `std::bad_function_call`, exit | no-op, client alive |
  | `network.http.max_cache_connections.set = -1` | exit | fault, client alive |
  | `network.http.max_host_connections.set = 2000` | exit | fault, client alive |
  | `network.http.max_host_connections.set = 512` | applied | applied |
