### PR TITLE
Reject a bencode string length that does not fit in unsigned int.

### DIFF
--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -77,15 +77,19 @@ object_read_bencode_c_value(const char* first, const char* last, int64_t& value)
 
 raw_string
 object_read_bencode_c_string(const char* first, const char* last) {
-  // Set the most-significant bit so that if there are no numbers in
-  // the input it will fail the length check, while "0" will shift the
-  // bit out.
-  unsigned int length = 0x1U << (std::numeric_limits<unsigned int>::digits - 1);
+  const char* start  = first;
+  uint64_t    length = 0;
 
-  while (first != last && *first >= '0' && *first <= '9')
+  while (first != last && *first >= '0' && *first <= '9') {
     length = length * 10 + (*first++ - '0');
 
-  if (length + 1 > static_cast<unsigned int>(std::distance(first, last)) || length + 1 == 0 || *first++ != ':')
+    if (length > static_cast<uint64_t>(std::numeric_limits<unsigned int>::max()))
+      throw torrent::bencode_error("Invalid bencode data.");
+  }
+
+  if (first == start ||
+      length + 1 > static_cast<uint64_t>(std::distance(first, last)) ||
+      *first++ != ':')
     throw torrent::bencode_error("Invalid bencode data.");
 
   return raw_string(first, length);

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -195,3 +195,29 @@ ObjectStreamTest::test_write() {
   obj.as_map()["d"] = torrent::Object();
   CPPUNIT_ASSERT(object_write_bencode(obj, "d1:ai1e1:b4:test1:cl3:fooee"));
 }
+
+static bool
+read_string_rejected(const char* input) {
+  try {
+    torrent::Object tmp;
+    torrent::object_read_bencode_c(input, input + std::strlen(input), &tmp);
+    return false;
+
+  } catch (const torrent::bencode_error&) {
+    return true;
+  }
+}
+
+void
+ObjectStreamTest::test_read_string_length() {
+  torrent::Object tmp;
+  const char* input = "4:abcd";
+
+  CPPUNIT_ASSERT(torrent::object_read_bencode_c(input, input + std::strlen(input), &tmp) != input);
+  CPPUNIT_ASSERT(tmp.is_raw_string() || tmp.is_string());
+
+  CPPUNIT_ASSERT(read_string_rejected("4294967296:abcd"));
+  CPPUNIT_ASSERT(read_string_rejected("4294967300:abcd"));
+  CPPUNIT_ASSERT(read_string_rejected("18446744073709551616:abcd"));
+  CPPUNIT_ASSERT(read_string_rejected(":abcd"));
+}

--- a/test/torrent/object_stream_test.h
+++ b/test/torrent/object_stream_test.h
@@ -9,6 +9,7 @@ class ObjectStreamTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testOutputMask);
   CPPUNIT_TEST(testBuffer);
   CPPUNIT_TEST(testReadBencodeC);
+  CPPUNIT_TEST(test_read_string_length);
 
   CPPUNIT_TEST(test_read_skip);
   CPPUNIT_TEST(test_read_skip_invalid);
@@ -22,6 +23,7 @@ public:
   void testBuffer();
 
   void testReadBencodeC();
+  void test_read_string_length();
 
   void test_read_skip();
   void test_read_skip_invalid();


### PR DESCRIPTION
The accumulator wrapped, so 4294967300: was accepted as a four byte string.