### PR TITLE
Don't dereference an empty peer list when building a ut_pex message.

### DIFF
--- a/src/protocol/extensions.cc
+++ b/src/protocol/extensions.cc
@@ -172,11 +172,17 @@ ProtocolExtension::generate_ut_pex_message(const PEXList& added, const PEXList& 
   auto end = buffer;
 
   end += sprintf(end, "d5:added%d:", added_len);
-  memcpy(end, added.begin()->c_str(), added_len);
+
+  if (!added.empty())
+    memcpy(end, added.begin()->c_str(), added_len);
+
   end += added_len;
 
   end += sprintf(end, "7:dropped%d:", removed_len);
-  memcpy(end, removed.begin()->c_str(), removed_len);
+
+  if (!removed.empty())
+    memcpy(end, removed.begin()->c_str(), removed_len);
+
   end += removed_len;
 
   *end++ = 'e';


### PR DESCRIPTION
A delta that only drops peers still evaluated added.begin()->c_str().

UBSan reports "member call on null pointer of type 'const struct SocketAddressCompact'" at extensions.cc:175 for a removals-only delta; with the guards it is quiet and the message is unchanged.