### PR TITLE
Detect overflow when reading a bencode integer.

### DIFF
--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -50,6 +50,8 @@ object_read_string(std::istream* input, std::string& str) {
 
 static const char*
 object_read_bencode_c_value(const char* first, const char* last, int64_t& value) {
+  const char* start = first;
+
   if (first == last)
     return first;
 
@@ -64,13 +66,20 @@ object_read_bencode_c_value(const char* first, const char* last, int64_t& value)
     first++;
   }
 
-  value = 0;
+  uint64_t result = 0;
+  uint64_t limit  = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + (neg ? 1 : 0);
 
-  while (first != last && *first >= '0' && *first <= '9')
-    value = value * 10 + (*first++ - '0');
+  while (first != last && *first >= '0' && *first <= '9') {
+    uint64_t digit = *first - '0';
 
-  if (neg)
-    value = -value;
+    if (result > (limit - digit) / 10)
+      return start;
+
+    result = result * 10 + digit;
+    first++;
+  }
+
+  value = neg ? static_cast<int64_t>(0 - result) : static_cast<int64_t>(result);
 
   return first;
 }

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -195,3 +195,42 @@ ObjectStreamTest::test_write() {
   obj.as_map()["d"] = torrent::Object();
   CPPUNIT_ASSERT(object_write_bencode(obj, "d1:ai1e1:b4:test1:cl3:fooee"));
 }
+
+static bool
+read_value_ok(const char* input, int64_t expected) {
+  try {
+    torrent::Object tmp;
+    const char* last = input + std::strlen(input);
+
+    return torrent::object_read_bencode_c(input, last, &tmp) == last &&
+      tmp.is_value() && tmp.as_value() == expected;
+
+  } catch (const torrent::bencode_error&) {
+    return false;
+  }
+}
+
+static bool
+read_value_rejected(const char* input) {
+  try {
+    torrent::Object tmp;
+    torrent::object_read_bencode_c(input, input + std::strlen(input), &tmp);
+    return false;
+
+  } catch (const torrent::bencode_error&) {
+    return true;
+  }
+}
+
+void
+ObjectStreamTest::test_read_value_bounds() {
+  CPPUNIT_ASSERT(read_value_ok("i0e", 0));
+  CPPUNIT_ASSERT(read_value_ok("i-1e", -1));
+  CPPUNIT_ASSERT(read_value_ok("i9223372036854775807e", std::numeric_limits<int64_t>::max()));
+  CPPUNIT_ASSERT(read_value_ok("i-9223372036854775808e", std::numeric_limits<int64_t>::min()));
+
+  CPPUNIT_ASSERT(read_value_rejected("i9223372036854775808e"));
+  CPPUNIT_ASSERT(read_value_rejected("i-9223372036854775809e"));
+  CPPUNIT_ASSERT(read_value_rejected("i18446744073709551615e"));
+  CPPUNIT_ASSERT(read_value_rejected("i99999999999999999999e"));
+}

--- a/test/torrent/object_stream_test.h
+++ b/test/torrent/object_stream_test.h
@@ -9,6 +9,7 @@ class ObjectStreamTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testOutputMask);
   CPPUNIT_TEST(testBuffer);
   CPPUNIT_TEST(testReadBencodeC);
+  CPPUNIT_TEST(test_read_value_bounds);
 
   CPPUNIT_TEST(test_read_skip);
   CPPUNIT_TEST(test_read_skip_invalid);
@@ -22,6 +23,7 @@ public:
   void testBuffer();
 
   void testReadBencodeC();
+  void test_read_value_bounds();
 
   void test_read_skip();
   void test_read_skip_invalid();


### PR DESCRIPTION
The accumulator wrapped, so i9223372036854775808e parsed as the smallest integer.