### PR TITLE
scheduler.h: fix build with Clang <17

### DIFF
--- a/src/torrent/system/scheduler.h
+++ b/src/torrent/system/scheduler.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <thread>
+#include <vector>
 #include <torrent/system/common.h>
 
 namespace torrent::system {


### PR DESCRIPTION
```
In file included from display/frame.cc:9:
In file included from ./display/window.h:5:
/opt/local/include/torrent/system/scheduler.h:54:32: error: implicit instantiation of undefined template 'std::vector<std::unique_ptr<torrent::system::SchedulerHandle>>'
  heap_type                    m_heap;
                               ^
/opt/local/include/libcxx/v1/iosfwd:216:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
In file included from display/frame.cc:9:
In file included from ./display/window.h:5:
/opt/local/include/torrent/system/scheduler.h:87:68: error: cannot initialize object parameter of type 'torrent::system::Scheduler' with an expression of type 'torrent::system::ExternalScheduler'
  void                external_perform(time_type time)           { perform(time); }
                                                                   ^~~~~~~
/opt/local/include/torrent/system/scheduler.h:89:68: error: cannot initialize object parameter of type 'torrent::system::Scheduler' with an expression of type 'torrent::system::ExternalScheduler'
  void                external_set_thread_id(std::thread::id id) { set_thread_id(id); }
                                                                   ^~~~~~~~~~~~~
/opt/local/include/torrent/system/scheduler.h:90:68: error: cannot initialize object parameter of type 'torrent::system::Scheduler' with an expression of type 'torrent::system::ExternalScheduler'
  void                external_set_cached_time(time_type t)      { set_cached_time(t); }
                                                                   ^~~~~~~~~~~~~~~
```