### PR TITLE
Add DHT peer nodes learned from the peer protocol PORT message.

### DIFF
--- a/src/dht/dht_router.cc
+++ b/src/dht/dht_router.cc
@@ -22,8 +22,9 @@ namespace torrent {
 
 HashString DhtRouter::zero_id;
 
-DhtRouter::DhtRouter(const Object& cache)
+DhtRouter::DhtRouter(tracker::DhtController* controller, const Object& cache)
   : DhtNode(zero_id, sa_make_inet_any().get()), // actual ID is set later
+    m_controller(controller),
     m_server(this),
     m_curToken(random()),
     m_prevToken(random()),
@@ -106,6 +107,8 @@ DhtRouter::start(int port) {
   LT_LOG_THIS("starting: port:%d", port);
 
   m_server.start(port);
+
+  m_controller->set_nodes_populated(check_nodes_populated());
 
   // Set timeout slot and schedule it to be called immediately for initial bootstrapping if
   // necessary.
@@ -403,7 +406,9 @@ DhtRouter::receive_timeout_bootstrap() {
   // we have enough nodes in our routing table. After we have 32 nodes, we switch
   // to a less aggressive non-bootstrap mode of collecting nodes that contact us
   // and through doing normal torrent announces.
-  if (m_nodes.size() < num_bootstrap_complete) {
+  m_controller->set_nodes_populated(check_nodes_populated());
+
+  if (!check_nodes_populated()) {
     if (!m_contacts.has_value())
       throw internal_error("DhtRouter::receive_timeout_bootstrap called without contact list.");
 
@@ -480,6 +485,8 @@ DhtRouter::receive_timeout() {
     }
     ++itr;
   }
+
+  m_controller->set_nodes_populated(check_nodes_populated());
 
   m_server.update();
 

--- a/src/dht/dht_router.h
+++ b/src/dht/dht_router.h
@@ -35,7 +35,7 @@ public:
   // A node ID of all zero.
   static HashString zero_id;
 
-  DhtRouter(const Object& cache);
+  DhtRouter(tracker::DhtController* controller, const Object& cache);
   ~DhtRouter();
 
   void                start(int port);
@@ -100,6 +100,8 @@ private:
   // Maximum number of potential contacts to keep until bootstrap complete.
   static constexpr unsigned int num_bootstrap_contacts = 64;
 
+  bool                check_nodes_populated() const    { return m_nodes.size() >= num_bootstrap_complete; }
+
   using DhtBucketList = std::map<const HashString, DhtBucket*>;
 
   DhtBucketList::iterator find_bucket(const HashString& id);
@@ -119,6 +121,8 @@ private:
 
   // buffer needs to hold an SHA1 hash (20 bytes), not just the token (8 bytes)
   static char*        generate_token(const sockaddr* sa, int token, char buffer[20]);
+
+  tracker::DhtController* m_controller;
 
   system::SchedulerEntry m_task_timeout;
 

--- a/src/torrent/runtime/network_manager.cc
+++ b/src/torrent/runtime/network_manager.cc
@@ -169,10 +169,11 @@ NetworkManager::dht_add_bootstrap_node(std::string host, int port){
 }
 
 void
-NetworkManager::dht_add_peer_node([[maybe_unused]] const sockaddr* sa, [[maybe_unused]] int port) {
-  // Ignore peer nodes as we shouldn't need them(?)
-  //
-  // Re-enable this if it causes issues.
+NetworkManager::dht_add_peer_node(const sockaddr* sa, int port) {
+  if (m_dht_controller->is_nodes_populated())
+    return;
+
+  m_dht_controller->add_node(sa, port);
 }
 
 bool

--- a/src/torrent/tracker/dht_controller.cc
+++ b/src/torrent/tracker/dht_controller.cc
@@ -56,7 +56,7 @@ DhtController::initialize(const Object& dht_cache) {
   LT_LOG("initializing", 0);
 
   try {
-    m_router = std::make_unique<DhtRouter>(dht_cache);
+    m_router = std::make_unique<DhtRouter>(this, dht_cache);
 
   } catch (const torrent::local_error& e) {
     LT_LOG("initialization failed : %s", e.what());

--- a/src/torrent/tracker/dht_controller.h
+++ b/src/torrent/tracker/dht_controller.h
@@ -1,6 +1,7 @@
 #ifndef LIBTORRENT_TRACKER_DHT_CONTROLLER_H
 #define LIBTORRENT_TRACKER_DHT_CONTROLLER_H
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <torrent/common.h>
@@ -44,6 +45,7 @@ public:
   bool                is_valid();
   bool                is_active();
   bool                is_receiving_requests();
+  bool                is_nodes_populated();
 
   void                set_receive_requests(bool state);
 
@@ -69,19 +71,34 @@ public:
   void                reset_statistics();
 
 protected:
+  friend class torrent::DhtRouter;
   friend class torrent::TrackerDht;
+
+  void                set_nodes_populated(bool state);
 
   // Called from tracker_thread.
   void                announce(const HashString& info_hash, std::weak_ptr<TrackerDht> weak_tracker);
   void                cancel_announce(const HashString& info_hash, std::weak_ptr<TrackerDht> weak_tracker);
 
 private:
+  std::atomic<bool>   m_nodes_populated{false};
+
   std::mutex          m_lock;
   uint16_t            m_port{0};
   bool                m_receive_requests{true};
 
   std::unique_ptr<DhtRouter> m_router;
 };
+
+inline bool
+DhtController::is_nodes_populated() {
+  return m_nodes_populated.load(std::memory_order_relaxed);
+}
+
+inline void
+DhtController::set_nodes_populated(bool state) {
+  m_nodes_populated.store(state, std::memory_order_relaxed);
+}
 
 } // namespace torrent::tracker
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -83,6 +83,8 @@ LibTorrent_Test_Torrent_Utils_SOURCES = $(LibTorrent_Test_Common) \
 	torrent/utils/test_uri_parser.h
 
 LibTorrent_Test_Torrent_SOURCES = $(LibTorrent_Test_Common) \
+	torrent/test_dht_controller.cc \
+	torrent/test_dht_controller.h \
 	torrent/object_test.cc \
 	torrent/object_test.h \
 	torrent/object_test_utils.cc \

--- a/test/torrent/test_dht_controller.cc
+++ b/test/torrent/test_dht_controller.cc
@@ -1,0 +1,99 @@
+#include "config.h"
+
+#include "test_dht_controller.h"
+
+#include "torrent/hash_string.h"
+#include "torrent/net/socket_address.h"
+#include "torrent/object.h"
+#include "torrent/runtime/network_config.h"
+#include "torrent/runtime/network_manager.h"
+#include "torrent/runtime/socket_manager.h"
+#include "torrent/tracker/dht_controller.h"
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(test_dht_controller, "torrent");
+
+namespace {
+
+constexpr uint16_t     dht_port = 43821;
+constexpr unsigned int bootstrap_complete_nodes = 32;
+
+torrent::Object
+create_dht_cache(unsigned int node_count) {
+  torrent::HashString self_id;
+  self_id.clear(0x55);
+
+  auto cache = torrent::Object::create_map();
+  cache.insert_key("self_id", self_id.str());
+
+  auto& nodes = cache.insert_key("nodes", torrent::Object::create_map());
+
+  for (unsigned int i = 0; i < node_count; i++) {
+    torrent::HashString node_id = self_id;
+    node_id.data()[i / 8] ^= 0x80 >> (i % 8);
+
+    auto& node = nodes.insert_key(node_id.str(), torrent::Object::create_map());
+
+    node.insert_key("i", int64_t{0x7f000001});
+    node.insert_key("p", int64_t{10000 + i});
+    node.insert_key("t", int64_t{0});
+  }
+
+  return cache;
+}
+
+unsigned int
+add_peer_node_and_count_queries() {
+  auto dht = torrent::runtime::network_manager()->dht_controller();
+
+  auto queries_sent = dht->get_statistics().queries_sent;
+  auto sa = torrent::sa_make_inet_h(0x7f000002, 0);
+
+  torrent::runtime::network_manager()->dht_add_peer_node(sa.get(), 6881);
+
+  return dht->get_statistics().queries_sent - queries_sent;
+}
+
+} // namespace
+
+void
+test_dht_controller::setUp() {
+  TestFixtureWithMainNetTrackerThread::setUp();
+
+  torrent::runtime::socket_manager()->set_max_size_and_adjust(1024);
+  torrent::runtime::network_config()->set_override_dht_port(dht_port);
+}
+
+void
+test_dht_controller::tearDown() {
+  torrent::runtime::network_manager()->dht_controller()->stop();
+
+  TestFixtureWithMainNetTrackerThread::tearDown();
+}
+
+void
+test_dht_controller::test_add_peer_node_while_bootstrapping() {
+  auto dht = torrent::runtime::network_manager()->dht_controller();
+
+  CPPUNIT_ASSERT(!dht->is_nodes_populated());
+
+  dht->initialize(create_dht_cache(0));
+
+  CPPUNIT_ASSERT(dht->start());
+  CPPUNIT_ASSERT_EQUAL(0u, dht->get_statistics().num_nodes);
+  CPPUNIT_ASSERT(!dht->is_nodes_populated());
+
+  CPPUNIT_ASSERT_EQUAL(1u, add_peer_node_and_count_queries());
+}
+
+void
+test_dht_controller::test_add_peer_node_after_bootstrap() {
+  auto dht = torrent::runtime::network_manager()->dht_controller();
+
+  dht->initialize(create_dht_cache(bootstrap_complete_nodes));
+
+  CPPUNIT_ASSERT(dht->start());
+  CPPUNIT_ASSERT_EQUAL(bootstrap_complete_nodes, dht->get_statistics().num_nodes);
+  CPPUNIT_ASSERT(dht->is_nodes_populated());
+
+  CPPUNIT_ASSERT_EQUAL(0u, add_peer_node_and_count_queries());
+}

--- a/test/torrent/test_dht_controller.h
+++ b/test/torrent/test_dht_controller.h
@@ -1,0 +1,15 @@
+#include "helpers/test_main_thread.h"
+
+class test_dht_controller : public TestFixtureWithMainNetTrackerThread {
+  CPPUNIT_TEST_SUITE(test_dht_controller);
+  CPPUNIT_TEST(test_add_peer_node_while_bootstrapping);
+  CPPUNIT_TEST(test_add_peer_node_after_bootstrap);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override;
+  void tearDown() override;
+
+  void test_add_peer_node_while_bootstrapping();
+  void test_add_peer_node_after_bootstrap();
+};


### PR DESCRIPTION
NetworkManager::dht_add_peer_node has an empty body — the arguments are [[maybe_unused]] and the comment says peer nodes are ignored, with a note to re-enable if it causes issues. So every DHT node advertised over the peer protocol's PORT message is discarded, and the DHT router only ever learns nodes from bootstrap and from DHT traffic itself.
  
Pass them to m_dht_controller->add_node(sa, port), which is what the callers already assume happens.