### PR TITLE
Reject leading zeros in a bencode integer regardless of sign.

### DIFF
--- a/src/torrent/object_stream.cc
+++ b/src/torrent/object_stream.cc
@@ -59,11 +59,17 @@ object_read_bencode_c_value(const char* first, const char* last, int64_t& value)
   if (errc.ptr >= last || *errc.ptr != 'e')
     throw torrent::bencode_error("Invalid bencode data: missing 'e' terminator.");
 
-  if (value != 0 && *first == '0')
-    throw torrent::bencode_error("Invalid bencode data: leading zeros are not allowed.");
+  if (*first == '-') {
+    if (value == 0)
+      throw torrent::bencode_error("Invalid bencode data: negative zero is not allowed.");
 
-  if (value == 0 && *first == '-')
-    throw torrent::bencode_error("Invalid bencode data: negative zero is not allowed.");
+    if (*(first + 1) == '0' && errc.ptr != first + 2)
+      throw torrent::bencode_error("Invalid bencode data: leading zeros are not allowed.");
+
+  } else {
+    if (*first == '0' && errc.ptr != first + 1)
+      throw torrent::bencode_error("Invalid bencode data: leading zeros are not allowed.");
+  }
 
   return errc.ptr + 1;
 }

--- a/test/torrent/object_stream_test.cc
+++ b/test/torrent/object_stream_test.cc
@@ -273,4 +273,15 @@ ObjectStreamTest::test_read_value_bounds() {
   CPPUNIT_ASSERT(read_value_rejected("i-9223372036854775809e"));
   CPPUNIT_ASSERT(read_value_rejected("i18446744073709551615e"));
   CPPUNIT_ASSERT(read_value_rejected("i99999999999999999999e"));
+
+  CPPUNIT_ASSERT(read_value_ok("i0e", 0));
+  CPPUNIT_ASSERT(read_value_ok("i-1e", -1));
+
+  CPPUNIT_ASSERT(read_value_rejected("i01e"));
+  CPPUNIT_ASSERT(read_value_rejected("i00e"));
+  CPPUNIT_ASSERT(read_value_rejected("i000e"));
+  CPPUNIT_ASSERT(read_value_rejected("i-0e"));
+  CPPUNIT_ASSERT(read_value_rejected("i-00e"));
+  CPPUNIT_ASSERT(read_value_rejected("i-01e"));
+  CPPUNIT_ASSERT(read_value_rejected("i-000123e"));
 }


### PR DESCRIPTION
The check read the parsed value, so i00e and i-01e were accepted.