### PR TITLE
Check the file length sum before it overflows.

### DIFF
--- a/src/download/download_constructor.cc
+++ b/src/download/download_constructor.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 
 #include "manager.h"
 #include "download/download_wrapper.h"
@@ -199,7 +200,7 @@ DownloadConstructor::parse_multi_files(const Object& b, uint32_t chunk_size) {
 
     int64_t length = object.get_key_value("length");
 
-    if (length < 0 || torrent_size + length < 0)
+    if (length < 0 || length > std::numeric_limits<int64_t>::max() - torrent_size)
       throw input_error("Bad torrent file, invalid length for file.");
 
     torrent_size += length;


### PR DESCRIPTION
The overflow check itself relied on signed overflow.

  `parse_multi_files` accumulates the file lengths and guards with:

  ```cpp
  if (length < 0 || torrent_size + length < 0)
  ```

  The addition happens before the test, so the guard depends on the signed
  overflow it is meant to detect. A torrent with two files whose lengths are each a
  valid `int64_t` but which sum past `INT64_MAX` triggers it:

  ```
  __ubsan_handle_add_overflow_abort
    #10 torrent::DownloadConstructor::parse_multi_files  download/download_constructor.cc:205
  ```

  Comparing against the remaining headroom tests the same condition without
  overflowing.