### PR TITLE
Encode a negative bencode value without negating the minimum.

### DIFF
--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -444,19 +444,23 @@ object_write_bencode_c_value(object_write_data_t* output, int64_t src) {
   if (src == 0)
     return object_write_bencode_c_char(output, '0');
 
+  uint64_t value;
+
   if (src < 0) {
     object_write_bencode_c_char(output, '-');
-    src = -src;
+    value = -static_cast<uint64_t>(src);
+  } else {
+    value = static_cast<uint64_t>(src);
   }
 
   char buffer[20];
   char* first = buffer + 20;
 
   // We don't need locale support, so just do this directly.
-  while (src != 0) {
-    *--first = '0' + src % 10;
+  while (value != 0) {
+    *--first = '0' + value % 10;
 
-    src /= 10;
+    value /= 10;
   }
 
   object_write_bencode_c_string(output, first, 20 - std::distance(buffer, first));


### PR DESCRIPTION
TL;DR Negating INT64_MIN is undefined and wrote the wrong digits.

**Repro**
 A `.torrent` whose info dict contains any integer set to `-9223372036854775808`.

**Long version**
  `object_write_bencode_c_value` negates a negative value with `src = -src`. For
  `INT64_MIN` there is no positive counterpart, so this is undefined behaviour; in
  practice the value stays negative and the digit loop then evaluates
  `'0' + src % 10` with a negative remainder, writing bytes that are not digits.

  The writer runs when the info dict is re-encoded to compute the infohash and when
  the session is saved, so on a normal build the visible results are a wrong
  infohash and corrupted session data rather than a crash. A build with UBSan
  aborts:

  ```
  __ubsan_handle_negate_overflow_abort
    #10 object_write_bencode_c_value       torrent/object_stream.cc:449
    #11 object_write_bencode_c_obj_value   torrent/object_stream.cc:468
  ```

  Doing the negation and the digit loop in `uint64_t` makes it well defined:
  `-static_cast<uint64_t>(src)` is the correct magnitude for every `int64_t`,
  including the minimum. The nineteen digits of `INT64_MIN` still fit the existing
  buffer, since the sign is written separately.