### PR TITLE
Rebuild the log cache and shift group outputs when closing an output.

### DIFF
--- a/src/torrent/utils/log.cc
+++ b/src/torrent/utils/log.cc
@@ -280,8 +280,20 @@ log_close_output(const char* name) {
 
   auto itr = log_find_output_name(name);
 
-  if (itr != log_outputs.end())
-    log_outputs.erase(itr);
+  if (itr == log_outputs.end())
+    return;
+
+  size_t index = std::distance(log_outputs.begin(), itr);
+  log_outputs.erase(itr);
+
+  for (auto& group : log_groups) {
+    auto outputs = group.outputs();
+    auto lower = outputs & log_group::outputs_type((uint64_t{1} << index) - 1);
+
+    group.set_outputs(lower | ((outputs >> (index + 1)) << index));
+  }
+
+  log_rebuild_cache();
 }
 
 void


### PR DESCRIPTION
log_close_output erases the entry from log_outputs without rebuilding the cache or adjusting log_groups. Each group's output bitmask still refers to the pre-erase indices, so after a close the groups point at the wrong outputs and the cache holds empty std::functions, which are then called. log.close on a running client reaches it.
 
 Shift each group's mask down across the erased index and rebuild the cache.