### PR TITLE
Reject a torrent with an empty name instead of aborting.

### DIFF
--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -37,12 +37,7 @@ DownloadConstructor::parse_name(const Object& b) {
   if (is_invalid_path_element(b.get_key("name")))
     throw input_error("Bad torrent file, \"name\" is an invalid path name.");
 
-  auto& name = b.get_key_string("name");
-
-  if (name.empty())
-    throw internal_error("DownloadConstructor::parse_name(...) Ended up with an empty Path.");
-
-  m_download->info()->set_name(name);
+  m_download->info()->set_name(b.get_key_string("name"));
 }
 
 void
@@ -154,6 +149,7 @@ bool
 DownloadConstructor::is_valid_path_element(const Object& b) {
   return
     b.is_string() &&
+    !b.as_string().empty() &&
     b.as_string() != "." &&
     b.as_string() != ".." &&
     std::find(b.as_string().begin(), b.as_string().end(), '/') == b.as_string().end() &&


### PR DESCRIPTION
TL;DR An empty info name threw internal_error out of the constructor.

**Repro**


  A `.torrent` whose info dict has `name: ""`, loaded with `load.start_verbose`.
  Delivery is anything that parses a torrent: RPC, a watch directory, or a session
  file replayed at startup.


  `DownloadConstructor::parse_name` throws `internal_error` when `info.name` is an
  empty string. The value comes straight out of a `.torrent`, so this is malformed
  input, not a broken invariant — and `internal_error` is not a `local_error`, so it
  escapes the handler in `DownloadList::create` and takes the process with it.

  ```
  rtorrent: caught torrent::internal_error: DownloadConstructor::parse_name(...)
  ```

  `input_error` is the class the caller already handles, so the torrent is rejected
  and the client stays up.