### PR TITLE
Refresh the thread cached time after polling, before dispatching events.

### DIFF
--- a/src/torrent/system/poll_epoll.cc
+++ b/src/torrent/system/poll_epoll.cc
@@ -13,6 +13,7 @@
 #include "torrent/net/fd.h"
 #include "torrent/system/event.h"
 #include "torrent/system/thread.h"
+#include "torrent/utils/chrono.h"
 #include "torrent/utils/log.h"
 
 #define LT_LOG(log_fmt, ...)                                        \
@@ -194,6 +195,8 @@ Poll::cleanup_thread() {
 unsigned int
 Poll::do_poll(std::chrono::microseconds timeout) {
   int status = poll(timeout);
+
+  this_thread::thread()->set_cached_time(torrent::utils::time_since_epoch());
 
   if (status == -1) {
     if (errno != EINTR)

--- a/src/torrent/system/poll_kqueue.cc
+++ b/src/torrent/system/poll_kqueue.cc
@@ -15,6 +15,7 @@
 #include "torrent/net/fd.h"
 #include "torrent/system/event.h"
 #include "torrent/system/thread.h"
+#include "torrent/utils/chrono.h"
 
 // TODO: Change to use unordered_map, and at regular intervals trim the size?
 
@@ -195,6 +196,8 @@ Poll::cleanup_thread() {
 unsigned int
 Poll::do_poll(std::chrono::microseconds timeout) {
   int status = poll(timeout);
+
+  this_thread::thread()->set_cached_time(torrent::utils::time_since_epoch());
 
   if (status == -1) {
     if (errno != EINTR)


### PR DESCRIPTION
TL;DR A timer scheduled from an event handler was computed against a clock from before the wait, so a wait longer than the timer fired it immediately.

After a minute idle, the first request from ruTorrent, flood or autodl is dropped. Most clients retry so you see a blip; autodl doesn't  — that announce is missed.


Verbose version: ---Poll::do_poll() waits in poll() and then dispatches the ready events inline, but the thread's cached clock is only refreshed at the top  of the next Thread::process_events() iteration. Any timer scheduled from inside an event handler is therefore computed as m_cached_time +  interval, where m_cached_time predates the wait. When the wait is longer than the interval, the deadline is already in the past and  Scheduler::perform() fires the timer on the very next pass.

 This is reachable today through the SCGI task timeout added in rtorrent af6d8a1 (timeout_request = 60s). The SCGI thread's next_timeout()  is 10 minutes, so an idle instance sleeps far longer than 60 seconds; the first RPC request to arrive after that is accepted, its timeout  is armed against the stale clock, and the connection is closed microseconds later without a single byte being read. The client sees  ECONNRESET; an immediate retry succeeds, because by then the clock has been refreshed.
