### PR TITLE
Do not dereference the end iterator when updating group iterators.

### DIFF
--- a/src/torrent/download/resource_manager.cc
+++ b/src/torrent/download/resource_manager.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <memory>
 #include <numeric>
 
 #include "download/download_main.h"
@@ -62,13 +63,13 @@ ResourceManager::update_group_iterators() {
   auto group_itr = m_choke_groups.begin();
 
   while (group_itr != m_choke_groups.end()) {
-    (*group_itr)->set_first(&*entry_itr);
+    (*group_itr)->set_first(std::to_address(entry_itr));
 
     entry_itr = std::find_if(entry_itr, end(), [group_itr, this](value_type v) {
       return (std::distance(m_choke_groups.begin(), group_itr)) < v.group();
     });
 
-    (*group_itr)->set_last(&*entry_itr);
+    (*group_itr)->set_last(std::to_address(entry_itr));
     group_itr++;
   }
 }
@@ -79,14 +80,14 @@ ResourceManager::validate_group_iterators() {
   auto group_itr = m_choke_groups.begin();
 
   while (group_itr != m_choke_groups.end()) {
-    if ((*group_itr)->first() != &*entry_itr)
+    if ((*group_itr)->first() != std::to_address(entry_itr))
       throw internal_error("ResourceManager::receive_tick() invalid first iterator.");
 
     entry_itr = std::find_if(entry_itr, end(), [group_itr, this](value_type v) {
       return (std::distance(m_choke_groups.begin(), group_itr)) < v.group();
     });
 
-    if ((*group_itr)->last() != &*entry_itr)
+    if ((*group_itr)->last() != std::to_address(entry_itr))
       throw internal_error("ResourceManager::receive_tick() invalid last iterator.");
 
     group_itr++;


### PR DESCRIPTION
TL;DR An empty entries vector made every tick undefined behaviour.


  ```
  runtime error: reference binding to null pointer of type 'value_type'
    #10 __normal_iterator<...>::operator*() const  bits/stl_iterator.h:1091
    #11 torrent::ResourceManager::validate_group_iterators()  download/resource_manager.cc:82
    #12 torrent::ResourceManager::receive_tick()  download/resource_manager.cc:289
    #13 torrent::Manager::receive_tick()  manager.cc:111
  ```

  On a normal libstdc++ release build it happens to work — the computed pointer
  compares equal to the other past-the-end pointer — but it is UB and it makes the
  project untestable under UBSan, since the daemon cannot reach its first tick.