### PR TITLE
Fix outgoing handshake rejecting a plaintext stream.

### DIFF
--- a/src/protocol/handshake.cc
+++ b/src/protocol/handshake.cc
@@ -467,7 +467,7 @@ Handshake::read_encryption_negotiation() {
 
       m_encryption.info()->decrypt(m_readBuffer.position(), std::min<uint32_t>(m_readPos, m_readBuffer.remaining()));
 
-    } if (m_encryption.is_stream_encrypted()) {
+    } else if (m_encryption.is_stream_encrypted()) {
       LT_LOG_EXTRA_DEBUG_SA(m_address, "read_encryption_negotiation: peer offered encrypted stream", 0);
 
       if (m_encryption.policy().require_plaintext_stream())


### PR DESCRIPTION
A missing else meant the encrypted-stream branch was evaluated even after the plaintext branch had run, so its else always fired and every peer that selected the plaintext stream on a connection we initiated was dropped.

Reproduced with two instances on loopback, seeder set to  `handshake_allow,stream_deny` so it selects crypto_plaintext, leecher set to  `handshake_require,stream_allow` so it always initiates MSE: on master the  leecher transfers nothing and stays at zero peers, with the else added the  transfer completes in about a second.