### PR TITLE
Reject a torrent with duplicate or nested file paths.

### DIFF
--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -214,6 +214,17 @@ DownloadConstructor::parse_multi_files(const Object& b, uint32_t chunk_size) {
     split_list.emplace_back(length, path, attr_flags);
   }
 
+  std::vector<const Path*> sorted_paths;
+  sorted_paths.reserve(split_list.size());
+
+  for (const auto& split : split_list)
+    sorted_paths.push_back(&std::get<1>(split));
+
+  std::sort(sorted_paths.begin(), sorted_paths.end(), &Path::compare_less);
+
+  if (std::adjacent_find(sorted_paths.begin(), sorted_paths.end(), &Path::is_prefix) != sorted_paths.end())
+    throw input_error("Bad torrent file, a file path is a duplicate or the prefix of another.");
+
   FileList* file_list = m_download->main()->file_list();
   file_list->set_multi_file(true);
 

--- a/src/torrent/path.cc
+++ b/src/torrent/path.cc
@@ -23,6 +23,19 @@ Path::insert_path(iterator pos, const std::string& path) {
   }
 }
 
+bool
+Path::compare_less(const Path* left, const Path* right) {
+  return std::lexicographical_compare(left->begin(), left->end(), right->begin(), right->end(),
+                                      [](const auto& l, const auto& r) { return l.str() < r.str(); });
+}
+
+bool
+Path::is_prefix(const Path* prefix, const Path* path) {
+  return prefix->size() <= path->size() &&
+    std::equal(prefix->begin(), prefix->end(), path->begin(),
+               [](const auto& l, const auto& r) { return l.str() == r.str(); });
+}
+
 std::string
 Path::as_string() const {
   if (empty())

--- a/src/torrent/path.h
+++ b/src/torrent/path.h
@@ -36,6 +36,9 @@ public:
 
   base_type*         base()                               { return this; }
   const base_type*   base() const                         { return this; }
+
+  static bool        compare_less(const Path* left, const Path* right);
+  static bool        is_prefix(const Path* prefix, const Path* path);
 };
 
 inline void Path::push_back(const std::string& path) { insert_path(end(), path); }


### PR DESCRIPTION
  A multi-file torrent whose `files` list repeats a path, or contains one path that
  is a prefix of another (`dir` alongside `dir/inner`), produces a `FileList` where
  an adjacent match depth equals the whole path length. `FileList::update_paths`
  then runs its own `verify_file_list` check, which throws:

  ```
  rtorrent: caught torrent::internal_error: verify_file_list() 3.
  ```

  `internal_error` is not a `local_error`, so it escapes the handler in
  `DownloadList::create` and the process exits.

**Repro**
  `files: [{path:["same"]},{path:["same"]}]` or
  `files: [{path:["dir"]},{path:["dir","inner"]}]`, delivered three ways, all
  fatal:

  - `load.start_verbose` over RPC
  - dropped into a watch directory, no RPC involved
  - placed in the session directory, where it exits **255 on every start** and is
    never removed, so the client cannot boot again
