### PR TITLE
Let the dns class enum cover the whole wire range.

### DIFF
--- a/src/net/udns/udns.h
+++ b/src/net/udns/udns.h
@@ -83,7 +83,8 @@ enum dns_class {	/* DNS RR Classes */
   DNS_C_IN	= 1,	/* Internet */
   DNS_C_CH	= 3,	/* CHAOS */
   DNS_C_HS	= 4,	/* HESIOD */
-  DNS_C_ANY	= 255	/* wildcard */
+  DNS_C_ANY	= 255,	/* wildcard */
+  DNS_C_MAX	= 65536
 };
 
 enum dns_type {		/* DNS RR Types */


### PR DESCRIPTION
TLDR; A class is 16 bits on the wire, and dns_type already carries DNS_T_MAX.

 A resource record class is a 16 bit field on the wire, but the enumerators in enum dns_class stop at DNS_C_ANY = 255, so dns_initparse() and dns_nextrr() cast  a larger value into an enum whose range does not include it. enum dns_type  already carries DNS_T_MAX = 65536 for exactly this reason; this adds the  equivalent for classes.