### PR TITLE
Pad the Diffie-Hellman shared secret to the full key width.

### DIFF
--- a/src/utils/diffie_hellman.cc
+++ b/src/utils/diffie_hellman.cc
@@ -56,12 +56,25 @@ bool
 DiffieHellman::compute_secret(const unsigned char *pubkey, unsigned int length) {
   BIGNUM* k = BN_bin2bn(pubkey, length, nullptr);
 
-  m_secret = std::make_unique<char[]>(DH_size(dh_get(m_dh)));
-  m_size = DH_compute_key(reinterpret_cast<unsigned char*>(m_secret.get()), k, dh_get(m_dh));
-  
+  int secret_size = DH_size(dh_get(m_dh));
+
+  m_secret = std::make_unique<char[]>(secret_size);
+
+  int computed_size = DH_compute_key(reinterpret_cast<unsigned char*>(m_secret.get()), k, dh_get(m_dh));
+
   BN_free(k);
 
-  return m_size != -1;
+  if (computed_size == -1)
+    return false;
+
+  if (computed_size < secret_size) {
+    std::memmove(m_secret.get() + secret_size - computed_size, m_secret.get(), computed_size);
+    std::memset(m_secret.get(), 0, secret_size - computed_size);
+  }
+
+  m_size = secret_size;
+
+  return true;
 }
 
 void


### PR DESCRIPTION
DH_compute_key omits leading zero bytes, but the handshake hashes 96 bytes.

DH_compute_key() writes the secret without leading zero bytes, so roughly one  exchange in 250 produces fewer than 96 and m_size is short.

Specs: https://jwodder.github.io/kbits/posts/bt-encrypt/

When used as a byte string in later steps, S is encoded as a 96-byte (768-bit) big-endian integer

So padding is required.
