### PR TITLE
Bound the range passed to update_range by the bitfield size.

### DIFF
--- a/src/torrent/download.cc
+++ b/src/torrent/download.cc
@@ -339,6 +339,9 @@ Download::update_range(int flags, uint32_t first, uint32_t last) {
   if (m_ptr->main()->file_list()->bitfield()->empty())
     throw input_error("Download::clear_range(...) Bitfield is empty.");
 
+  if (first > last || last > m_ptr->main()->file_list()->bitfield()->size_bits())
+    throw input_error("Download::update_range(...) Range is out of bounds.");
+
   if (flags & update_range_recheck)
     m_ptr->hash_checker()->hashing_ranges().insert(first, last);
 


### PR DESCRIPTION
Crafted resume data drove an out of bounds bitfield access.

**Repro**
  Save a session, then set `uncertain_pieces` to a 4-byte index past the end and
  `uncertain_pieces.timestamp` below the torrent's load date, and restart.

**Long version**
  `resume_load_uncertain_pieces` reads 4-byte indices out of the
  `uncertain_pieces` string in a session file and hands each one to
  `Download::update_range`. That function checks the hash-check state and that the
  bitfield is not empty, but never that the index falls inside it, so the index
  reaches the bitfield unvalidated.

  With `uncertain_pieces` set to `\xff\xff\xff\xff`, the client segfaults on the
  next start and cannot boot until the file is removed:

  ```
  core::Manager::receive_hashing_changed()      manager.cc:415
    torrent::resume_load_progress()
      torrent::resume_load_uncertain_pieces()
        torrent::Download::update_range()
          torrent::Bitfield::get()              bitfield.h:59
  ```

  `4ed7d2bc` fixed the iterator over-read in resume parsing but not index
  validation.

  The check belongs in `update_range` rather than the loader: it is public API with
  other callers, it already rejects its other invalid states with `input_error`,
  and the call site in `core::Manager` catches `local_error`, so a corrupt file
  costs a rehash instead of the process.