### PR TITLE
Reject a meta-download that also carries file entries.

### DIFF
--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -61,6 +61,9 @@ DownloadConstructor::parse_info(const Object& b) {
     m_download->info()->set_flags(DownloadInfo::flag_meta_download);
 
   if (m_download->info()->is_meta_download()) {
+    if (b.has_key("length") || b.has_key("files"))
+      throw input_error("Meta-download has file entries.");
+
     if (b.get_key_string("pieces").length() != HashString::size_data)
       throw input_error("Meta-download has invalid piece data.");
 


### PR DESCRIPTION
  When `info.meta_download` is set, `parse_info` calls `parse_single_file` to add
  the placeholder entry. It then falls through to the `length` / `files` checks
  below, so a torrent carrying both `meta_download` and `files` also runs
  `parse_multi_files`, and one `FileList` ends up with entries from both paths:

  ```
  rtorrent: caught torrent::internal_error: FileList::split(...) split size does not match
  ```

  `c3852fde` added a guard in `FileList::open`, which this path never reaches.
  Rejecting the combination in the meta branch stops it at the source, and also
  covers `meta_download` + `length`, which does not crash but is equally
  meaningless.

  A magnet placeholder built by libtorrent itself contains only `pieces`, `name`
  and `meta_download` (`download_constructor.cc:374-379`), so no legitimate
  metadata download carries file entries.