### PR TITLE
network: add local port override for tracker announces

### DIFF
--- a/src/torrent/runtime/network_config.cc
+++ b/src/torrent/runtime/network_config.cc
@@ -264,6 +264,53 @@ NetworkConfig::local_inet6_address_str() const {
   return sa_addr_str(m_local_inet6_address.get());
 }
 
+uint16_t
+NetworkConfig::local_inet_port() const {
+  auto guard = lock_guard();
+  return m_local_inet_port;
+}
+
+uint16_t
+NetworkConfig::local_inet6_port() const {
+  auto guard = lock_guard();
+  return m_local_inet6_port;
+}
+
+uint16_t
+NetworkConfig::local_port_for_family(int family) const {
+  auto guard = lock_guard();
+
+  switch (family) {
+  case AF_INET:  return m_local_inet_port;
+  case AF_INET6: return m_local_inet6_port;
+  default:
+    throw input_error("NetworkConfig::local_port_for_family() called with invalid address family");
+  }
+}
+
+uint16_t
+NetworkConfig::local_port_best_match() const {
+  auto guard = lock_guard();
+
+  if (m_local_inet_port == 0)
+    return m_local_inet6_port;
+
+  if (m_local_inet6_port == 0)
+    return m_local_inet_port;
+
+  if (m_prefer_ipv6) {
+    if (m_block_ipv6 && !m_block_ipv4)
+      return m_local_inet_port;
+
+    return m_local_inet6_port;
+  }
+
+  if (m_block_ipv4 && !m_block_ipv6)
+    return m_local_inet6_port;
+
+  return m_local_inet_port;
+}
+
 void
 NetworkConfig::set_bind_address(const sockaddr* sa) {
   auto guard = lock_guard();
@@ -343,6 +390,25 @@ NetworkConfig::set_local_inet6_address(const sockaddr* sa) {
 void
 NetworkConfig::set_local_inet6_address_str(const std::string& addr) {
   set_local_inet6_address(sa_lookup_address(addr, AF_INET6).get());
+}
+
+void
+NetworkConfig::set_local_inet_port(uint16_t port) {
+  auto guard = lock_guard();
+  m_local_inet_port = port;
+}
+
+void
+NetworkConfig::set_local_inet6_port(uint16_t port) {
+  auto guard = lock_guard();
+  m_local_inet6_port = port;
+}
+
+void
+NetworkConfig::set_local_port(uint16_t port) {
+  auto guard = lock_guard();
+  m_local_inet_port  = port;
+  m_local_inet6_port = port;
 }
 
 void

--- a/src/torrent/runtime/network_config.h
+++ b/src/torrent/runtime/network_config.h
@@ -82,6 +82,13 @@ public:
   c_sa_shared_ptr     local_inet6_address_or_null() const;
   std::string         local_inet6_address_str() const;
 
+  // Ports reported to trackers, parallel to the local addresses above. A port of 0 means unset,
+  // in which case trackers fall back to reporting runtime::listen_port().
+  uint16_t            local_inet_port() const;
+  uint16_t            local_inet6_port() const;
+  uint16_t            local_port_for_family(int family) const;
+  uint16_t            local_port_best_match() const;
+
   void                set_bind_address(const sockaddr* sa);
   void                set_bind_address_str(const std::string& addr);
   void                set_bind_inet_address(const sockaddr* sa);
@@ -94,6 +101,10 @@ public:
   void                set_local_inet_address_str(const std::string& addr);
   void                set_local_inet6_address(const sockaddr* sa);
   void                set_local_inet6_address_str(const std::string& addr);
+
+  void                set_local_inet_port(uint16_t port);
+  void                set_local_inet6_port(uint16_t port);
+  void                set_local_port(uint16_t port);
 
   int                 listen_backlog() const;
   void                set_listen_backlog(int backlog);
@@ -169,6 +180,9 @@ private:
   c_sa_shared_ptr     m_bind_inet6_address;
   c_sa_shared_ptr     m_local_inet_address;
   c_sa_shared_ptr     m_local_inet6_address;
+
+  uint16_t            m_local_inet_port{0};
+  uint16_t            m_local_inet6_port{0};
 
   int                 m_listen_backlog{SOMAXCONN};
   uint16_t            m_override_dht_port{0};

--- a/src/tracker/tracker_http.cc
+++ b/src/tracker/tracker_http.cc
@@ -313,7 +313,9 @@ TrackerHttp::request_announce_url(tracker::TrackerState::event_enum state, int f
   if (m_params.numwant >= 0 && state != tracker::TrackerState::EVENT_STOPPED)
     s << "&numwant=" << m_params.numwant;
 
-  s << "&port="       << runtime::listen_port()
+  auto local_port = runtime::network_config()->local_port_for_family(family);
+
+  s << "&port="       << (local_port != 0 ? local_port : runtime::listen_port())
     << "&uploaded="   << m_params.uploaded_adjusted
     << "&downloaded=" << m_params.completed_adjusted
     << "&left="       << m_params.download_left;

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -298,7 +298,9 @@ TrackerUdp::prepare_announce(int family, uint32_t id, buffer_type& buffer) {
 
   buffer.write_32(info().key);
   buffer.write_32(m_params.numwant);
-  buffer.write_16(runtime::listen_port());
+
+  auto local_port = runtime::network_config()->local_port_for_family(family);
+  buffer.write_16(local_port != 0 ? local_port : runtime::listen_port());
 
   if (buffer.size_end() != 98)
     throw internal_error("TrackerUdp::prepare_announce() unexpected buffer size.");


### PR DESCRIPTION
Add per-family (ipv4/ipv6) "local ports" to NetworkConfig, parallel to the existing local addresses. A local port of 0 is treated as unset, in which case trackers fall back to reporting runtime::listen_port().

Announce requests now report the configured local port for the address family of the tracker connection instead of always using the listening port:
- HTTP trackers: the &port= query parameter (tracker_http.cc)
- UDP trackers: the port field of the announce packet (tracker_udp.cc)

Why: behind multiple layers of NAT, the port rtorrent is listening on is not the port other peers must reach the client at. Manually specifying the reported port per address family lets the client advertise the forwarded public port while still listening on the local one.