### PR TITLE
Bound the piece skip read to the null buffer size.

### DIFF
--- a/src/protocol/peer_connection_base.cc
+++ b/src/protocol/peer_connection_base.cc
@@ -546,7 +546,8 @@ PeerConnectionBase::down_chunk_skip() {
     return false;
   }
 
-  uint32_t length = read_stream_throws(m_nullBuffer, std::min(quota, m_request_list.transfer()->piece().length() - m_request_list.transfer()->position()));
+  uint32_t remaining = m_request_list.transfer()->piece().length() - m_request_list.transfer()->position();
+  uint32_t length = read_stream_throws(m_nullBuffer, std::min({quota, remaining, static_cast<uint32_t>(null_buffer_size)}));
   throttle->node_used(m_peer_chunks.download_throttle(), length);
 
   if (is_encrypted())


### PR DESCRIPTION
TL; DR An unrequested piece let a peer overflow the shared skip buffer.

**Repro**

  Against master `d65158dd` built with `-fsanitize=address,undefined`: add an
  8-piece torrent, connect to the listen port, complete the handshake, then send
  message id 7 with a 500000-byte body that was never requested.

  ```
  ==ERROR: AddressSanitizer: heap-buffer-overflow
  WRITE of size 293152 at 0x761437ba1800 thread T0
      #0 in recv
      #2 in torrent::SocketStream::read_stream(void*, unsigned int) net/socket_stream.h:57
      #3 in torrent::PeerConnectionBase::down_chunk_skip() protocol/peer_connection_base.cc:549
  0x761437ba1800 is located 0 bytes after 131072-byte region
  allocated by thread T0 here:
      #1 in __static_initialization_and_destruction_0 net/socket_stream.cc:7
  ```

**Long version**
  A peer that sends a PIECE message it was never asked for reaches this path. In
  `RequestList::downloading()` the piece matches nothing in any queue, so the
  `downloading_error` branch builds a dummy `BlockTransfer` from the peer's own
  piece — index, offset and length as sent. The connection enters
  `READ_SKIP_PIECE` and skips that many bytes into the fixed buffer.

  Nothing bounds the length first. `down_chunk_start()` returns false at the
  `request_list()->downloading(piece)` check, which is before
  `file_list()->is_valid_piece(piece)`, so the one check that would reject an
  absurd length is never reached on this path. With no download throttle
  configured the quota is effectively unlimited, so the read length is whatever
  the peer put in the message-length field.

  The sibling skip path already gets this right — `PeerConnectionMetadata::read_skip_bitfield`
  clamps with `std::min(m_skipLength, static_cast<uint32_t>(null_buffer_size))`.
  This makes the piece skip path do the same. The loop still consumes the whole
  oversized body, just in buffer-sized steps.
